### PR TITLE
Fix compilation on Linux

### DIFF
--- a/examples/common.cpp
+++ b/examples/common.cpp
@@ -6,6 +6,7 @@
 #include "dr_wav.h"
 
 #include <cmath>
+#include <cstring>
 #include <fstream>
 #include <regex>
 #include <locale>


### PR DESCRIPTION
Was getting this error when compiling on Fedora 37/38 with gcc-c++ 13. [cppreference](https://en.cppreference.com/w/cpp/string/byte/strlen) says std::strlen is defined in `<cstring>` header.
 
```/home/eyusupov/mlsources/ggml/examples/common.cpp: In function ‘std::map<std::__cxx11::basic_string<char>, std::vector<int> > extract_tests_from_file(const std::string&)’:
/home/eyusupov/mlsources/ggml/examples/common.cpp:319:68: error: ‘strlen’ is not a member of ‘std’; did you mean ‘mbrlen’?
  319 |             std::string s_tokens = line.substr(delimiterPos + std::strlen(delimeter));
      |                                                                    ^~~~~~
      |                                                                    mbrlen
make[2]: *** [examples/CMakeFiles/common.dir/build.make:76: examples/CMakeFiles/common.dir/common.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:647: examples/CMakeFiles/common.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
```