### PR TITLE
readme: Add link to ggml-gobject

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,3 +118,4 @@ cmake -DGGML_CLBLAST=ON ..
 - [GGML - Large Language Models for Everyone](https://github.com/rustformers/llm/blob/main/crates/ggml/README.md): a description of the GGML format provided by the maintainers of the `llm` Rust crate, which provides Rust bindings for GGML
 - [marella/ctransformers](https://github.com/marella/ctransformers): Python bindings for GGML models.
 - [go-skynet/go-ggml-transformers.cpp](https://github.com/go-skynet/go-ggml-transformers.cpp): Golang bindings for GGML models
+- [smspillaz/ggml-gobject](https://github.com/smspillaz/ggml-gobject): GObject-introspectable wrapper for use of GGML on the GNOME platform.


### PR DESCRIPTION
This enables also some bindings to python (through pygi), gjs, vala, csharp, etc. However `ggml-gobject`s main purpose is to make the library a bit more friendly to the desktop platform, eg, by providing asynchronous operation, a DBus service, etc.