### PR TITLE
make struct initialization more portable

### DIFF
--- a/examples/gpt-2/main.cpp
+++ b/examples/gpt-2/main.cpp
@@ -427,7 +427,8 @@ bool gpt2_eval(
     };
 
     struct ggml_context * ctx0 = ggml_init(params);
-    struct ggml_cgraph gf = { .n_threads = n_threads };
+    struct ggml_cgraph gf = {};
+    gf.n_threads = n_threads;
 
     struct ggml_tensor * embd = ggml_new_tensor_1d(ctx0, GGML_TYPE_I32, N);
     memcpy(embd->data, embd_inp.data(), N*ggml_element_size(embd));

--- a/examples/gpt-j/main.cpp
+++ b/examples/gpt-j/main.cpp
@@ -426,7 +426,8 @@ bool gptj_eval(
     };
 
     struct ggml_context * ctx0 = ggml_init(params);
-    struct ggml_cgraph gf = { .n_threads = n_threads };
+    struct ggml_cgraph gf = {};
+    gf.n_threads = n_threads;
 
     struct ggml_tensor * embd = ggml_new_tensor_1d(ctx0, GGML_TYPE_I32, N);
     memcpy(embd->data, embd_inp.data(), N*ggml_element_size(embd));

--- a/examples/mnist/main.cpp
+++ b/examples/mnist/main.cpp
@@ -174,7 +174,8 @@ int mnist_eval(
     };
 
     struct ggml_context * ctx0 = ggml_init(params);
-    struct ggml_cgraph gf = { .n_threads = n_threads };
+    struct ggml_cgraph gf = {};
+    gf.n_threads = n_threads;
 
     struct ggml_tensor * input = ggml_new_tensor_1d(ctx0, GGML_TYPE_F32, hparams.n_input);
     memcpy(input->data, digit.data(), ggml_nbytes(input));

--- a/examples/stablelm/main.cpp
+++ b/examples/stablelm/main.cpp
@@ -427,7 +427,8 @@ bool stablelm_eval(
     };
 
     struct ggml_context * ctx0 = ggml_init(params);
-    struct ggml_cgraph gf = { .n_threads = n_threads };
+    struct ggml_cgraph gf = {};
+    gf.n_threads = n_threads;
 
     struct ggml_tensor * embd = ggml_new_tensor_1d(ctx0, GGML_TYPE_I32, N);
     memcpy(embd->data, embd_inp.data(), N*ggml_element_size(embd));


### PR DESCRIPTION
The current struct definition causes portability issues (tried on gcc v7.5.0) and fails with the error `sorry, unimplemented: non-trivial designated initializers not supported`.

https://stackoverflow.com/questions/4900739/why-are-designated-initializers-not-implemented-in-g
