### PR TITLE
Update StarCoder example to follow the naming convention of other examples

### DIFF
--- a/examples/starcoder/README.md
+++ b/examples/starcoder/README.md
@@ -36,16 +36,16 @@ options:
 
 $ ./bin/starcoder -m ../models/bigcode/gpt_bigcode-santacoder-ggml-q4_1.bin -p "def fibonnaci(" -t 4 --top_k 0 --top_p 0.95 --temp 0.2      
 main: seed = 1683881276
-gpt2_model_load: loading model from '../models/bigcode/gpt_bigcode-santacoder-ggml-q4_1.bin'
-gpt2_model_load: n_vocab = 49280
-gpt2_model_load: n_ctx   = 2048
-gpt2_model_load: n_embd  = 2048
-gpt2_model_load: n_head  = 16
-gpt2_model_load: n_layer = 24
-gpt2_model_load: ftype   = 3
-gpt2_model_load: ggml ctx size = 1794.90 MB
-gpt2_model_load: memory size =   768.00 MB, n_mem = 49152
-gpt2_model_load: model size  =  1026.83 MB
+starcoder_model_load: loading model from '../models/bigcode/gpt_bigcode-santacoder-ggml-q4_1.bin'
+starcoder_model_load: n_vocab = 49280
+starcoder_model_load: n_ctx   = 2048
+starcoder_model_load: n_embd  = 2048
+starcoder_model_load: n_head  = 16
+starcoder_model_load: n_layer = 24
+starcoder_model_load: ftype   = 3
+starcoder_model_load: ggml ctx size = 1794.90 MB
+starcoder_model_load: memory size =   768.00 MB, n_mem = 49152
+starcoder_model_load: model size  =  1026.83 MB
 main: prompt: 'def fibonnaci('
 main: number of tokens in prompt = 7, first 8 tokens: 563 24240 78 2658 64 2819 7 
 

--- a/examples/starcoder/quantize.cpp
+++ b/examples/starcoder/quantize.cpp
@@ -14,7 +14,7 @@
 #include <regex>
 
 // default hparams (GPT-2 117M)
-struct gpt2_hparams {
+struct starcoder_hparams {
     int32_t n_vocab = 49280;
     int32_t n_ctx   = 2048;
     int32_t n_embd  = 2048;
@@ -24,7 +24,7 @@ struct gpt2_hparams {
 };
 
 // quantize a model
-bool gpt2_model_quantize(const std::string & fname_inp, const std::string & fname_out, ggml_ftype ftype) {
+bool starcoder_model_quantize(const std::string & fname_inp, const std::string & fname_out, ggml_ftype ftype) {
     gpt_vocab vocab;
 
     printf("%s: loading model from '%s'\n", __func__, fname_inp.c_str());
@@ -53,7 +53,7 @@ bool gpt2_model_quantize(const std::string & fname_inp, const std::string & fnam
         fout.write((char *) &magic, sizeof(magic));
     }
 
-    gpt2_hparams hparams;
+    starcoder_hparams hparams;
 
     // load hparams
     {
@@ -157,7 +157,7 @@ int main(int argc, char ** argv) {
     {
         const int64_t t_start_us = ggml_time_us();
 
-        if (!gpt2_model_quantize(fname_inp, fname_out, ggml_ftype(ftype))) {
+        if (!starcoder_model_quantize(fname_inp, fname_out, ggml_ftype(ftype))) {
             fprintf(stderr, "%s: failed to quantize model from '%s'\n", __func__, fname_inp.c_str());
             return 1;
         }


### PR DESCRIPTION
For example, in Dolly V2 names start with `dollyv2_` and not `gpt_neox_`. This will help keep the struct / function names across examples unique.