### PR TITLE
Fix ggml_alibi tensor size

### DIFF
--- a/src/ggml.c
+++ b/src/ggml.c
@@ -6317,7 +6317,7 @@ struct ggml_tensor * ggml_alibi(
 
     ggml_scratch_save(ctx);
 
-    struct ggml_tensor * b = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, 2);
+    struct ggml_tensor * b = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, 3);
 
     ((int32_t *) b->data)[0] = n_past;
     ((int32_t *) b->data)[1] = n_head;


### PR DESCRIPTION
hi! i've debugged mpt-7b implementation, and encounter assertion failing:
- here https://github.com/ggerganov/ggml/blob/07bd0114365c7cb0cbb2ad8297d7a64788f882c4/src/ggml.c#L10833
- and here https://github.com/ggerganov/ggml/blob/07bd0114365c7cb0cbb2ad8297d7a64788f882c4/src/ggml.c#L10897

this patch should fix it, 
thanks

cc https://github.com/rustformers/llm/issues/281