### PR TITLE
examples : add missing header file

### DIFF
--- a/examples/mnist/main.cpp
+++ b/examples/mnist/main.cpp
@@ -4,6 +4,7 @@
 
 #include <cmath>
 #include <cstdio>
+#include <cstring>
 #include <ctime>
 #include <fstream>
 #include <string>

--- a/examples/mpt/main.cpp
+++ b/examples/mpt/main.cpp
@@ -6,6 +6,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdio>
+#include <cstring>
 #include <fstream>
 #include <cinttypes>
 #include <map>


### PR DESCRIPTION
Some of the examples are missing the cstring header which is needed for memcpy().