### PR TITLE
Add special tokens for fill-in-the-middle task for starcoder.

### DIFF
--- a/examples/starcoder/main.cpp
+++ b/examples/starcoder/main.cpp
@@ -146,6 +146,10 @@ bool starcoder_model_load(const std::string & fname, starcoder_model & model, gp
                 "<|user|>",
                 "<|assistant|>",
                 "<|end|>",
+                "<fim-prefix>",
+                "<fim-middle>",
+                "<fim-suffix>",
+                "<fim-pad>"
             }) {
             if (vocab.token_to_id.find(token) != vocab.token_to_id.end()) {
                 vocab.add_special_token(token);


### PR DESCRIPTION
Example prompt for testing:
```
<fim-prefix>// This function doubles the number and returns the result.
function double_number(n) {
<fim-suffix>
    return result;
}
<fim-middle>
```