### PR TITLE
Starcoder repeat penalty

### DIFF
--- a/examples/common.cpp
+++ b/examples/common.cpp
@@ -39,6 +39,10 @@ bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
             params.top_p = std::stof(argv[++i]);
         } else if (arg == "--temp") {
             params.temp = std::stof(argv[++i]);
+        } else if (arg == "--repeat-last-n") {
+            params.repeat_last_n = std::stof(argv[++i]);
+        } else if (arg == "--repeat-penalty") {
+            params.repeat_penalty = std::stof(argv[++i]);            
         } else if (arg == "-b" || arg == "--batch_size") {
             params.n_batch = std::stoi(argv[++i]);
         } else if (arg == "-m" || arg == "--model") {
@@ -90,6 +94,8 @@ void gpt_print_usage(int /*argc*/, char ** argv, const gpt_params & params) {
     fprintf(stderr, "  --top_k N             top-k sampling (default: %d)\n", params.top_k);
     fprintf(stderr, "  --top_p N             top-p sampling (default: %.1f)\n", params.top_p);
     fprintf(stderr, "  --temp N              temperature (default: %.1f)\n", params.temp);
+    fprintf(stderr, "  --repeat-last-n N     last n tokens to consider for penalize (default: %d, 0 = disabled)\n", params.repeat_last_n);
+    fprintf(stderr, "  --repeat-penalty N    penalize repeat sequence of tokens (default: %.2f, 1.0 = disabled)\n", (double)params.repeat_penalty);    
     fprintf(stderr, "  -b N, --batch_size N  batch size for prompt processing (default: %d)\n", params.n_batch);
     fprintf(stderr, "  -m FNAME, --model FNAME\n");
     fprintf(stderr, "                        model path (default: %s)\n", params.model.c_str());

--- a/examples/common.h
+++ b/examples/common.h
@@ -23,6 +23,8 @@ struct gpt_params {
     int32_t top_k = 40;
     float   top_p = 0.9f;
     float   temp  = 0.9f;
+    int32_t repeat_last_n  = 64;
+    float   repeat_penalty = 1.00f;
 
     int32_t n_batch = 8; // batch size for prompt processing
 

--- a/examples/starcoder/main.cpp
+++ b/examples/starcoder/main.cpp
@@ -785,7 +785,13 @@ int main(int argc, char ** argv) {
     if (params.repeat_last_n == -1) {
         params.repeat_last_n = model.hparams.n_ctx;
     }
-
+    printf("\n");
+    printf("%s: temp           = %.3f\n", __func__, params.temp);
+    printf("%s: top_k          = %d\n",   __func__, params.top_k);
+    printf("%s: top_p          = %.3f\n", __func__, params.top_p);
+    printf("%s: repeat_last_n  = %d\n",   __func__, params.repeat_last_n);
+    printf("%s: repeat_penalty = %.3f\n", __func__, params.repeat_penalty);
+    
     int n_past = 0;
 
     int64_t t_sample_us  = 0;


### PR DESCRIPTION
The santacoder model doesn't do well without `repeat-penalty`, failing to emit EOS for many basic prompts. For example:

```
main: prompt: 'def fib('
main: number of tokens in prompt = 3
main: token[0] =    563, def
main: token[1] =  24240,  fib
main: token[2] =      7, (


def fib(n):
    if n == 0:
        return 0
    elif n == 1:
        return 1
    else:
        return fib(n-1) + fib(n-2)

def fib_iter(n):
    a, b = 0, 1
    for i in range(n):
        a, b = b, a + b
    return a

def fib_iter_2(n):
    a, b = 0, 1
    for i in range(n):
        a, b = b, a + b
    return a

def fib_iter_3(n):
    a, b = 0, 1
    for i in range(n):
        a, b = b, a + b
    return a

def fib_iter_4(n):
    a, b = 0, 1
    for i in range(n):
        a, b =
```

This change heavily borrows from examples/mpt/main.cpp to use `gpt_sample_top_k_top_p_repeat` and connect the necessary parameters.  In an effort to not affect other examples using the same code, I have left the default repeat penalty at 1.0 so it wont be enabled by surprise.

Applying a `--repeat-penalty 1.176` to the example above yields:

```
main: temp           = 0.900
main: top_k          = 1
main: top_p          = 0.900
main: repeat_last_n  = 64
main: repeat_penalty = 1.176
main: prompt: 'def fib('
main: number of tokens in prompt = 3
main: token[0] =    563, def
main: token[1] =  24240,  fib
main: token[2] =      7, (


def fib(n):
    if n == 0:
        return 1

    elif n == 1 or n == 2:
        return 1

    else:
        return fib(n - 1) + fib(n - 2)


print("fibonacci series:")
for i in range(5, 36):
    print("{0} = {1}".format(i, fib(i)))<|endoftext|>
```

Which is a much more useful result.