### PR TITLE
mnist : add missing header

### DIFF
--- a/examples/mnist/main-cpu.cpp
+++ b/examples/mnist/main-cpu.cpp
@@ -12,6 +12,7 @@
 
 #include "ggml/ggml.h"
 
+#include <algorithm>
 #include <cmath>
 #include <cstdio>
 #include <cstring>


### PR DESCRIPTION
Fixes this error:
```
[ 68%] Building CXX object examples/mnist/CMakeFiles/mnist-cpu.dir/main-cpu.cpp.o
/home/eyusupov/mlsources/ggml/examples/mnist/main-cpu.cpp: In function ‘int mnist_eval(const char*, int, std::vector<float>)’:
/home/eyusupov/mlsources/ggml/examples/mnist/main-cpu.cpp:61:33: error: ‘max_element’ is not a member of ‘std’; did you mean ‘tuple_element’?
   61 |     const int prediction = std::max_element(probs_data, probs_data + 10) - probs_data;
      |                                 ^~~~~~~~~~~
      |                                 tuple_element
make[2]: *** [examples/mnist/CMakeFiles/mnist-cpu.dir/build.make:76: examples/mnist/CMakeFiles/mnist-cpu.dir/main-cpu.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:922: examples/mnist/CMakeFiles/mnist-cpu.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
```

[cppreference](https://en.cppreference.com/w/cpp/algorithm/max_element).