### PR TITLE
Add link to CLIP example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Some of the development is currently happening in the [llama.cpp](https://github
 - [X] Example of Replit inference [examples/replit](https://github.com/ggerganov/ggml/tree/master/examples/replit)
 - [X] Example of BioGPT inference [PABannier/biogpt.cpp](https://github.com/PABannier/biogpt.cpp)
 - [X] Example of Encodec inference [PABannier/encodec.cpp](https://github.com/PABannier/encodec.cpp) 
+- [X] Example of CLIP inference [monatis/clip.cpp](https://github.com/monatis/clip.cpp)
 
 ## Whisper inference (example)
 


### PR DESCRIPTION
Simply adding a link to [monatis/clip.cpp](https://github.com/monatis/clip.cpp) in readme.