### PR TITLE
mpt - Add flags for prompt context size (-c/--ctx_size)

### DIFF
--- a/examples/common.cpp
+++ b/examples/common.cpp
@@ -78,7 +78,7 @@ void gpt_print_usage(int /*argc*/, char ** argv, const gpt_params & params) {
     fprintf(stderr, "  -n N, --n_predict N   number of tokens to predict (default: %d)\n", params.n_predict);
     fprintf(stderr, "  --top_k N             top-k sampling (default: %d)\n", params.top_k);
     fprintf(stderr, "  --top_p N             top-p sampling (default: %.1f)\n", params.top_p);
-    fprintf(stderr, "  -c N, --ctx_size N    size of the prompt context (default: %d)\n", params.n_ctx)
+    fprintf(stderr, "  -c N, --ctx_size N    size of the prompt context (default: %d)\n", params.n_ctx);
     fprintf(stderr, "  --temp N              temperature (default: %.1f)\n", params.temp);
     fprintf(stderr, "  -b N, --batch_size N  batch size for prompt processing (default: %d)\n", params.n_batch);
     fprintf(stderr, "  -m FNAME, --model FNAME\n");

--- a/examples/common.cpp
+++ b/examples/common.cpp
@@ -27,6 +27,8 @@ bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
             params.n_predict = std::stoi(argv[++i]);
         } else if (arg == "--top_k") {
             params.top_k = std::stoi(argv[++i]);
+        } else if (arg == "-c" || arg == "--ctx_size") {
+            params.n_ctx = std::stoi(argv[++i]);
         } else if (arg == "--top_p") {
             params.top_p = std::stof(argv[++i]);
         } else if (arg == "--temp") {
@@ -76,6 +78,7 @@ void gpt_print_usage(int /*argc*/, char ** argv, const gpt_params & params) {
     fprintf(stderr, "  -n N, --n_predict N   number of tokens to predict (default: %d)\n", params.n_predict);
     fprintf(stderr, "  --top_k N             top-k sampling (default: %d)\n", params.top_k);
     fprintf(stderr, "  --top_p N             top-p sampling (default: %.1f)\n", params.top_p);
+    fprintf(stderr, "  -c N, --ctx_size N    size of the prompt context (default: %d)\n", params.n_ctx)
     fprintf(stderr, "  --temp N              temperature (default: %.1f)\n", params.temp);
     fprintf(stderr, "  -b N, --batch_size N  batch size for prompt processing (default: %d)\n", params.n_batch);
     fprintf(stderr, "  -m FNAME, --model FNAME\n");

--- a/examples/common.h
+++ b/examples/common.h
@@ -14,10 +14,12 @@
 // CLI argument parsing
 //
 
-struct gpt_params {
+struct gpt_params { //default values
     int32_t seed      = -1; // RNG seed
     int32_t n_threads = std::min(4, (int32_t) std::thread::hardware_concurrency());
     int32_t n_predict = 200; // new tokens to predict
+
+    int32_t n_ctx = 2048; //default context size
 
     // sampling parameters
     int32_t top_k = 40;


### PR DESCRIPTION
mpt: Adds flags (`-c/--ctx_size`) for increasing prompt context size (e.g. from 4096 to 65536) for use with storywriter models.

In conjunction with #173, should improve/fix:
- https://github.com/ggerganov/ggml/issues/171, 
- https://github.com/ggerganov/ggml/issues/158 , 
- maybe https://github.com/bigcode-project/starcoder.cpp/issues/3
- https://github.com/ggerganov/llama.cpp/issues/1333#issuecomment-1537412858 