### PR TITLE
tests : increase stack size for test1 when building with MSVC

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -223,6 +223,9 @@ add_test(NAME ${TEST_TARGET} COMMAND $<TARGET_FILE:${TEST_TARGET}>)
 set(TEST_TARGET test1)
 add_executable(${TEST_TARGET} ${TEST_TARGET}.c)
 target_link_libraries(${TEST_TARGET} PRIVATE ggml)
+if (MSVC)
+    target_link_options(${TEST_TARGET} PRIVATE "/STACK: 8388608") # 8MB
+endif()
 add_test(NAME ${TEST_TARGET} COMMAND $<TARGET_FILE:${TEST_TARGET}>)
 
 #


### PR DESCRIPTION
The default stack size on Windows with MSVC is 1MB. This is not enough for `test1` and it crashes with a stack overflow. 

This PR increases the stack size for this test to 8 MB (the default on Linux)