### PR TITLE
fix conversion from 'const int64_t' to 'const int'

### DIFF
--- a/src/ggml.c
+++ b/src/ggml.c
@@ -4325,7 +4325,7 @@ int64_t ggml_nelements(const struct ggml_tensor * tensor) {
     return tensor->ne[0]*tensor->ne[1]*tensor->ne[2]*tensor->ne[3];
 }
 
-int ggml_nrows(const struct ggml_tensor * tensor) {
+int64_t ggml_nrows(const struct ggml_tensor * tensor) {
     static_assert(GGML_MAX_DIMS == 4, "GGML_MAX_DIMS is not 4 - update this function");
 
     return tensor->ne[1]*tensor->ne[2]*tensor->ne[3];
@@ -6078,8 +6078,8 @@ struct ggml_tensor * ggml_permute(
 
     struct ggml_tensor * result = ggml_view_tensor(ctx, a);
 
-    int ne[GGML_MAX_DIMS];
-    int nb[GGML_MAX_DIMS];
+    int64_t ne[GGML_MAX_DIMS];
+    size_t nb[GGML_MAX_DIMS];
 
     ne[axis0] = a->ne[0];
     ne[axis1] = a->ne[1];
@@ -7292,20 +7292,20 @@ static void ggml_compute_forward_add_q_f32(
     const int64_t ne2  = dst->ne[2];
     const int64_t ne3  = dst->ne[3];
 
-    const int nb00 = src0->nb[0];
-    const int nb01 = src0->nb[1];
-    const int nb02 = src0->nb[2];
-    const int nb03 = src0->nb[3];
+    const size_t nb00 = src0->nb[0];
+    const size_t nb01 = src0->nb[1];
+    const size_t nb02 = src0->nb[2];
+    const size_t nb03 = src0->nb[3];
 
-    const int nb10 = src1->nb[0];
-    const int nb11 = src1->nb[1];
-    const int nb12 = src1->nb[2];
-    const int nb13 = src1->nb[3];
+    const size_t nb10 = src1->nb[0];
+    const size_t nb11 = src1->nb[1];
+    const size_t nb12 = src1->nb[2];
+    const size_t nb13 = src1->nb[3];
 
-    const int nb0  = dst->nb[0];
-    const int nb1  = dst->nb[1];
-    const int nb2  = dst->nb[2];
-    const int nb3  = dst->nb[3];
+    const size_t nb0  = dst->nb[0];
+    const size_t nb1  = dst->nb[1];
+    const size_t nb2  = dst->nb[2];
+    const size_t nb3  = dst->nb[3];
 
     const int ith = params->ith;
     const int nth = params->nth;
@@ -7320,7 +7320,7 @@ static void ggml_compute_forward_add_q_f32(
     quantize_row_q_t const quantize_row_q = quantize_fns[type].quantize_row_q;
 
     // we don't support permuted src0 or src1
-    GGML_ASSERT(nb00 == (int) GGML_TYPE_SIZE[type]);
+    GGML_ASSERT(nb00 == GGML_TYPE_SIZE[type]);
     GGML_ASSERT(nb10 == sizeof(float));
 
     // dst cannot be transposed or permuted
@@ -7781,21 +7781,21 @@ static void ggml_compute_forward_repeat_f32(
     assert( dst->ne[2] == 1);
     assert( dst->ne[3] == 1);
 
-    const int nc  = dst->ne[0];
-    const int nr  = dst->ne[1];
-    const int nc0 = src0->ne[0];
-    const int nr0 = src0->ne[1];
-    const int ncr = nc/nc0; // guaranteed to be an integer due to the check in ggml_can_repeat
-    const int nrr = nr/nr0; // guaranteed to be an integer due to the check in ggml_can_repeat
+    const int64_t nc  = dst->ne[0];
+    const int64_t nr  = dst->ne[1];
+    const int64_t nc0 = src0->ne[0];
+    const int64_t nr0 = src0->ne[1];
+    const int64_t ncr = nc/nc0; // guaranteed to be an integer due to the check in ggml_can_repeat
+    const int64_t nrr = nr/nr0; // guaranteed to be an integer due to the check in ggml_can_repeat
 
     // TODO: support for transposed / permuted tensors
     assert( dst->nb[0] == sizeof(float));
     assert(src0->nb[0] == sizeof(float));
 
     // TODO: maybe this is not optimal?
-    for (int i = 0; i < nrr; i++) {
-        for (int j = 0; j < ncr; j++) {
-            for (int k = 0; k < nr0; k++) {
+    for (int64_t i = 0; i < nrr; i++) {
+        for (int64_t j = 0; j < ncr; j++) {
+            for (int64_t k = 0; k < nr0; k++) {
                 ggml_vec_cpy_f32(nc0,
                         (float *) ((char *)  dst->data + (i*nr0 + k)*( dst->nb[1]) + j*nc0*( dst->nb[0])),
                         (float *) ((char *) src0->data + (        k)*(src0->nb[1])));
@@ -8361,23 +8361,23 @@ static void ggml_compute_forward_mul_mat_f32(
     const int64_t ne2  = dst->ne[2];
     const int64_t ne3  = dst->ne[3];
 
-    const int nb00 = src0->nb[0];
+    const size_t nb00 = src0->nb[0];
 #endif
-    const int nb01 = src0->nb[1];
-    const int nb02 = src0->nb[2];
-    const int nb03 = src0->nb[3];
+    const size_t nb01 = src0->nb[1];
+    const size_t nb02 = src0->nb[2];
+    const size_t nb03 = src0->nb[3];
 
 #ifndef NDEBUG
-    const int nb10 = src1->nb[0];
+    const size_t nb10 = src1->nb[0];
 #endif
-    const int nb11 = src1->nb[1];
-    const int nb12 = src1->nb[2];
-    const int nb13 = src1->nb[3];
+    const size_t nb11 = src1->nb[1];
+    const size_t nb12 = src1->nb[2];
+    const size_t nb13 = src1->nb[3];
 
-    const int nb0  = dst->nb[0];
-    const int nb1  = dst->nb[1];
-    const int nb2  = dst->nb[2];
-    const int nb3  = dst->nb[3];
+    const size_t nb0  = dst->nb[0];
+    const size_t nb1  = dst->nb[1];
+    const size_t nb2  = dst->nb[2];
+    const size_t nb3  = dst->nb[3];
 
     const int ith = params->ith;
     const int nth = params->nth;
@@ -8540,20 +8540,20 @@ static void ggml_compute_forward_mul_mat_f16_f32(
     const int64_t ne3  = dst->ne[3];
     //const int64_t ne   = ne0*ne1*ne2*ne3;
 
-    const int nb00 = src0->nb[0];
-    const int nb01 = src0->nb[1];
-    const int nb02 = src0->nb[2];
-    const int nb03 = src0->nb[3];
+    const size_t nb00 = src0->nb[0];
+    const size_t nb01 = src0->nb[1];
+    const size_t nb02 = src0->nb[2];
+    const size_t nb03 = src0->nb[3];
 
-    const int nb10 = src1->nb[0];
-    const int nb11 = src1->nb[1];
-    const int nb12 = src1->nb[2];
-    const int nb13 = src1->nb[3];
+    const size_t nb10 = src1->nb[0];
+    const size_t nb11 = src1->nb[1];
+    const size_t nb12 = src1->nb[2];
+    const size_t nb13 = src1->nb[3];
 
-    const int nb0  = dst->nb[0];
-    const int nb1  = dst->nb[1];
-    const int nb2  = dst->nb[2];
-    const int nb3  = dst->nb[3];
+    const size_t nb0  = dst->nb[0];
+    const size_t nb1  = dst->nb[1];
+    const size_t nb2  = dst->nb[2];
+    const size_t nb3  = dst->nb[3];
 
     const int ith = params->ith;
     const int nth = params->nth;
@@ -8754,20 +8754,20 @@ static void ggml_compute_forward_mul_mat_q_f32(
     const int64_t ne2  = dst->ne[2];
     const int64_t ne3  = dst->ne[3];
 
-    const int nb00 = src0->nb[0];
-    const int nb01 = src0->nb[1];
-    const int nb02 = src0->nb[2];
-    const int nb03 = src0->nb[3];
+    const size_t nb00 = src0->nb[0];
+    const size_t nb01 = src0->nb[1];
+    const size_t nb02 = src0->nb[2];
+    const size_t nb03 = src0->nb[3];
 
-    const int nb10 = src1->nb[0];
-    const int nb11 = src1->nb[1];
-    const int nb12 = src1->nb[2];
-    const int nb13 = src1->nb[3];
+    const size_t nb10 = src1->nb[0];
+    const size_t nb11 = src1->nb[1];
+    const size_t nb12 = src1->nb[2];
+    const size_t nb13 = src1->nb[3];
 
-    const int nb0  = dst->nb[0];
-    const int nb1  = dst->nb[1];
-    const int nb2  = dst->nb[2];
-    const int nb3  = dst->nb[3];
+    const size_t nb0  = dst->nb[0];
+    const size_t nb1  = dst->nb[1];
+    const size_t nb2  = dst->nb[2];
+    const size_t nb3  = dst->nb[3];
 
     const int ith = params->ith;
     const int nth = params->nth;
@@ -8783,7 +8783,7 @@ static void ggml_compute_forward_mul_mat_q_f32(
     enum ggml_type   const vec_dot_type       = quantize_fns[type].vec_dot_type;
 
     // we don't support permuted src0 or src1
-    GGML_ASSERT(nb00 == (int) GGML_TYPE_SIZE[type]);
+    GGML_ASSERT(nb00 == GGML_TYPE_SIZE[type]);
     GGML_ASSERT(nb10 == sizeof(float));
 
     // dst cannot be transposed or permuted
@@ -9387,18 +9387,18 @@ static void ggml_compute_forward_alibi_f32(
     const int n_past = ((int32_t *) src1->data)[0];
     const int n_head = ((int32_t *) src1->data)[1];
 
-    const int ne0 = src0->ne[0]; // all_seq_len = n_past + ne1
-    const int ne1 = src0->ne[1]; // seq_len_without_past
-    //const int ne2 = src0->ne[2]; // n_head -> this is k
-    //const int ne3 = src0->ne[3]; // 1 -> bsz
+    const int64_t ne0 = src0->ne[0]; // all_seq_len = n_past + ne1
+    const int64_t ne1 = src0->ne[1]; // seq_len_without_past
+    //const int64_t ne2 = src0->ne[2]; // n_head -> this is k
+    //const int64_t ne3 = src0->ne[3]; // 1 -> bsz
 
     const int n  = ggml_nrows(src0);
     const int ne2_ne3 = n/ne1; // ne2*ne3
 
-    const int nb0 = src0->nb[0];
-    const int nb1 = src0->nb[1];
-    const int nb2 = src0->nb[2];
-    //const int nb3 = src0->nb[3];
+    const size_t nb0 = src0->nb[0];
+    const size_t nb1 = src0->nb[1];
+    const size_t nb2 = src0->nb[2];
+    //const size_t nb3 = src0->nb[3];
 
     assert(nb0 == sizeof(float));
     assert(ne1 + n_past == ne0); (void) n_past;
@@ -9448,17 +9448,17 @@ static void ggml_compute_forward_alibi_f16(
     const int n_past = ((int32_t *) src1->data)[0];
     const int n_head = ((int32_t *) src1->data)[1];
 
-    const int ne0 = src0->ne[0]; // all_seq_len = n_past + ne1
-    const int ne1 = src0->ne[1]; // seq_len_without_past
-    //const int ne2 = src0->ne[2]; // n_head -> this is k
-    //const int ne3 = src0->ne[3]; // 1 -> bsz
+    const int64_t ne0 = src0->ne[0]; // all_seq_len = n_past + ne1
+    const int64_t ne1 = src0->ne[1]; // seq_len_without_past
+    //const int64_t ne2 = src0->ne[2]; // n_head -> this is k
+    //const int64_t ne3 = src0->ne[3]; // 1 -> bsz
 
     const int n  = ggml_nrows(src0);
     const int ne2_ne3 = n/ne1; // ne2*ne3
 
-    const int nb0 = src0->nb[0];
-    const int nb1 = src0->nb[1];
-    const int nb2 = src0->nb[2];
+    const size_t nb0 = src0->nb[0];
+    const size_t nb1 = src0->nb[1];
+    const size_t nb2 = src0->nb[2];
     //const int nb3 = src0->nb[3];
 
     assert(nb0 == sizeof(ggml_fp16_t));
@@ -9470,8 +9470,8 @@ static void ggml_compute_forward_alibi_f16(
     const float m0 = powf(2.0f, -8.0f / n_heads_log2_floor);
     const float m1 = powf(2.0f, -4.0f / n_heads_log2_floor);
 
-    for (int i = 0; i < ne0; i++) {
-        for (int j = 0; j < ne1; j++) {
+    for (int64_t i = 0; i < ne0; i++) {
+        for (int64_t j = 0; j < ne1; j++) {
             for (int k = 0; k < ne2_ne3; k++) {
                 ggml_fp16_t * const src  = (ggml_fp16_t *)((char *) src0->data + i*nb0 + j*nb1 + k*nb2);
                       float *      pdst  =       (float *)((char *)  dst->data + i*nb0 + j*nb1 + k*nb2);
@@ -9547,10 +9547,10 @@ static void ggml_compute_forward_rope_f32(
     const int64_t ne2 = src0->ne[2];
     const int64_t ne3 = src0->ne[3];
 
-    const int nb0 = src0->nb[0];
-    const int nb1 = src0->nb[1];
-    const int nb2 = src0->nb[2];
-    const int nb3 = src0->nb[3];
+    const size_t nb0 = src0->nb[0];
+    const size_t nb1 = src0->nb[1];
+    const size_t nb2 = src0->nb[2];
+    const size_t nb3 = src0->nb[3];
 
     //printf("ne0: %d, ne1: %d, ne2: %d, ne3: %d\n", ne0, ne1, ne2, ne3);
     //printf("n_past = %d, ne2 = %d\n", n_past, ne2);
@@ -9637,10 +9637,10 @@ static void ggml_compute_forward_rope_f16(
     const int64_t ne2 = src0->ne[2];
     const int64_t ne3 = src0->ne[3];
 
-    const int nb0 = src0->nb[0];
-    const int nb1 = src0->nb[1];
-    const int nb2 = src0->nb[2];
-    const int nb3 = src0->nb[3];
+    const size_t nb0 = src0->nb[0];
+    const size_t nb1 = src0->nb[1];
+    const size_t nb2 = src0->nb[2];
+    const size_t nb3 = src0->nb[3];
 
     //printf("ne0: %d, ne1: %d, ne2: %d, ne3: %d\n", ne0, ne1, ne2, ne3);
     //printf("n_past = %d, ne2 = %d\n", n_past, ne2);
@@ -9757,20 +9757,20 @@ static void ggml_compute_forward_conv_1d_1s_f16_f32(
     //const int64_t ne3  = dst->ne[3];
     //const int64_t ne   = ne0*ne1*ne2*ne3;
 
-    const int nb00 = src0->nb[0];
-    const int nb01 = src0->nb[1];
-    const int nb02 = src0->nb[2];
-    //const int nb03 = src0->nb[3];
+    const size_t nb00 = src0->nb[0];
+    const size_t nb01 = src0->nb[1];
+    const size_t nb02 = src0->nb[2];
+    //const size_t nb03 = src0->nb[3];
 
-    const int nb10 = src1->nb[0];
-    const int nb11 = src1->nb[1];
-    //const int nb12 = src1->nb[2];
-    //const int nb13 = src1->nb[3];
+    const size_t nb10 = src1->nb[0];
+    const size_t nb11 = src1->nb[1];
+    //const size_t nb12 = src1->nb[2];
+    //const size_t nb13 = src1->nb[3];
 
-    //const int nb0  = dst->nb[0];
-    const int nb1  = dst->nb[1];
-    //const int nb2  = dst->nb[2];
-    //const int nb3  = dst->nb[3];
+    //const size_t nb0  = dst->nb[0];
+    const size_t nb1  = dst->nb[1];
+    //const size_t nb2  = dst->nb[2];
+    //const size_t nb3  = dst->nb[3];
 
     const int ith = params->ith;
     const int nth = params->nth;
@@ -9877,20 +9877,20 @@ static void ggml_compute_forward_conv_1d_1s_f32(
     //const int64_t ne3  = dst->ne[3];
     //const int64_t ne   = ne0*ne1*ne2*ne3;
 
-    const int nb00 = src0->nb[0];
-    const int nb01 = src0->nb[1];
-    const int nb02 = src0->nb[2];
-    //const int nb03 = src0->nb[3];
+    const size_t nb00 = src0->nb[0];
+    const size_t nb01 = src0->nb[1];
+    const size_t nb02 = src0->nb[2];
+    //const size_t nb03 = src0->nb[3];
 
-    const int nb10 = src1->nb[0];
-    const int nb11 = src1->nb[1];
-    //const int nb12 = src1->nb[2];
-    //const int nb13 = src1->nb[3];
+    const size_t nb10 = src1->nb[0];
+    const size_t nb11 = src1->nb[1];
+    //const size_t nb12 = src1->nb[2];
+    //const size_t nb13 = src1->nb[3];
 
-    //const int nb0  = dst->nb[0];
-    const int nb1  = dst->nb[1];
-    //const int nb2  = dst->nb[2];
-    //const int nb3  = dst->nb[3];
+    //const size_t nb0  = dst->nb[0];
+    const size_t nb1  = dst->nb[1];
+    //const size_t nb2  = dst->nb[2];
+    //const size_t nb3  = dst->nb[3];
 
     const int ith = params->ith;
     const int nth = params->nth;
@@ -10020,20 +10020,20 @@ static void ggml_compute_forward_conv_1d_2s_f16_f32(
     //const int64_t ne3  = dst->ne[3];
     //const int64_t ne   = ne0*ne1*ne2*ne3;
 
-    const int nb00 = src0->nb[0];
-    const int nb01 = src0->nb[1];
-    const int nb02 = src0->nb[2];
-    //const int nb03 = src0->nb[3];
+    const size_t nb00 = src0->nb[0];
+    const size_t nb01 = src0->nb[1];
+    const size_t nb02 = src0->nb[2];
+    //const size_t nb03 = src0->nb[3];
 
-    const int nb10 = src1->nb[0];
-    const int nb11 = src1->nb[1];
-    //const int nb12 = src1->nb[2];
-    //const int nb13 = src1->nb[3];
+    const size_t nb10 = src1->nb[0];
+    const size_t nb11 = src1->nb[1];
+    //const size_t nb12 = src1->nb[2];
+    //const size_t nb13 = src1->nb[3];
 
-    //const int nb0  = dst->nb[0];
-    const int nb1  = dst->nb[1];
-    //const int nb2  = dst->nb[2];
-    //const int nb3  = dst->nb[3];
+    //const size_t nb0  = dst->nb[0];
+    const size_t nb1  = dst->nb[1];
+    //const size_t nb2  = dst->nb[2];
+    //const size_t nb3  = dst->nb[3];
 
     const int ith = params->ith;
     const int nth = params->nth;
@@ -10140,20 +10140,20 @@ static void ggml_compute_forward_conv_1d_2s_f32(
     //const int64_t ne3  = dst->ne[3];
     //const int64_t ne   = ne0*ne1*ne2*ne3;
 
-    const int nb00 = src0->nb[0];
-    const int nb01 = src0->nb[1];
-    const int nb02 = src0->nb[2];
-    //const int nb03 = src0->nb[3];
+    const size_t nb00 = src0->nb[0];
+    const size_t nb01 = src0->nb[1];
+    const size_t nb02 = src0->nb[2];
+    //const size_t nb03 = src0->nb[3];
 
-    const int nb10 = src1->nb[0];
-    const int nb11 = src1->nb[1];
-    //const int nb12 = src1->nb[2];
-    //const int nb13 = src1->nb[3];
+    const size_t nb10 = src1->nb[0];
+    const size_t nb11 = src1->nb[1];
+    //const size_t nb12 = src1->nb[2];
+    //const size_t nb13 = src1->nb[3];
 
-    //const int nb0  = dst->nb[0];
-    const int nb1  = dst->nb[1];
-    //const int nb2  = dst->nb[2];
-    //const int nb3  = dst->nb[3];
+    //const size_t nb0  = dst->nb[0];
+    const size_t nb1  = dst->nb[1];
+    //const size_t nb2  = dst->nb[2];
+    //const size_t nb3  = dst->nb[3];
 
     const int ith = params->ith;
     const int nth = params->nth;
@@ -10285,25 +10285,25 @@ static void ggml_compute_forward_flash_attn_f32(
     //const int64_t ne2  = dst->ne[2];
     //const int64_t ne3  = dst->ne[3];
 
-    const int nbk0 = k->nb[0];
-    const int nbk1 = k->nb[1];
-    const int nbk2 = k->nb[2];
-    const int nbk3 = k->nb[3];
+    const size_t nbk0 = k->nb[0];
+    const size_t nbk1 = k->nb[1];
+    const size_t nbk2 = k->nb[2];
+    const size_t nbk3 = k->nb[3];
 
-    const int nbq0 = q->nb[0];
-    const int nbq1 = q->nb[1];
-    const int nbq2 = q->nb[2];
-    const int nbq3 = q->nb[3];
+    const size_t nbq0 = q->nb[0];
+    const size_t nbq1 = q->nb[1];
+    const size_t nbq2 = q->nb[2];
+    const size_t nbq3 = q->nb[3];
 
-    const int nbv0 = v->nb[0];
-    const int nbv1 = v->nb[1];
-    const int nbv2 = v->nb[2];
-    const int nbv3 = v->nb[3];
+    const size_t nbv0 = v->nb[0];
+    const size_t nbv1 = v->nb[1];
+    const size_t nbv2 = v->nb[2];
+    const size_t nbv3 = v->nb[3];
 
-    const int nb0  = dst->nb[0];
-    const int nb1  = dst->nb[1];
-    const int nb2  = dst->nb[2];
-    const int nb3  = dst->nb[3];
+    const size_t nb0  = dst->nb[0];
+    const size_t nb1  = dst->nb[1];
+    const size_t nb2  = dst->nb[2];
+    const size_t nb3  = dst->nb[3];
 
     const int ith = params->ith;
     const int nth = params->nth;
@@ -10494,25 +10494,25 @@ static void ggml_compute_forward_flash_attn_f16(
     //const int64_t ne2  = dst->ne[2];
     //const int64_t ne3  = dst->ne[3];
 
-    const int nbk0 = k->nb[0];
-    const int nbk1 = k->nb[1];
-    const int nbk2 = k->nb[2];
-    const int nbk3 = k->nb[3];
+    const size_t nbk0 = k->nb[0];
+    const size_t nbk1 = k->nb[1];
+    const size_t nbk2 = k->nb[2];
+    const size_t nbk3 = k->nb[3];
 
-    const int nbq0 = q->nb[0];
-    const int nbq1 = q->nb[1];
-    const int nbq2 = q->nb[2];
-    const int nbq3 = q->nb[3];
+    const size_t nbq0 = q->nb[0];
+    const size_t nbq1 = q->nb[1];
+    const size_t nbq2 = q->nb[2];
+    const size_t nbq3 = q->nb[3];
 
-    const int nbv0 = v->nb[0];
-    const int nbv1 = v->nb[1];
-    const int nbv2 = v->nb[2];
-    const int nbv3 = v->nb[3];
+    const size_t nbv0 = v->nb[0];
+    const size_t nbv1 = v->nb[1];
+    const size_t nbv2 = v->nb[2];
+    const size_t nbv3 = v->nb[3];
 
-    const int nb0  = dst->nb[0];
-    const int nb1  = dst->nb[1];
-    const int nb2  = dst->nb[2];
-    const int nb3  = dst->nb[3];
+    const size_t nb0  = dst->nb[0];
+    const size_t nb1  = dst->nb[1];
+    const size_t nb2  = dst->nb[2];
+    const size_t nb3  = dst->nb[3];
 
     const int ith = params->ith;
     const int nth = params->nth;
@@ -10776,35 +10776,35 @@ static void ggml_compute_forward_flash_ff_f16(
     const int64_t ne2 = dst->ne[2];
     //const int64_t ne3 = dst->ne[3];
 
-    const int nba0 = a->nb[0];
-    const int nba1 = a->nb[1];
-    const int nba2 = a->nb[2];
-    const int nba3 = a->nb[3];
+    const size_t nba0 = a->nb[0];
+    const size_t nba1 = a->nb[1];
+    const size_t nba2 = a->nb[2];
+    const size_t nba3 = a->nb[3];
 
-    const int nbb00 = b0->nb[0];
-    const int nbb01 = b0->nb[1];
-    const int nbb02 = b0->nb[2];
-    const int nbb03 = b0->nb[3];
+    const size_t nbb00 = b0->nb[0];
+    const size_t nbb01 = b0->nb[1];
+    const size_t nbb02 = b0->nb[2];
+    const size_t nbb03 = b0->nb[3];
 
-    const int nbb10 = b1->nb[0];
-    //const int nbb11 = b1->nb[1];
-    //const int nbb12 = b1->nb[2];
-    //const int nbb13 = b1->nb[3];
+    const size_t nbb10 = b1->nb[0];
+    //const size_t nbb11 = b1->nb[1];
+    //const size_t nbb12 = b1->nb[2];
+    //const size_t nbb13 = b1->nb[3];
 
-    const int nbc00 = c0->nb[0];
-    const int nbc01 = c0->nb[1];
-    const int nbc02 = c0->nb[2];
-    const int nbc03 = c0->nb[3];
+    const size_t nbc00 = c0->nb[0];
+    const size_t nbc01 = c0->nb[1];
+    const size_t nbc02 = c0->nb[2];
+    const size_t nbc03 = c0->nb[3];
 
-    const int nbc10 = c1->nb[0];
-    //const int nbc11 = c1->nb[1];
-    //const int nbc12 = c1->nb[2];
-    //const int nbc13 = c1->nb[3];
+    const size_t nbc10 = c1->nb[0];
+    //const size_t nbc11 = c1->nb[1];
+    //const size_t nbc12 = c1->nb[2];
+    //const size_t nbc13 = c1->nb[3];
 
-    const int nb0 = dst->nb[0];
-    const int nb1 = dst->nb[1];
-    const int nb2 = dst->nb[2];
-    const int nb3 = dst->nb[3];
+    const size_t nb0 = dst->nb[0];
+    const size_t nb1 = dst->nb[1];
+    const size_t nb2 = dst->nb[2];
+    const size_t nb3 = dst->nb[3];
 
     const int ith = params->ith;
     const int nth = params->nth;


### PR DESCRIPTION
fix warning like

```c
D:\a\whisper.cpp\whisper.cpp\ggml.c(5966,22): warning C4244: '=': conversion from 'int64_t' to 'int', possible loss of data [D:\a\whisper.cpp\whisper.cpp\build\whisper.vcxproj]
```

in win build.