### PR TITLE
Fast inverse square root to GPT-2 dot product scaling

### DIFF
--- a/examples/gpt-2/main.cpp
+++ b/examples/gpt-2/main.cpp
@@ -534,7 +534,7 @@ bool gpt2_eval(
             struct ggml_tensor * KQ_scaled =
                 ggml_scale_inplace(ctx0,
                         KQ,
-                        ggml_new_f32(ctx0, 1.0f/sqrt(float(n_embd)/n_head))
+                        ggml_new_f32(ctx0, ggml_fast_inv_sqrt(float(n_embd)/n_head))
                         );
 
             // KQ_masked = mask_past(KQ_scaled)

--- a/include/ggml/ggml.h
+++ b/include/ggml/ggml.h
@@ -1284,6 +1284,10 @@ extern "C" {
             struct ggml_tensor          * b,
             struct ggml_tensor          * c);
 
+    // Fast Inverse Square Root
+    // Used for scaling in the self-attention layer
+    float ggml_fast_inv_sqrt(float a);
+
     //
     // automatic differentiation
     //

--- a/src/ggml.c
+++ b/src/ggml.c
@@ -18220,6 +18220,16 @@ size_t ggml_quantize_chunk(enum ggml_type type, const float * src, void * dst, i
     }
     return result;
 }
+////////////////////////////////////////////////////////////////////////////////
+
+float ggml_fast_inv_sqrt(float a){
+        float xhalf = 0.5f * a;
+        int i = *(int*)&a;            // store floating-point bits in integer
+        i = 0x5f3759df - (i >> 1);    // initial guess for Newton's method
+        a = *(float*)&i;              // convert new bits into float
+        a = a*(1.5f - xhalf*a*a);     // One round of Newton's method
+        return a;
+    }
 
 ////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
A couple of days ago I had a thought of optimizing the dot product scaling in the attention mechanism. I'm getting some performance benefits on the GPT-2 117M and 345M models. On the 117M I got 18ms/token down to 15ms/token. On the 345M models I got 46ms/token down to 43ms/token. I'm doing this on a 6 year old laptop, so if someone can also check whether they're getting similar performance gains I'd be very grateful. If nobody sees any issues with this implementation and it gets merged I'll add it to the rest of the models and in llama.cpp.