### PR TITLE
Fix public header path for submodules

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -260,7 +260,7 @@ if (GGML_CUDA_SOURCES)
     target_link_libraries(ggml PUBLIC stdc++)
 endif()
 
-set (GGML_PUBLIC_HEADERS ${CMAKE_SOURCE_DIR}/include/ggml/ggml.h)
+set (GGML_PUBLIC_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/../include/ggml/ggml.h)
 set_target_properties(${TARGET} PROPERTIES
                       PUBLIC_HEADER "${GGML_PUBLIC_HEADERS}")
 


### PR DESCRIPTION
Fixes bug introduced in #333 that assumed cmake was always being called from the root `ggml` directory, this caused the public header path to break when ggml is used as a submodule. Fixed this by using `CMAKE_CURRENT_SOURCE_DIR` instead which uses the location of the current CMakeLists file, in this case the one in the `src/` directory.