### PR TITLE
Fix MNIST example build due to missing import

### DIFF
--- a/examples/mnist/main.cpp
+++ b/examples/mnist/main.cpp
@@ -13,6 +13,7 @@
 #include <iostream>
 #include <unistd.h>
 #include <time.h>
+#include <algorithm>
 
 // default hparams
 struct mnist_hparams {


### PR DESCRIPTION
The new MNIST example misses the `<algorithm>` include, as otherwise it can't find `max_element`.

```
/home/bart/src/projects/ggml/examples/mnist/main.cpp: In function ‘int mnist_eval(const mnist_model&, int, std::vector<float>)’:
/home/bart/src/projects/ggml/examples/mnist/main.cpp:196:27: error: ‘max_element’ is not a member of ‘std’; did you mean ‘tuple_element’?
  196 |     int prediction = std::max_element(finalData, finalData + 10) - finalData;
      |                           ^~~~~~~~~~~
      |                           tuple_element
```