### PR TITLE
change of address storage of ptr value tensor->data from uint64_t to …

### DIFF
--- a/src/ggml.c
+++ b/src/ggml.c
@@ -15307,9 +15307,9 @@ void ggml_graph_export(const struct ggml_cgraph * cgraph, const char * fname) {
 
                 // store the pointer address
                 {
-                    const uint64_t ptr = (uint64_t) tensor->data;
+                    const uintptr_t ptr = (uintptr_t) tensor->data;
 
-                    fwrite(&ptr, sizeof(uint64_t), 1, fout);
+                    fwrite(&ptr, sizeof(uintptr_t), 1, fout);
                 }
 
                 fwrite(tensor->name, sizeof(char), GGML_MAX_NAME, fout);
@@ -15347,9 +15347,9 @@ void ggml_graph_export(const struct ggml_cgraph * cgraph, const char * fname) {
 
                 // store the pointer address
                 {
-                    const uint64_t ptr = (uint64_t) tensor->data;
+                    const uintptr_t ptr = (uintptr_t) tensor->data;
 
-                    fwrite(&ptr, sizeof(uint64_t), 1, fout);
+                    fwrite(&ptr, sizeof(uintptr_t), 1, fout);
                 }
 
                 fwrite(tensor->name, sizeof(char), GGML_MAX_NAME, fout);


### PR DESCRIPTION
Small change that I hope makes sense, the data value in the struct is of type void* so a cast to ```uintptr_t``` rather than ```uint64_t``` seems more appropriate here and may prove useful in the case of none-64-bit architectures.

Great project! Many thanks