### PR TITLE
Fix for starcoder ggml-model.bin being saved in wrong directory. Moderrnise by using argparse.

### DIFF
--- a/examples/starcoder/convert-hf-to-ggml.py
+++ b/examples/starcoder/convert-hf-to-ggml.py
@@ -46,6 +46,7 @@ args = parser.parse_args()
 use_f16 = not args.use_f32
 
 fname_out = args.outfile
+os.makedirs(os.path.dirname(fname_out), exist_ok=True)
 
 print("Loading model: ", args.model_name_or_path)
 tokenizer = AutoTokenizer.from_pretrained(args.model_name_or_path)

--- a/examples/starcoder/convert-hf-to-ggml.py
+++ b/examples/starcoder/convert-hf-to-ggml.py
@@ -8,6 +8,7 @@ import torch
 import numpy as np
 import re
 import os
+import argparse
 
 from transformers import AutoModelForCausalLM
 from transformers import AutoTokenizer, AutoModelForCausalLM, AutoConfig, BloomForCausalLM
@@ -34,34 +35,26 @@ def bytes_to_unicode():
     cs = [chr(n) for n in cs]
     return dict(zip(bs, cs))
 
-if len(sys.argv) < 2:
-    print("Usage: python convert-hf-to-ggml.py hf-model-name [use-f32]")
-    print("Example: python convert-hf-to-ggml.py bigcode/gpt_bigcode-santacoder")
-    print("Example: python convert-hf-to-ggml.py bigcode/starcoder")
-    sys.exit(1)
+parser = argparse.ArgumentParser(description='Convert starcoder HF model to GGML')
+parser.add_argument('model_name_or_path', type=str, help='Name of model on HF hub, or local model folder')
+parser.add_argument('--outfile', type=str, default='ggml-model.bin', help='Path of GGML file to write.')
+parser.add_argument('--use_f32', action="store_true", help='Save GGML file in fp32')
 
-model_name = sys.argv[1].strip()
-fname_out = "models/" + sys.argv[1].strip() + "-ggml.bin"
-os.makedirs(os.path.dirname(fname_out), exist_ok=True)
-
-
+args = parser.parse_args()
 
 # use 16-bit or 32-bit floats
-use_f16 = True
-if len(sys.argv) > 2:
-    use_f16 = False
+use_f16 = not args.use_f32
 
-print("Loading model: ", model_name)
-tokenizer = AutoTokenizer.from_pretrained(model_name)
-config = AutoConfig.from_pretrained(model_name, trust_remote_code=True)
+fname_out = args.outfile
+
+print("Loading model: ", args.model_name_or_path)
+tokenizer = AutoTokenizer.from_pretrained(args.model_name_or_path)
+config = AutoConfig.from_pretrained(args.model_name_or_path, trust_remote_code=True)
 hparams = config.to_dict()
-model = AutoModelForCausalLM.from_pretrained(model_name, config=config, torch_dtype=torch.float16 if use_f16 else torch.float32, low_cpu_mem_usage=True, trust_remote_code=True, offload_state_dict=True)
-print("Model loaded: ", model_name)
-
-#print (model)
+model = AutoModelForCausalLM.from_pretrained(args.model_name_or_path, config=config, torch_dtype=torch.float16 if use_f16 else torch.float32, low_cpu_mem_usage=True, trust_remote_code=True, offload_state_dict=True)
+print("Model loaded: ", args.model_name_or_path)
 
 list_vars = model.state_dict()
-#print (list_vars)
 
 encoder = tokenizer.vocab
 # Add added_tokens (special tokens) to the encoder


### PR DESCRIPTION
Currently the starcoder `convert-hf-to-ggml.py` script saves the resulting GGML file in a bizarre directory when the user specifies a local directory for the model source.  eg if I do `convert-hf-to-ggml.py /workspace/models/starcoder/source` I will get `/workspace/models/starcoder/models/workspace/models/starcoder/source-ggml.bin`

I have fixed this by moving to using `argparse`, and more closely matching the parameters of llama.cpp convert.py, with an `--outfile <path to desired model-bin>` parameter so the user can just specify the exact output filename and location they want.  Default filename if not specified is `ggml-model.bin` in the location the user is when they run the script.  

Whether to use fp32 or not is now a boolean `--use_f32` rather than being decided by the number of params specified.

I think it would be good if all the GGML example scripts matched this format or something similar.  I don't have time to do all the other scripts this second but could do shortly.

Let me know what you think of this and if you're happy I will update the other scripts to the same style, and maybe move this arg parsing and model downloading/loading to a central utils.py that gets loaded by all the scripts.