### PR TITLE
Export all symbols on windows when building shared library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -226,6 +226,8 @@ else()
 endif()
 
 if (BUILD_SHARED_LIBS)
+    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+
     target_link_libraries(${TARGET} PUBLIC
         ${CMAKE_DL_LIBS}
         )


### PR DESCRIPTION
Currently building ggml on windows as a shared library does not export all symbols by default.