### PR TITLE
ggml : fix equation used in ggml_gelu_f32

### DIFF
--- a/src/ggml.c
+++ b/src/ggml.c
@@ -2277,7 +2277,7 @@ static const float GELU_COEF_A    = 0.044715f;
 static const float SQRT_2_OVER_PI = 0.79788456080286535587989211986876f;
 
 inline static float ggml_gelu_f32(float x) {
-    return 0.5f*x*(1.0f + tanhf(SQRT_2_OVER_PI*x*(1.0f + GELU_COEF_A*x*x)));
+    return 0.5f*x*(1.0f + tanhf(SQRT_2_OVER_PI*x*(1.0f + GELU_COEF_A*x*x*x)));
 }
 
 inline static void ggml_vec_gelu_f16(const int n, ggml_fp16_t * y, const ggml_fp16_t * x) {


### PR DESCRIPTION
I am relatively new to machine learning and have been reading through the implementation of `ggml` as an educational exercise. As such I may be missing something obvious here.

While studying the code I happened to notice that the equation used in `ggml_gelu_f32` does not quite match the one in the GELU paper, where it is defined with a final `x^3` term. But `ggml` uses `x^2`. Is this wrong? If not, why not?

Going back through the git history, there are signs that the `x^3` term may have been present in some very early version but it is already commented out in `Initial release`. The comment was subsequently removed in 787efb4d2e8ec80ccf48168cf5b9e967e62fe0c2 (originally https://github.com/ggerganov/whisper.cpp/commit/f888c2373df91fc0449a75e678767d0889642070). I couldn't determine from the history whether the change from `x^3` to `x^2` was intentional or not.

https://github.com/ggerganov/ggml/blob/f21b84cd217a4cb39cc21c6dcfce30e0bff132f0/src/ggml.c#L425-L432