### PR TITLE
Fixed quantization for f16 models not working in GPT-2 and GPT-J examples

### DIFF
--- a/examples/gpt-2/quantize.cpp
+++ b/examples/gpt-2/quantize.cpp
@@ -289,6 +289,13 @@ int main(int argc, char ** argv) {
         return 1;
     }
 
+    // needed to initialize f16 tables
+    {
+        struct ggml_init_params params = { 0, NULL };
+        struct ggml_context * ctx = ggml_init(params);
+        ggml_free(ctx);
+    }
+
     const std::string fname_inp = argv[1];
     const std::string fname_out = argv[2];
 

--- a/examples/gpt-j/quantize.cpp
+++ b/examples/gpt-j/quantize.cpp
@@ -290,6 +290,13 @@ int main(int argc, char ** argv) {
         return 1;
     }
 
+    // needed to initialize f16 tables
+    {
+        struct ggml_init_params params = { 0, NULL };
+        struct ggml_context * ctx = ggml_init(params);
+        ggml_free(ctx);
+    }
+
     const std::string fname_inp = argv[1];
     const std::string fname_out = argv[2];
 


### PR DESCRIPTION
Fixed quantization for f16 models not working in GPT-2 and GPT-J examples, because the f16 tables were not initialized thus f16 to f32 conversion was failing.