### PR TITLE
Refs #292: Macro dim access

### DIFF
--- a/include/ggml/ggml.h
+++ b/include/ggml/ggml.h
@@ -368,6 +368,8 @@ extern "C" {
 
     static const size_t GGML_OBJECT_SIZE = sizeof(struct ggml_object);
 
+#define GGML_DIM_ELEMENTS(ptr, index) ((ptr)->ne[(index)])
+
     // n-dimensional tensor
     struct ggml_tensor {
         enum ggml_type    type;

--- a/src/ggml-cuda.cu
+++ b/src/ggml-cuda.cu
@@ -1643,7 +1643,7 @@ static cudaError_t ggml_cuda_cpy_tensor_2d(
     }
     char * dst_ptr = (char *) dst;
 
-    const int64_t ne0 = src->ne[0];
+    const int64_t ne0 = GGML_DIM_ELEMENTS(src, 0);
     const int64_t nb0 = src->nb[0];
     const int64_t nb1 = src->nb[1];
     const int64_t nb2 = src->nb[2];
@@ -1679,7 +1679,7 @@ inline void ggml_cuda_op_add(
     GGML_ASSERT(src1_ddf_i != nullptr);
     GGML_ASSERT(dst_ddf_i != nullptr);
 
-    const int64_t ne0 = src0->ne[0];
+    const int64_t ne0 = GGML_DIM_ELEMENTS(src0, 0);
     const int64_t i01_diff = i01_high - i01_low;
 
     // compute
@@ -1702,10 +1702,10 @@ inline void ggml_cuda_op_mul(
     GGML_ASSERT(src1_ddf_i != nullptr);
     GGML_ASSERT(dst_ddf_i != nullptr);
 
-    const int64_t ne00 = src0->ne[0];
+    const int64_t ne00 = GGML_DIM_ELEMENTS(src0, 0);
 
-    const int64_t ne10 = src1->ne[0];
-    const int64_t ne11 = src1->ne[1];
+    const int64_t ne10 = GGML_DIM_ELEMENTS(src1, 0);
+    const int64_t ne11 = GGML_DIM_ELEMENTS(src1, 1);
 
     for (int64_t i01 = i01_low; i01 < i01_high; i01++) {
         const int64_t i11 = i1*ne11 + i01%ne11; // broadcast src1 across src0
@@ -1732,7 +1732,7 @@ inline void ggml_cuda_op_silu(
     GGML_ASSERT(src0_ddf_i != nullptr);
     GGML_ASSERT(dst_ddf_i != nullptr);
 
-    const int64_t ne00 = src0->ne[0];
+    const int64_t ne00 = GGML_DIM_ELEMENTS(src0, 0);
     const int64_t i01_diff = i01_high - i01_low;
 
     // compute
@@ -1755,7 +1755,7 @@ inline void ggml_cuda_op_rms_norm(
     GGML_ASSERT(src0_ddf_i != nullptr);
     GGML_ASSERT(dst_ddf_i != nullptr);
 
-    const int64_t ne00 = src0->ne[0];
+    const int64_t ne00 = GGML_DIM_ELEMENTS(src0, 0);
     const int64_t i01_diff = i01_high - i01_low;
 
     // compute
@@ -1779,7 +1779,7 @@ inline void ggml_cuda_op_dequantize_mul_mat_vec(
     GGML_ASSERT(src1_ddf_i != nullptr);
     GGML_ASSERT(dst_ddf_i != nullptr);
 
-    const int64_t ne00 = src0->ne[0];
+    const int64_t ne00 = GGML_DIM_ELEMENTS(src0, 0);
     const int64_t nrows = i01_high - i01_low;
 
 // on some GPUs it is faster to convert src1 to half and to use half precision intrinsics
@@ -1866,12 +1866,12 @@ inline void ggml_cuda_op_mul_mat_cublas(
     const float alpha = 1.0f;
     const float beta = 0.0f;
 
-    const int64_t ne00 = src0->ne[0];
+    const int64_t ne00 = GGML_DIM_ELEMENTS(src0, 0);
 
-    const int64_t ne10 = src1->ne[0];
-    const int64_t ne11 = src1->ne[1];
+    const int64_t ne10 = GGML_DIM_ELEMENTS(src1, 0);
+    const int64_t ne11 = GGML_DIM_ELEMENTS(src1, 1);
 
-    const int64_t ne0 = dst->ne[0];
+    const int64_t ne0 = GGML_DIM_ELEMENTS(dst, 0);
     const int64_t i01_diff = i01_high - i01_low;
 
     int id;
@@ -1903,7 +1903,7 @@ inline void ggml_cuda_op_rope(
     GGML_ASSERT(src0_ddf_i != nullptr);
     GGML_ASSERT(dst_ddf_i != nullptr);
 
-    const int64_t ne00 = src0->ne[0];
+    const int64_t ne00 = GGML_DIM_ELEMENTS(src0, 0);
     const int64_t i01_diff = i01_high - i01_low;
 
     const int n_past = ((int32_t *) src1->data)[0];
@@ -1932,8 +1932,8 @@ inline void ggml_cuda_op_diag_mask_inf(
     GGML_ASSERT(src0_ddf_i != nullptr);
     GGML_ASSERT(dst_ddf_i != nullptr);
 
-    const int64_t ne00 = src0->ne[0];
-    const int64_t ne01 = src0->ne[1];
+    const int64_t ne00 = GGML_DIM_ELEMENTS(src0, 0);
+    const int64_t ne01 = GGML_DIM_ELEMENTS(src0, 1);
     const int64_t i01_diff = i01_high - i01_low;
 
     const int n_past = ((int32_t *) src1->data)[0];
@@ -1957,7 +1957,7 @@ inline void ggml_cuda_op_soft_max(
     GGML_ASSERT(src0_ddf_i != nullptr);
     GGML_ASSERT(dst_ddf_i != nullptr);
 
-    const int64_t ne00 = src0->ne[0];
+    const int64_t ne00 = GGML_DIM_ELEMENTS(src0, 0);
     const int64_t i01_diff = i01_high - i01_low;
 
     // compute
@@ -1982,7 +1982,7 @@ inline void ggml_cuda_op_scale(
 
     const float scale = ((float *) src1->data)[0];
 
-    const int64_t ne00 = src0->ne[0];
+    const int64_t ne00 = GGML_DIM_ELEMENTS(src0, 0);
     const int64_t i01_diff = i01_high - i01_low;
 
     // compute
@@ -1999,20 +1999,20 @@ inline void ggml_cuda_op_scale(
 
 static void ggml_cuda_op(const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst,
                          ggml_cuda_op_t op, bool src0_needs_f32, bool flatten_rows) {
-    const int64_t ne00 = src0->ne[0];
-    const int64_t ne01 = src0->ne[1];
-    const int64_t ne02 = src0->ne[2];
-    const int64_t ne03 = src0->ne[3];
+    const int64_t ne00 = GGML_DIM_ELEMENTS(src0, 0);
+    const int64_t ne01 = GGML_DIM_ELEMENTS(src0, 1);
+    const int64_t ne02 = GGML_DIM_ELEMENTS(src0, 2);
+    const int64_t ne03 = GGML_DIM_ELEMENTS(src0, 3);
     const int64_t nrows0 = ggml_nrows(src0);
 
     const bool use_src1 = src1 != nullptr;
-    const int64_t ne10 = use_src1 ? src1->ne[0] : 1;
-    const int64_t ne11 = use_src1 ? src1->ne[1] : 1;
-    const int64_t ne12 = use_src1 ? src1->ne[2] : 1;
-    const int64_t ne13 = use_src1 ? src1->ne[3] : 1;
+    const int64_t ne10 = use_src1 ? GGML_DIM_ELEMENTS(src1, 0) : 1;
+    const int64_t ne11 = use_src1 ? GGML_DIM_ELEMENTS(src1, 1) : 1;
+    const int64_t ne12 = use_src1 ? GGML_DIM_ELEMENTS(src1, 2) : 1;
+    const int64_t ne13 = use_src1 ? GGML_DIM_ELEMENTS(src1, 3) : 1;
 
-    const int64_t ne0 = dst->ne[0];
-    const int64_t ne1 = dst->ne[1];
+    const int64_t ne0 = GGML_DIM_ELEMENTS(dst, 0);
+    const int64_t ne1 = GGML_DIM_ELEMENTS(dst, 1);
 
     const int nb2  = dst->nb[2];
     const int nb3  = dst->nb[3];
@@ -2301,10 +2301,10 @@ void ggml_cuda_rms_norm(const ggml_tensor * src0, const ggml_tensor * src1, ggml
 }
 
 bool ggml_cuda_can_mul_mat(const struct ggml_tensor * src0, const struct ggml_tensor * src1, struct ggml_tensor * dst) {
-    const int64_t ne10 = src1->ne[0];
+    const int64_t ne10 = GGML_DIM_ELEMENTS(src1, 0);
 
-    const int64_t ne0 = dst->ne[0];
-    const int64_t ne1 = dst->ne[1];
+    const int64_t ne0 = GGML_DIM_ELEMENTS(dst, 0);
+    const int64_t ne1 = GGML_DIM_ELEMENTS(dst, 1);
 
     // TODO: find the optimal values for these
     if ((src0->type == GGML_TYPE_F32 || src0->type == GGML_TYPE_F16 || ggml_is_quantized(src0->type)) &&
@@ -2325,9 +2325,9 @@ void ggml_cuda_mul_mat_vec_p021(const ggml_tensor * src0, const ggml_tensor * sr
     GGML_ASSERT(src0->type == GGML_TYPE_F16);
     GGML_ASSERT(src1->type == GGML_TYPE_F32);
 
-    const int64_t ne00 = src0->ne[0];
-    const int64_t ne01 = src0->ne[1];
-    const int64_t ne02 = src0->ne[2];
+    const int64_t ne00 = GGML_DIM_ELEMENTS(src0, 0);
+    const int64_t ne01 = GGML_DIM_ELEMENTS(src0, 1);
+    const int64_t ne02 = GGML_DIM_ELEMENTS(src0, 2);
 
     CUDA_CHECK(cudaSetDevice(g_main_device));
     cudaStream_t cudaStream_main = g_cudaStreams_main[g_main_device];
@@ -2351,9 +2351,9 @@ void ggml_cuda_mul_mat_vec_nc(const ggml_tensor * src0, const ggml_tensor * src1
     GGML_ASSERT(src0->type == GGML_TYPE_F16);
     GGML_ASSERT(src1->type == GGML_TYPE_F32);
 
-    const int64_t ne00 = src0->ne[0];
-    const int64_t ne01 = src0->ne[1];
-    const int64_t ne02 = src0->ne[2];
+    const int64_t ne00 = GGML_DIM_ELEMENTS(src0, 0);
+    const int64_t ne01 = GGML_DIM_ELEMENTS(src0, 1);
+    const int64_t ne02 = GGML_DIM_ELEMENTS(src0, 2);
 
     const int64_t nb01 = src0->nb[1];
     const int64_t nb02 = src0->nb[2];
@@ -2380,14 +2380,14 @@ void ggml_cuda_mul_mat(const ggml_tensor * src0, const ggml_tensor * src1, ggml_
     bool all_on_device = (src0->backend == GGML_BACKEND_GPU || src0->backend == GGML_BACKEND_GPU_SPLIT) &&
         src1->backend == GGML_BACKEND_GPU && dst->backend == GGML_BACKEND_GPU;
 
-    if (all_on_device && ggml_is_permuted(src0) && ggml_is_permuted(src1) && src1->ne[1] == 1) {
+    if (all_on_device && ggml_is_permuted(src0) && ggml_is_permuted(src1) && GGML_DIM_ELEMENTS(src1, 1) == 1) {
         ggml_cuda_mul_mat_vec_p021(src0, src1, dst);
-    } else if (all_on_device && !ggml_is_contiguous(src0) && ggml_is_contiguous(src1) && src1->ne[1] == 1) {
+    } else if (all_on_device && !ggml_is_contiguous(src0) && ggml_is_contiguous(src1) && GGML_DIM_ELEMENTS(src1, 1) == 1) {
         ggml_cuda_mul_mat_vec_nc(src0, src1, dst);
     }else if (src0->type == GGML_TYPE_F32) {
         ggml_cuda_op(src0, src1, dst, ggml_cuda_op_mul_mat_cublas, true, false);
     } else if (ggml_is_quantized(src0->type) || src0->type == GGML_TYPE_F16) {
-        if (src1->ne[1] == 1 && src0->ne[0] % GGML_CUDA_DMMV_X == 0 && src0->ne[1] % GGML_CUDA_DMMV_Y == 0) {
+        if (GGML_DIM_ELEMENTS(src1, 1) == 1 && GGML_DIM_ELEMENTS(src0, 0) % GGML_CUDA_DMMV_X == 0 && GGML_DIM_ELEMENTS(src0, 1) % GGML_CUDA_DMMV_Y == 0) {
             ggml_cuda_op(src0, src1, dst, ggml_cuda_op_dequantize_mul_mat_vec, false, false);
         } else {
             ggml_cuda_op(src0, src1, dst, ggml_cuda_op_mul_mat_cublas, true, false);
@@ -2412,17 +2412,17 @@ void ggml_cuda_cpy(const ggml_tensor * src0, const ggml_tensor * src1, ggml_tens
     GGML_ASSERT(ggml_nbytes(src0) <= INT_MAX);
     GGML_ASSERT(ggml_nbytes(src1) <= INT_MAX);
 
-    const int64_t ne00 = src0->ne[0];
-    const int64_t ne01 = src0->ne[1];
-    GGML_ASSERT(src0->ne[3] == 1);
+    const int64_t ne00 = GGML_DIM_ELEMENTS(src0, 0);
+    const int64_t ne01 = GGML_DIM_ELEMENTS(src0, 1);
+    GGML_ASSERT(GGML_DIM_ELEMENTS(src0, 3) == 1);
 
     const int64_t nb00 = src0->nb[0];
     const int64_t nb01 = src0->nb[1];
     const int64_t nb02 = src0->nb[2];
 
-    const int64_t ne10 = src1->ne[0];
-    const int64_t ne11 = src1->ne[1];
-    GGML_ASSERT(src1->ne[3] == 1);
+    const int64_t ne10 = GGML_DIM_ELEMENTS(src1, 0);
+    const int64_t ne11 = GGML_DIM_ELEMENTS(src1, 1);
+    GGML_ASSERT(GGML_DIM_ELEMENTS(src1, 3) == 1);
 
     const int64_t nb10 = src1->nb[0];
     const int64_t nb11 = src1->nb[1];

--- a/src/ggml-metal.m
+++ b/src/ggml-metal.m
@@ -382,30 +382,30 @@ void ggml_metal_graph_compute(
                 struct ggml_tensor * src1 = gf->nodes[i]->src1;
                 struct ggml_tensor * dst  = gf->nodes[i];
 
-                const int64_t  ne00 = src0 ? src0->ne[0] : 0;
-                const int64_t  ne01 = src0 ? src0->ne[1] : 0;
-                const int64_t  ne02 = src0 ? src0->ne[2] : 0;
-                const int64_t  ne03 = src0 ? src0->ne[3] : 0;
+                const int64_t  ne00 = src0 ? GGML_DIM_ELEMENTS(src0, 0) : 0;
+                const int64_t  ne01 = src0 ? GGML_DIM_ELEMENTS(src0, 1) : 0;
+                const int64_t  ne02 = src0 ? GGML_DIM_ELEMENTS(src0, 2) : 0;
+                const int64_t  ne03 = src0 ? GGML_DIM_ELEMENTS(src0, 3) : 0;
 
                 const uint64_t nb00 = src0 ? src0->nb[0] : 0;
                 const uint64_t nb01 = src0 ? src0->nb[1] : 0;
                 const uint64_t nb02 = src0 ? src0->nb[2] : 0;
                 const uint64_t nb03 = src0 ? src0->nb[3] : 0;
 
-                const int64_t  ne10 = src1 ? src1->ne[0] : 0;
-                const int64_t  ne11 = src1 ? src1->ne[1] : 0;
-                const int64_t  ne12 = src1 ? src1->ne[2] : 0;
-                const int64_t  ne13 = src1 ? src1->ne[3] : 0; UNUSED(ne13);
+                const int64_t  ne10 = src1 ? GGML_DIM_ELEMENTS(src1, 0) : 0;
+                const int64_t  ne11 = src1 ? GGML_DIM_ELEMENTS(src1, 1) : 0;
+                const int64_t  ne12 = src1 ? GGML_DIM_ELEMENTS(src1, 2) : 0;
+                const int64_t  ne13 = src1 ? GGML_DIM_ELEMENTS(src1, 3) : 0; UNUSED(ne13);
 
                 const uint64_t nb10 = src1 ? src1->nb[0] : 0;
                 const uint64_t nb11 = src1 ? src1->nb[1] : 0;
                 const uint64_t nb12 = src1 ? src1->nb[2] : 0;
                 const uint64_t nb13 = src1 ? src1->nb[3] : 0; UNUSED(nb13);
 
-                const int64_t  ne0  = dst ? dst->ne[0] : 0;
-                const int64_t  ne1  = dst ? dst->ne[1] : 0;
-                const int64_t  ne2  = dst ? dst->ne[2] : 0;
-                const int64_t  ne3  = dst ? dst->ne[3] : 0;
+                const int64_t  ne0  = dst ? GGML_DIM_ELEMENTS(dst, 0) : 0;
+                const int64_t  ne1  = dst ? GGML_DIM_ELEMENTS(dst, 1) : 0;
+                const int64_t  ne2  = dst ? GGML_DIM_ELEMENTS(dst, 2) : 0;
+                const int64_t  ne3  = dst ? GGML_DIM_ELEMENTS(dst, 3) : 0;
 
                 const uint64_t nb0  = dst ? dst->nb[0] : 0;
                 const uint64_t nb1  = dst ? dst->nb[1] : 0;
@@ -761,7 +761,7 @@ void ggml_metal_graph_compute(
                             [encoder setBuffer:id_src0 offset:offs_src0 atIndex:0];
                             [encoder setBuffer:id_src1 offset:offs_src1 atIndex:1];
                             [encoder setBuffer:id_dst  offset:offs_dst  atIndex:2];
-                            [encoder setBytes:&(src0->ne[0]) length:sizeof( int64_t) atIndex:3];
+                            [encoder setBytes:&(GGML_DIM_ELEMENTS(src0, 0)) length:sizeof( int64_t) atIndex:3];
                             [encoder setBytes:&(src0->nb[1]) length:sizeof(uint64_t) atIndex:4];
                             [encoder setBytes:&(dst->nb[1])  length:sizeof(uint64_t) atIndex:5];
 

--- a/src/ggml-opencl.cpp
+++ b/src/ggml-opencl.cpp
@@ -1159,8 +1159,8 @@ void ggml_cl_free_data(const struct ggml_tensor* tensor) {
 
 static cl_int ggml_cl_h2d_tensor_2d(cl_command_queue queue, cl_mem dst, size_t offset, const struct ggml_tensor * src, uint64_t i3, uint64_t i2, cl_event* ev) {
     cl_int err;
-    const uint64_t ne0 = src->ne[0];
-    const uint64_t ne1 = src->ne[1];
+    const uint64_t ne0 = GGML_DIM_ELEMENTS(src, 0);
+    const uint64_t ne1 = GGML_DIM_ELEMENTS(src, 1);
     const uint64_t nb0 = src->nb[0];
     const uint64_t nb1 = src->nb[1];
     const uint64_t nb2 = src->nb[2];
@@ -1196,15 +1196,15 @@ static cl_int ggml_cl_h2d_tensor_2d(cl_command_queue queue, cl_mem dst, size_t o
 
 static void ggml_cl_mul_f32(const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
     GGML_ASSERT(src1->backend == GGML_BACKEND_GPU);
-    const int64_t ne00 = src0->ne[0];
-    const int64_t ne01 = src0->ne[1];
-    const int64_t ne02 = src0->ne[2];
-    const int64_t ne03 = src0->ne[2];
+    const int64_t ne00 = GGML_DIM_ELEMENTS(src0, 0);
+    const int64_t ne01 = GGML_DIM_ELEMENTS(src0, 1);
+    const int64_t ne02 = GGML_DIM_ELEMENTS(src0, 2);
+    const int64_t ne03 = GGML_DIM_ELEMENTS(src0, 2);
     const int64_t ne0 = ne00 * ne01 * ne02 * ne03;
-    const int64_t ne10 = src1->ne[0];
-    const int64_t ne11 = src1->ne[1];
-    const int64_t ne12 = src1->ne[2];
-    const int64_t ne13 = src1->ne[3];
+    const int64_t ne10 = GGML_DIM_ELEMENTS(src1, 0);
+    const int64_t ne11 = GGML_DIM_ELEMENTS(src1, 1);
+    const int64_t ne12 = GGML_DIM_ELEMENTS(src1, 2);
+    const int64_t ne13 = GGML_DIM_ELEMENTS(src1, 3);
     const int64_t nb10 = src1->nb[0];
     const int nb2  = dst->nb[2];
     const int nb3  = dst->nb[3];
@@ -1288,13 +1288,13 @@ void ggml_cl_mul(const struct ggml_tensor * src0, const struct ggml_tensor * src
 }
 
 static void ggml_cl_mul_mat_f32(const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
-    const int64_t ne00 = src0->ne[0];
-    const int64_t ne01 = src0->ne[1];
-    const int64_t ne02 = src0->ne[2];
-    const int64_t ne03 = src0->ne[3];
+    const int64_t ne00 = GGML_DIM_ELEMENTS(src0, 0);
+    const int64_t ne01 = GGML_DIM_ELEMENTS(src0, 1);
+    const int64_t ne02 = GGML_DIM_ELEMENTS(src0, 2);
+    const int64_t ne03 = GGML_DIM_ELEMENTS(src0, 3);
 
-    const int64_t ne10 = src1->ne[0];
-    const int64_t ne11 = src1->ne[1];
+    const int64_t ne10 = GGML_DIM_ELEMENTS(src1, 0);
+    const int64_t ne11 = GGML_DIM_ELEMENTS(src1, 1);
 
     const int nb2  = dst->nb[2];
     const int nb3  = dst->nb[3];
@@ -1359,13 +1359,13 @@ static void ggml_cl_mul_mat_f32(const ggml_tensor * src0, const ggml_tensor * sr
 static void ggml_cl_mul_mat_f16(const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst, void * wdata, size_t /* wsize */) {
     GGML_ASSERT(fp16_support);
 
-    const int64_t ne00 = src0->ne[0];
-    const int64_t ne01 = src0->ne[1];
-    const int64_t ne02 = src0->ne[2];
-    const int64_t ne03 = src0->ne[3];
+    const int64_t ne00 = GGML_DIM_ELEMENTS(src0, 0);
+    const int64_t ne01 = GGML_DIM_ELEMENTS(src0, 1);
+    const int64_t ne02 = GGML_DIM_ELEMENTS(src0, 2);
+    const int64_t ne03 = GGML_DIM_ELEMENTS(src0, 3);
 
-    const int64_t ne10 = src1->ne[0];
-    const int64_t ne11 = src1->ne[1];
+    const int64_t ne10 = GGML_DIM_ELEMENTS(src1, 0);
+    const int64_t ne11 = GGML_DIM_ELEMENTS(src1, 1);
 
     const int nb10 = src1->nb[0];
     const int nb11 = src1->nb[1];
@@ -1464,13 +1464,13 @@ static void ggml_cl_mul_mat_f16(const ggml_tensor * src0, const ggml_tensor * sr
 }
 
 static void ggml_cl_mul_mat_q_f32(const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
-    const int64_t ne00 = src0->ne[0];
-    const int64_t ne01 = src0->ne[1];
-    const int64_t ne02 = src0->ne[2];
-    const int64_t ne03 = src0->ne[3];
+    const int64_t ne00 = GGML_DIM_ELEMENTS(src0, 0);
+    const int64_t ne01 = GGML_DIM_ELEMENTS(src0, 1);
+    const int64_t ne02 = GGML_DIM_ELEMENTS(src0, 2);
+    const int64_t ne03 = GGML_DIM_ELEMENTS(src0, 3);
 
-    const int64_t ne10 = src1->ne[0];
-    const int64_t ne11 = src1->ne[1];
+    const int64_t ne10 = GGML_DIM_ELEMENTS(src1, 0);
+    const int64_t ne11 = GGML_DIM_ELEMENTS(src1, 1);
 
     const int nb2  = dst->nb[2];
     const int nb3  = dst->nb[3];
@@ -1591,10 +1591,10 @@ static void ggml_cl_mul_mat_q_f32(const ggml_tensor * src0, const ggml_tensor * 
 
 
 bool ggml_cl_can_mul_mat(const struct ggml_tensor * src0, const struct ggml_tensor * src1, struct ggml_tensor * dst) {
-    const int64_t ne10 = src1->ne[0];
+    const int64_t ne10 = GGML_DIM_ELEMENTS(src1, 0);
 
-    const int64_t ne0 = dst->ne[0];
-    const int64_t ne1 = dst->ne[1];
+    const int64_t ne0 = GGML_DIM_ELEMENTS(dst, 0);
+    const int64_t ne1 = GGML_DIM_ELEMENTS(dst, 1);
 
     // TODO: find the optimal values for these
     if ((src0->type == GGML_TYPE_F32 || src0->type == GGML_TYPE_F16 || ggml_is_quantized(src0->type)) &&
@@ -1657,10 +1657,10 @@ size_t ggml_cl_mul_mat_get_wsize(const struct ggml_tensor * src0, const struct g
 }
 
 void ggml_cl_transform_tensor(void * data, ggml_tensor * tensor) {
-    const int64_t ne0 = tensor->ne[0];
-    const int64_t ne1 = tensor->ne[1];
-    const int64_t ne2 = tensor->ne[2];
-    const int64_t ne3 = tensor->ne[3];
+    const int64_t ne0 = GGML_DIM_ELEMENTS(tensor, 0);
+    const int64_t ne1 = GGML_DIM_ELEMENTS(tensor, 1);
+    const int64_t ne2 = GGML_DIM_ELEMENTS(tensor, 2);
+    const int64_t ne3 = GGML_DIM_ELEMENTS(tensor, 3);
 
     const ggml_type type = tensor->type;
     const size_t q_sz = ggml_type_size(type) * ne0 * ne1 * ne2 * ne3 / ggml_blck_size(type);

--- a/src/ggml.c
+++ b/src/ggml.c
@@ -4403,13 +4403,13 @@ struct ggml_tensor * ggml_new_tensor_impl(
     //ggml_assert_aligned(result->data);
 
     for (int i = 0; i < n_dims; i++) {
-        result->ne[i] = ne[i];
+        GGML_DIM_ELEMENTS(result, i) = ne[i];
     }
 
     result->nb[0] = GGML_TYPE_SIZE[type];
     result->nb[1] = result->nb[0]*(GGML_DIM_ELEMENTS(result, 0)/GGML_BLCK_SIZE[type]);
     for (int i = 2; i < GGML_MAX_DIMS; i++) {
-        result->nb[i] = result->nb[i - 1]*result->ne[i - 1];
+        result->nb[i] = result->nb[i - 1]*GGML_DIM_ELEMENTS(result, i - 1);
     }
 
     ctx->n_objects++;
@@ -5246,7 +5246,7 @@ struct ggml_tensor * ggml_sum_rows(
 
     int64_t ne[4] = {1,1,1,1};
     for (int i=1; i<a->n_dims; ++i) {
-        ne[i] = a->ne[i];
+        ne[i] = GGML_DIM_ELEMENTS(a, i);
     }
 
     struct ggml_tensor * result = ggml_new_tensor(ctx, a->type, a->n_dims, ne);

--- a/src/ggml.c
+++ b/src/ggml.c
@@ -17296,7 +17296,7 @@ void ggml_graph_export(const struct ggml_cgraph * cgraph, const char * fname) {
                 fwrite(&n_dims, sizeof(uint32_t), 1, fout);
 
                 for (int j = 0; j < GGML_MAX_DIMS; ++j) {
-                    const uint64_t ne = tensor->ne[j];
+                    const uint64_t ne = GGML_DIM_ELEMENTS(tensor, j);
                     const uint64_t nb = tensor->nb[j];
 
                     fwrite(&ne, sizeof(uint64_t), 1, fout);
@@ -17336,7 +17336,7 @@ void ggml_graph_export(const struct ggml_cgraph * cgraph, const char * fname) {
                 fwrite(&n_dims, sizeof(uint32_t), 1, fout);
 
                 for (int j = 0; j < GGML_MAX_DIMS; ++j) {
-                    const uint64_t ne = tensor->ne[j];
+                    const uint64_t ne = GGML_DIM_ELEMENTS(tensor, j);
                     const uint64_t nb = tensor->nb[j];
 
                     fwrite(&ne, sizeof(uint64_t), 1, fout);


### PR DESCRIPTION
Introduce a new macro : `GGML_DIM_ELEMENTS(tensor, i)`  that can be used to access `tensor->ne[i]`