### PR TITLE
Fix typo in ggml.h

### DIFF
--- a/include/ggml/ggml.h
+++ b/include/ggml/ggml.h
@@ -849,7 +849,7 @@ extern "C" {
             int                   n_past);
 
     // in-place, returns view(a)
-    GGML_API struct ggml_tensor * gml_diag_mask_zero_inplace(
+    GGML_API struct ggml_tensor * ggml_diag_mask_zero_inplace(
             struct ggml_context * ctx,
             struct ggml_tensor  * a,
             int                   n_past);


### PR DESCRIPTION
Small typo in `ggml.h`, correct spelling in `ggml.c`