### PR TITLE
Return input tensor in ggml_set_name

### DIFF
--- a/include/ggml/ggml.h
+++ b/include/ggml/ggml.h
@@ -513,8 +513,8 @@ extern "C" {
     GGML_API void *  ggml_get_data    (const struct ggml_tensor * tensor);
     GGML_API float * ggml_get_data_f32(const struct ggml_tensor * tensor);
 
-    GGML_API const char * ggml_get_name(const struct ggml_tensor * tensor);
-    GGML_API void         ggml_set_name(struct ggml_tensor * tensor, const char * name);
+    GGML_API const char *         ggml_get_name(const struct ggml_tensor * tensor);
+    GGML_API struct ggml_tensor * ggml_set_name(struct ggml_tensor * tensor, const char * name);
 
     //
     // operations on tensors with backpropagation

--- a/src/ggml.c
+++ b/src/ggml.c
@@ -4518,9 +4518,10 @@ const char * ggml_get_name(const struct ggml_tensor * tensor) {
     return tensor->name;
 }
 
-void ggml_set_name(struct ggml_tensor * tensor, const char * name) {
+struct ggml_tensor * ggml_set_name(struct ggml_tensor * tensor, const char * name) {
     strncpy(tensor->name, name, sizeof(tensor->name));
     tensor->name[sizeof(tensor->name) - 1] = '\0';
+    return tensor;
 }
 
 struct ggml_tensor * ggml_view_tensor(


### PR DESCRIPTION
this is SO USEFUL for debugging. in order to find any cgraph node, I can wrap it in ggml_set_name and set a conditional breakpoint.

but I can only wrap existing code if this returns its input. otherwise the barrier becomes annoyingly high (have to move a bunch of code around to add name to a tensor)