### PR TITLE
tests: fix compile error

### DIFF
--- a/tests/test-mul-mat2.c
+++ b/tests/test-mul-mat2.c
@@ -1887,7 +1887,7 @@ void vec_dot_gq_5(const int n, float * restrict s, const void * restrict x, cons
         const uint8_t * restrict p0 = pb0 + i*QK/2;
         const uint8_t * restrict p1 = pb1 + i*QK/2;
 
-        const int8x16_t m4b = vdupq_n_s8(0xf);
+        const uint8x16_t m4b = vdupq_n_u8(0xf);
         const int8x16_t s8b = vdupq_n_s8(0x8);
 
         const uint8x16_t v0_0 = vld1q_u8(p0);
@@ -2280,7 +2280,7 @@ void vec_dot_gq_6(const int n, float * restrict s, const void * restrict x, cons
         const uint8_t * restrict p0 = pb0 + i*16;
         const uint8_t * restrict p1 = pb1 + i*16;
 
-        const int8x16_t m4b = vdupq_n_s8(0xf);
+        const uint8x16_t m4b = vdupq_n_u8(0xf);
         const int8x16_t s8b = vdupq_n_s8(0x8);
 
         const uint8x16_t v0_0 = vld1q_u8(p0);


### PR DESCRIPTION
fix a trivial error: incompatible type for argument 2 of ‘vandq_u8’ in https://github.com/nomic-ai/gpt4all-chat/issues/66