### PR TITLE
build : fix compilation errors and warnigns when building with MSVC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,12 @@
 build/
 build-debug/
 build-*/
+out/
 
 compile_commands.json
+CMakeSettings.json
+.vs/
+.vscode/
 
 .exrc
 .cache

--- a/examples/common.cpp
+++ b/examples/common.cpp
@@ -17,6 +17,10 @@
 #define M_PI 3.14159265358979323846
 #endif
 
+#if defined(_MSC_VER)
+#pragma warning(disable: 4244 4267) // possible loss of data
+#endif
+
 bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
     for (int i = 1; i < argc; i++) {
         std::string arg = argv[i];
@@ -366,7 +370,7 @@ void test_gpt_tokenizer(gpt_vocab & vocab, const std::string & fpath_test){
         }
     }
 
-    fprintf(stderr, "%s : %lu tests failed out of %lu tests.\n", __func__, n_fails, tests.size());
+    fprintf(stderr, "%s : %zu tests failed out of %zu tests.\n", __func__, n_fails, tests.size());
 }
 
 bool gpt_vocab_init(const std::string & fname, gpt_vocab & vocab) {

--- a/examples/dolly-v2/main.cpp
+++ b/examples/dolly-v2/main.cpp
@@ -13,6 +13,10 @@
 #include <string>
 #include <vector>
 
+#if defined(_MSC_VER)
+#pragma warning(disable: 4244 4267) // possible loss of data
+#endif
+
 // default hparams (Dolly-V2 3B)
 struct dollyv2_hparams {
     int32_t n_vocab = 50254; // tokenizer.vocab_size

--- a/examples/gpt-2/main.cpp
+++ b/examples/gpt-2/main.cpp
@@ -12,6 +12,10 @@
 #include <string>
 #include <vector>
 
+#if defined(_MSC_VER)
+#pragma warning(disable: 4244 4267) // possible loss of data
+#endif
+
 // default hparams (GPT-2 117M)
 struct gpt2_hparams {
     int32_t n_vocab = 50257;

--- a/examples/gpt-j/main.cpp
+++ b/examples/gpt-j/main.cpp
@@ -12,6 +12,11 @@
 #include <string>
 #include <vector>
 
+#if defined(_MSC_VER)
+#pragma warning(disable: 4244 4267) // possible loss of data
+#endif
+
+
 // default hparams (GPT-J 6B)
 struct gptj_hparams {
     int32_t n_vocab = 50400;

--- a/examples/gpt-neox/main.cpp
+++ b/examples/gpt-neox/main.cpp
@@ -13,6 +13,10 @@
 #include <string>
 #include <vector>
 
+#if defined(_MSC_VER)
+#pragma warning(disable: 4244 4267) // possible loss of data
+#endif
+
 // default hparams (StableLM 3B)
 struct gpt_neox_hparams {
     int32_t n_vocab = 50257;

--- a/examples/mnist/main-cpu.cpp
+++ b/examples/mnist/main-cpu.cpp
@@ -20,6 +20,10 @@
 #include <fstream>
 #include <vector>
 
+#if defined(_MSC_VER)
+#pragma warning(disable: 4244 4267) // possible loss of data
+#endif
+
 // evaluate the MNIST compute graph
 //
 //   - fname_cgraph: path to the compute graph

--- a/examples/mnist/main.cpp
+++ b/examples/mnist/main.cpp
@@ -11,6 +11,10 @@
 #include <vector>
 #include <algorithm>
 
+#if defined(_MSC_VER)
+#pragma warning(disable: 4244 4267) // possible loss of data
+#endif
+
 // default hparams
 struct mnist_hparams {
     int32_t n_input   = 784;

--- a/examples/mpt/main.cpp
+++ b/examples/mpt/main.cpp
@@ -14,6 +14,10 @@
 #include <utility>
 #include <vector>
 
+#if defined(_MSC_VER)
+#pragma warning(disable: 4244 4267) // possible loss of data
+#endif
+
 // no defaults for now
 struct mpt_hparams {
     int32_t d_model      = 0;
@@ -932,7 +936,7 @@ int main(int argc, char ** argv) {
     printf("%s: number of tokens in prompt = %zu\n", __func__, embd_inp.size());
 
     for (size_t i = 0; i < embd_inp.size(); i++) {
-        printf("%s: token[%lu] = %6d\n", __func__, i, embd_inp[i]);
+        printf("%s: token[%zu] = %6d\n", __func__, i, embd_inp[i]);
     }
     printf("\n");
 

--- a/examples/starcoder/main.cpp
+++ b/examples/starcoder/main.cpp
@@ -12,6 +12,10 @@
 #include <string>
 #include <vector>
 
+#if defined(_MSC_VER)
+#pragma warning(disable: 4244 4267) // possible loss of data
+#endif
+
 // default hparams (GPT-2 117M)
 // https://huggingface.co/bigcode/gpt_bigcode-santacoder/blob/main/config.json
 struct starcoder_hparams {

--- a/examples/whisper/main.cpp
+++ b/examples/whisper/main.cpp
@@ -10,6 +10,10 @@
 #include <vector>
 #include <cstring>
 
+#if defined(_MSC_VER)
+#pragma warning(disable: 4244 4267) // possible loss of data
+#endif
+
 // Terminal color map. 10 colors grouped in ranges [0.0, 0.1, ..., 0.9]
 // Lowest is red, middle is yellow, highest is green.
 const std::vector<std::string> k_colors = {

--- a/examples/whisper/whisper.cpp
+++ b/examples/whisper/whisper.cpp
@@ -19,6 +19,10 @@
 #include <regex>
 #include <random>
 
+#if defined(_MSC_VER)
+#pragma warning(disable: 4244 4267) // possible loss of data
+#endif
+
 #if defined(GGML_BIG_ENDIAN)
 #include <bit>
 

--- a/src/ggml.c
+++ b/src/ggml.c
@@ -1,5 +1,5 @@
-// Defines CLOCK_MONOTONIC on Linux
-#define _GNU_SOURCE
+#define _GNU_SOURCE // Defines CLOCK_MONOTONIC on Linux
+#define _CRT_SECURE_NO_DEPRECATE // Disables ridiculous "unsafe" warnigns on Windows
 
 #include "ggml.h"
 

--- a/tests/test-grad0.c
+++ b/tests/test-grad0.c
@@ -1,9 +1,14 @@
+#define _CRT_SECURE_NO_DEPRECATE // Disables ridiculous "unsafe" warnigns on Windows
 #include "ggml.h"
 
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
+
+#if defined(_MSC_VER)
+#pragma warning(disable: 4244 4267) // possible loss of data
+#endif
 
 #define MAX_NARGS 3
 

--- a/tests/test-mul-mat0.c
+++ b/tests/test-mul-mat0.c
@@ -1,3 +1,4 @@
+#define _CRT_SECURE_NO_DEPRECATE // Disables ridiculous "unsafe" warnigns on Windows
 #include "ggml/ggml.h"
 
 #include <math.h>
@@ -5,6 +6,10 @@
 #include <stdlib.h>
 #include <assert.h>
 #include <inttypes.h>
+
+#if defined(_MSC_VER)
+#pragma warning(disable: 4244 4267) // possible loss of data
+#endif
 
 #define MAX_NARGS 2
 

--- a/tests/test-mul-mat2.c
+++ b/tests/test-mul-mat2.c
@@ -5,13 +5,11 @@
 #include <float.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <inttypes.h>
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
-#include <time.h>
 #include <math.h>
-
-#include <sys/time.h>
 
 #if defined(__ARM_NEON)
 #include "arm_neon.h"
@@ -22,6 +20,12 @@
 #ifndef MIN
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
+#endif
+
+#if defined(_MSC_VER)
+#pragma warning(disable: 4244 4267) // possible loss of data
+#include <intrin.h>
+#define __builtin_popcountll __popcnt64
 #endif
 
 const int M = 1280;
@@ -52,12 +56,6 @@ const int K = 1280;
 
 float frand() {
     return (float) rand() / (float) RAND_MAX;
-}
-
-uint64_t get_time_us() {
-    struct timeval tv;
-    gettimeofday(&tv, NULL);
-    return tv.tv_sec * 1000000 + tv.tv_usec;
 }
 
 #if defined(__AVX2__)
@@ -255,8 +253,8 @@ void mul_mat_gq_1(
                     s1[b + 1] = d1*(1 << b);
                 }
 
-                m0[0] = -1ULL;
-                m1[0] = -1ULL;
+                m0[0] = 0-1ULL;
+                m1[0] = 0-1ULL;
 
                 for (int s = 0; s < QK/gq_t_bits; ++s) {
                     for (int b = 0; b < QB; b++) {
@@ -2373,6 +2371,7 @@ void mul_mat_gq_6(
 
 int main(int argc, const char ** argv) {
     assert(sizeof(gq_quant_t)*8 == gq_t_bits);
+    ggml_time_init();
 
     // needed to initialize f16 tables
     {
@@ -2462,7 +2461,7 @@ int main(int argc, const char ** argv) {
 
     // convert fp32 -> gq
     {
-        const uint64_t t_start = get_time_us();
+        const int64_t t_start = ggml_time_us();
 
         if (method == 1) {
             quantize_1(src0, src0_gq, M, K);
@@ -2494,7 +2493,7 @@ int main(int argc, const char ** argv) {
             quantize_6(src1, src1_gq, N, K);
         }
 
-        const uint64_t t_end = get_time_us();
+        const int64_t t_end = ggml_time_us();
         printf("convert time: %f ms / method = %d\n", (t_end - t_start) / 1000.0, method);
     }
 
@@ -2504,8 +2503,8 @@ int main(int argc, const char ** argv) {
 
     const int nIter = 1;
 
-    const clock_t start = clock();
-    const uint64_t start_us = get_time_us();
+    const int64_t start = ggml_cycles();
+    const int64_t start_us = ggml_time_us();
 
     double iM = 1.0/M;
     double sum = 0.0f;
@@ -2544,9 +2543,9 @@ int main(int argc, const char ** argv) {
     }
 
     {
-        const clock_t end = clock();
-        const uint64_t end_us = get_time_us();
-        printf("%s: elapsed ticks: %ld\n",  __func__, end - start);
+        const int64_t end = ggml_cycles();
+        const int64_t end_us = ggml_time_us();
+        printf("%s: elapsed ticks: %" PRIu64 "\n",  __func__, end - start);
         printf("%s: elapsed us:    %d / %f ms\n",  __func__, (int)(end_us - start_us), (end_us - start_us) / 1000.0 / nIter);
     }
 

--- a/tests/test2.c
+++ b/tests/test2.c
@@ -1,9 +1,14 @@
+#define _CRT_SECURE_NO_DEPRECATE // Disables ridiculous "unsafe" warnigns on Windows
 #include "ggml/ggml.h"
 
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
+
+#if defined(_MSC_VER)
+#pragma warning(disable: 4244 4267) // possible loss of data
+#endif
 
 bool is_close(float a, float b, float epsilon) {
     return fabs(a - b) < epsilon;

--- a/tests/test3.c
+++ b/tests/test3.c
@@ -60,7 +60,7 @@ int main(int argc, const char ** argv) {
                                     l)
                                 )
                             ),
-                        ggml_new_f32(ctx0, NP)
+                        ggml_new_f32(ctx0, (float)NP)
                         ),
                     ggml_mul(ctx0,
                         ggml_sum(ctx0, ggml_sqr(ctx0, x)),


### PR DESCRIPTION
In the spirit of this PR: https://github.com/ggerganov/llama.cpp/pull/1889

This is a cosmetic change. No functionality is changed. Warnings and compilation errors are fixed (and some warnings ignored) leading to a successful build with MSVC on Windows. "possible loss of data" warnings were mostly ignored.

Note that two tests (`test1` and `test2`) fail on Windows after this, but the failures are unrelated and will be addressed in separate issues