### PR TITLE
Support for convolution row sizes undivisible by 32  in `ggml_conv_2d_sk_p0`

### DIFF
--- a/src/ggml.c
+++ b/src/ggml.c
@@ -13179,8 +13179,7 @@ static void ggml_compute_forward_conv_2d_sk_p0_f16_f32(
     const int nk1 = ne01;
 
     // size of the convolution row - the kernel size unrolled across all channels
-    // round-up so it is more suitable for SIMD
-    const int ew0 = ggml_up32(nk0*nk1*ne02);
+    const int ew0 = nk0*nk1*ne02;
 
     GGML_ASSERT(nb00 == sizeof(ggml_fp16_t));
     GGML_ASSERT(nb10 == sizeof(float));


### PR DESCRIPTION
Rounding up the size of the convolution row in `ggml_compute_forward_conv_2d_sk_p0_f16_f32` yields NaN values with `kernel_size = 14`, which is first reported for large CLIP models in monatis/clip.cpp#9.
I debugged it in monatis/clip.cpp#11 and found out that the first NaN value comes into being when the size of the convolution row is rounded up to the multiples of 32, and then it propogates through all the calculations, leading to a all-NaN tensor.

https://github.com/ggerganov/ggml/blob/0a63fc0f6cb1915d1fa5c62c8f0f018d072253c9/src/ggml.c#L13181-L13184

With kernel sizes 32 and 16, this is not an issue because `ew0 % 32 = 0` in these cases. However, it's 608 (rounded up from 588) with kernel size 14, and a NaN value comes into being in the index 598 of `x` passed as an argument to `ggml_vec_dot_f16`. I couldn't discover the exact mechanism behind it, but disabling rounding up as in this PR eliminated the NaN issue in expense for multiplications of the leftover being done elementwise in `ggml_vec_dot_f16`.

So I'm not sure that this is the most elegant solution, but I wanted to bring this into the attention with a working solution.