### PR TITLE
examples : fix c++ standard errors and pedantic warnings

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2,6 +2,7 @@ if (GGML_ALL_WARNINGS)
   if (NOT MSVC)
       set(cxx_flags
           # TODO(marella): Add other warnings.
+          -Wpedantic
           -Wunused-variable
           -Wno-unused-function
           -Wno-multichar

--- a/examples/dolly-v2/main.cpp
+++ b/examples/dolly-v2/main.cpp
@@ -212,9 +212,9 @@ bool dollyv2_model_load(const std::string & fname, dollyv2_model & model, gpt_vo
     // create the ggml context
     {
         struct ggml_init_params params = {
-            .mem_size   = ctx_size,
-            .mem_buffer = NULL,
-            .no_alloc   = false,
+            /*.mem_size   =*/ ctx_size,
+            /*.mem_buffer =*/ NULL,
+            /*.no_alloc   =*/ false,
         };
 
         model.ctx = ggml_init(params);
@@ -473,9 +473,9 @@ bool dollyv2_eval(
     }
 
     struct ggml_init_params params = {
-        .mem_size   = buf_size,
-        .mem_buffer = buf,
-        .no_alloc   = false,
+        /*.mem_size   =*/ buf_size,
+        /*.mem_buffer =*/ buf,
+        /*.no_alloc   =*/ false,
     };
 
     struct ggml_context * ctx0 = ggml_init(params);

--- a/examples/gpt-2/main.cpp
+++ b/examples/gpt-2/main.cpp
@@ -196,9 +196,9 @@ bool gpt2_model_load(const std::string & fname, gpt2_model & model, gpt_vocab & 
     // create the ggml context
     {
         struct ggml_init_params params = {
-            .mem_size   = ctx_size,
-            .mem_buffer = NULL,
-            .no_alloc   = false,
+            /*.mem_size   =*/ ctx_size,
+            /*.mem_buffer =*/ NULL,
+            /*.no_alloc   =*/ false,
         };
 
         model.ctx = ggml_init(params);
@@ -418,9 +418,9 @@ bool gpt2_eval(
     }
 
     struct ggml_init_params params = {
-        .mem_size   = buf_size,
-        .mem_buffer = buf,
-        .no_alloc   = false,
+        /*.mem_size   =*/ buf_size,
+        /*.mem_buffer =*/ buf,
+        /*.no_alloc   =*/ false,
     };
 
     struct ggml_context * ctx0 = ggml_init(params);

--- a/examples/gpt-j/main.cpp
+++ b/examples/gpt-j/main.cpp
@@ -194,9 +194,9 @@ bool gptj_model_load(const std::string & fname, gptj_model & model, gpt_vocab & 
     // create the ggml context
     {
         struct ggml_init_params params = {
-            .mem_size   = ctx_size,
-            .mem_buffer = NULL,
-            .no_alloc   = false,
+            /*.mem_size   =*/ ctx_size,
+            /*.mem_buffer =*/ NULL,
+            /*.no_alloc   =*/ false,
         };
 
         model.ctx = ggml_init(params);
@@ -413,9 +413,9 @@ bool gptj_eval(
     }
 
     struct ggml_init_params params = {
-        .mem_size   = buf_size,
-        .mem_buffer = buf,
-        .no_alloc   = false,
+        /*.mem_size   =*/ buf_size,
+        /*.mem_buffer =*/ buf,
+        /*.no_alloc   =*/ false,
     };
 
     struct ggml_context * ctx0 = ggml_init(params);

--- a/examples/gpt-neox/main.cpp
+++ b/examples/gpt-neox/main.cpp
@@ -198,9 +198,9 @@ bool gpt_neox_model_load(const std::string & fname, gpt_neox_model & model, gpt_
     // create the ggml context
     {
         struct ggml_init_params params = {
-            .mem_size   = ctx_size,
-            .mem_buffer = NULL,
-            .no_alloc   = false,
+            /*.mem_size   =*/ ctx_size,
+            /*.mem_buffer =*/ NULL,
+            /*.no_alloc   =*/ false,
         };
 
         model.ctx = ggml_init(params);
@@ -465,9 +465,9 @@ bool gpt_neox_eval(
     }
 
     struct ggml_init_params params = {
-        .mem_size   = buf_size,
-        .mem_buffer = buf,
-        .no_alloc   = false,
+        /*.mem_size   =*/ buf_size,
+        /*.mem_buffer =*/ buf,
+        /*.no_alloc   =*/ false,
     };
 
     struct ggml_context * ctx0 = ggml_init(params);

--- a/examples/mnist/main-cpu.cpp
+++ b/examples/mnist/main-cpu.cpp
@@ -45,9 +45,9 @@ int mnist_eval(
     static void * buf = malloc(buf_size);
 
     struct ggml_init_params params = {
-        .mem_size   = buf_size,
-        .mem_buffer = buf,
-        .no_alloc   = false,
+        /*.mem_size   =*/ buf_size,
+        /*.mem_buffer =*/ buf,
+        /*.no_alloc   =*/ false,
     };
 
     struct ggml_context * ctx_work = ggml_init(params);

--- a/examples/mnist/main.cpp
+++ b/examples/mnist/main.cpp
@@ -73,9 +73,9 @@ bool mnist_model_load(const std::string & fname, mnist_model & model) {
     // create the ggml context
     {
         struct ggml_init_params params = {
-            .mem_size   = ctx_size + 1024*1024,
-            .mem_buffer = NULL,
-            .no_alloc   = false,
+            /*.mem_size   =*/ ctx_size + 1024*1024,
+            /*.mem_buffer =*/ NULL,
+            /*.no_alloc   =*/ false,
         };
 
         model.ctx = ggml_init(params);
@@ -175,9 +175,9 @@ int mnist_eval(
     static void * buf = malloc(buf_size);
 
     struct ggml_init_params params = {
-        .mem_size   = buf_size,
-        .mem_buffer = buf,
-        .no_alloc   = false,
+        /*.mem_size   =*/ buf_size,
+        /*.mem_buffer =*/ buf,
+        /*.no_alloc   =*/ false,
     };
 
     struct ggml_context * ctx0 = ggml_init(params);

--- a/examples/mpt/main.cpp
+++ b/examples/mpt/main.cpp
@@ -291,9 +291,9 @@ bool mpt_model_load(const std::string & fname, mpt_model & model, gpt_vocab & vo
     // create the ggml context
     {
         struct ggml_init_params params = {
-            .mem_size = ctx_size,
-            .mem_buffer = NULL,
-            .no_alloc = false,
+            /*.mem_size   =*/ ctx_size,
+            /*.mem_buffer =*/ NULL,
+            /*.no_alloc   =*/ false,
         };
 
         model.ctx = ggml_init(params);
@@ -488,13 +488,14 @@ bool mpt_eval(const mpt_model & model, const int n_threads, const int n_past,
     }
 
     struct ggml_init_params params = {
-        .mem_size = buf_size,
-        .mem_buffer = buf,
-        .no_alloc = false,
+        /*.mem_size   =*/ buf_size,
+        /*.mem_buffer =*/ buf,
+        /*.no_alloc   =*/ false,
     };
 
     struct ggml_context * ctx0 = ggml_init(params);
-    struct ggml_cgraph gf = {.n_threads = n_threads};
+    struct ggml_cgraph gf = {};
+    gf.n_threads = n_threads;
 
     struct ggml_tensor * embd = ggml_new_tensor_1d(ctx0, GGML_TYPE_I32, N);
     memcpy(embd->data, embd_inp.data(), N * ggml_element_size(embd));

--- a/examples/replit/main.cpp
+++ b/examples/replit/main.cpp
@@ -260,9 +260,9 @@ bool replit_model_load(const std::string & fname, replit_model & model, replit_t
     // create the ggml context
     {
         struct ggml_init_params params = {
-            .mem_size = ctx_size,
-            .mem_buffer = NULL,
-            .no_alloc = false,
+            /*.mem_size   =*/ ctx_size,
+            /*.mem_buffer =*/ NULL,
+            /*.no_alloc   =*/ false,
         };
 
         model.ctx = ggml_init(params);
@@ -452,13 +452,14 @@ bool replit_eval(const replit_model & model, const int n_threads, const int n_pa
     }
 
     struct ggml_init_params params = {
-        .mem_size = buf_size,
-        .mem_buffer = buf,
-        .no_alloc = false,
+        /*.mem_size   =*/ buf_size,
+        /*.mem_buffer =*/ buf,
+        /*.no_alloc   =*/ false,
     };
 
     struct ggml_context * ctx0 = ggml_init(params);
-    struct ggml_cgraph gf = {.n_threads = n_threads};
+    struct ggml_cgraph gf = {};
+    gf.n_threads = n_threads;
 
     struct ggml_tensor * embd = ggml_new_tensor_1d(ctx0, GGML_TYPE_I32, N);
     memcpy(embd->data, embd_inp.data(), N * ggml_element_size(embd));

--- a/examples/starcoder/main.cpp
+++ b/examples/starcoder/main.cpp
@@ -202,9 +202,9 @@ bool starcoder_model_load(const std::string & fname, starcoder_model & model, gp
     // create the ggml context
     {
         struct ggml_init_params params = {
-            .mem_size   = ctx_size,
-            .mem_buffer = NULL,
-            .no_alloc   = false,
+            /*.mem_size   =*/ ctx_size,
+            /*.mem_buffer =*/ NULL,
+            /*.no_alloc   =*/ false,
         };
 
         model.ctx = ggml_init(params);
@@ -436,9 +436,9 @@ bool starcoder_eval(
     }
 
     struct ggml_init_params params = {
-        .mem_size   = buf_size,
-        .mem_buffer = buf,
-        .no_alloc   = false,
+        /*.mem_size   =*/ buf_size,
+        /*.mem_buffer =*/ buf,
+        /*.no_alloc   =*/ false,
     };
 
     struct ggml_context * ctx0 = ggml_init(params);

--- a/examples/whisper/main.cpp
+++ b/examples/whisper/main.cpp
@@ -424,13 +424,13 @@ bool output_json(struct whisper_context * ctx, const char * fname, const whisper
         indent++;
     };
 
-    auto end_arr = [&](bool end = false) {
+    auto end_arr = [&](bool end) {
         indent--;
         doindent();
         fout << (end ? "]\n" : "},\n");
     };
 
-    auto start_obj = [&](const char *name = nullptr) {
+    auto start_obj = [&](const char *name) {
         doindent();
         if (name) {
             fout << "\"" << name << "\": {\n";
@@ -440,7 +440,7 @@ bool output_json(struct whisper_context * ctx, const char * fname, const whisper
         indent++;
     };
 
-    auto end_obj = [&](bool end = false) {
+    auto end_obj = [&](bool end) {
         indent--;
         doindent();
         fout << (end ? "}\n" : "},\n");
@@ -451,24 +451,24 @@ bool output_json(struct whisper_context * ctx, const char * fname, const whisper
         fout << "\"" << name << "\": ";
     };
 
-    auto value_s = [&](const char *name, const char *val, bool end = false) {
+    auto value_s = [&](const char *name, const char *val, bool end) {
         start_value(name);
         char * val_escaped = escape_double_quotes_and_backslashes(val);
         fout << "\"" << val_escaped << (end ? "\"\n" : "\",\n");
         free(val_escaped);
     };
 
-    auto end_value = [&](bool end = false) {
+    auto end_value = [&](bool end) {
         fout << (end ? "\n" : ",\n");
     };
 
-    auto value_i = [&](const char *name, const int64_t val, bool end = false) {
+    auto value_i = [&](const char *name, const int64_t val, bool end) {
         start_value(name);
         fout << val;
         end_value(end);
     };
 
-    auto value_b = [&](const char *name, const bool val, bool end = false) {
+    auto value_b = [&](const char *name, const bool val, bool end) {
         start_value(name);
         fout << (val ? "true" : "false");
         end_value(end);
@@ -480,35 +480,35 @@ bool output_json(struct whisper_context * ctx, const char * fname, const whisper
     }
 
     fprintf(stderr, "%s: saving output to '%s'\n", __func__, fname);
-    start_obj();
-        value_s("systeminfo", whisper_print_system_info());
+    start_obj(nullptr);
+        value_s("systeminfo", whisper_print_system_info(), false);
         start_obj("model");
-            value_s("type", whisper_model_type_readable(ctx));
-            value_b("multilingual", whisper_is_multilingual(ctx));
-            value_i("vocab", whisper_model_n_vocab(ctx));
+            value_s("type", whisper_model_type_readable(ctx), false);
+            value_b("multilingual", whisper_is_multilingual(ctx), false);
+            value_i("vocab", whisper_model_n_vocab(ctx), false);
             start_obj("audio");
-                value_i("ctx", whisper_model_n_audio_ctx(ctx));
-                value_i("state", whisper_model_n_audio_state(ctx));
-                value_i("head", whisper_model_n_audio_head(ctx));
+                value_i("ctx", whisper_model_n_audio_ctx(ctx), false);
+                value_i("state", whisper_model_n_audio_state(ctx), false);
+                value_i("head", whisper_model_n_audio_head(ctx), false);
                 value_i("layer", whisper_model_n_audio_layer(ctx), true);
-            end_obj();
+            end_obj(false);
             start_obj("text");
-                value_i("ctx", whisper_model_n_text_ctx(ctx));
-                value_i("state", whisper_model_n_text_state(ctx));
-                value_i("head", whisper_model_n_text_head(ctx));
+                value_i("ctx", whisper_model_n_text_ctx(ctx), false);
+                value_i("state", whisper_model_n_text_state(ctx), false);
+                value_i("head", whisper_model_n_text_head(ctx), false);
                 value_i("layer", whisper_model_n_text_layer(ctx), true);
-            end_obj();
-            value_i("mels", whisper_model_n_mels(ctx));
+            end_obj(false);
+            value_i("mels", whisper_model_n_mels(ctx), false);
             value_i("ftype", whisper_model_ftype(ctx), true);
-        end_obj();
+        end_obj(false);
         start_obj("params");
-            value_s("model", params.model.c_str());
-            value_s("language", params.language.c_str());
+            value_s("model", params.model.c_str(), false);
+            value_s("language", params.language.c_str(), false);
             value_b("translate", params.translate, true);
-        end_obj();
+        end_obj(false);
         start_obj("result");
             value_s("language", whisper_lang_str(whisper_full_lang_id(ctx)), true);
-        end_obj();
+        end_obj(false);
         start_arr("transcription");
 
             const int n_segments = whisper_full_n_segments(ctx);
@@ -517,15 +517,15 @@ bool output_json(struct whisper_context * ctx, const char * fname, const whisper
                 const int64_t t0 = whisper_full_get_segment_t0(ctx, i);
                 const int64_t t1 = whisper_full_get_segment_t1(ctx, i);
 
-                start_obj();
+                start_obj(nullptr);
                     start_obj("timestamps");
-                        value_s("from", to_timestamp(t0, true).c_str());
+                        value_s("from", to_timestamp(t0, true).c_str(), false);
                         value_s("to", to_timestamp(t1, true).c_str(), true);
-                    end_obj();
+                    end_obj(false);
                     start_obj("offsets");
-                        value_i("from", t0 * 10);
+                        value_i("from", t0 * 10, false);
                         value_i("to", t1 * 10, true);
-                    end_obj();
+                    end_obj(false);
                     value_s("text", text, true);
                 end_obj(i == (n_segments - 1));
             }


### PR DESCRIPTION
Currently these examples (except whisper) don't compile on Windows with `CMAKE_CXX_STANDARD 11`.

Adding `-Wpedantic` should prevent such issues in future.