### PR TITLE
Fix bug in ggml_alibi

### DIFF
--- a/src/ggml.c
+++ b/src/ggml.c
@@ -9425,7 +9425,7 @@ static void ggml_compute_forward_alibi_f32(
                     m_k = powf(m1, 2 * (k - n_heads_log2_floor) + 1);
                 }
 
-                pdst[0] = (j+1) * m_k + src[0];
+                pdst[0] = i * m_k + src[0];
             }
         }
     }
@@ -9487,7 +9487,7 @@ static void ggml_compute_forward_alibi_f16(
                 }
 
                 // we return F32
-                pdst[0] = (j+1) * m_k + GGML_FP16_TO_FP32(src[0]);
+                pdst[0] = i * m_k + GGML_FP16_TO_FP32(src[0]);
             }
         }
     }


### PR DESCRIPTION
According to https://github.com/NouamaneTazi/bloomz.cpp/issues/27, I found there is a wrong implementation in `ggml_alibi`.

Now, `ggml_alibi` will get same result compare to the `build_alibi_tensor` in `transformers.models.bloom.modeling_bloom`