### PR TITLE
Removed duplicate lines in convert-pt-to-ggml.py whisper example

### DIFF
--- a/examples/whisper/convert-pt-to-ggml.py
+++ b/examples/whisper/convert-pt-to-ggml.py
@@ -297,8 +297,6 @@ for name in list_vars.keys():
                 name == "encoder.conv2.bias"   or \
                 name == "encoder.positional_embedding" or \
                 name == "decoder.positional_embedding":
-            ftype = 0
-            data = data.astype(np.float32)
             print("  Converting to float32")
             data = data.astype(np.float32)
             ftype = 0


### PR DESCRIPTION
Hey, I appreciate your work!
I cleaned up 2 lines: `ftype=0;` and `data = data.astype(np.float32)`.
As you can see, lines 300, 301 are repeated in 303, 304.
No real impact, just for cleaner code.