### PR TITLE
Build on Windows fixed (dynamic linking of stdc++)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -257,7 +257,10 @@ if (GGML_CUDA_SOURCES)
     message(STATUS "GGML CUDA sources found, configuring CUDA architecture")
     set_property(TARGET ggml  PROPERTY CUDA_ARCHITECTURES OFF)
     set_property(TARGET ggml  PROPERTY CUDA_SELECT_NVCC_ARCH_FLAGS "Auto")
-    target_link_libraries(ggml PUBLIC stdc++)
+    # Windows native does not link stdc++
+    if(NOT (("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows") OR WIN32))
+        target_link_libraries(ggml PUBLIC stdc++)
+    endif()
 endif()
 
 set (GGML_PUBLIC_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/../include/ggml/ggml.h)


### PR DESCRIPTION
stdc++ linking is fixed for Windows native builds.

The original build produced the following error, which has been resolved:
```sh
>------ Build started: Project: CMakeLists, Configuration: Release ------
  [1/9] Building C object src\CMakeFiles\ggml.dir\ggml.c.obj
ggml\out\build\x64-Release-CUDA-Ninja_x64_x64\cl : Command line warning D9002: ignoring unknown option '-mfma'
ggml\out\build\x64-Release-CUDA-Ninja_x64_x64\cl : Command line warning D9002: ignoring unknown option '-mf16c'
ggml\out\build\x64-Release-CUDA-Ninja_x64_x64\cl : Command line warning D9002: ignoring unknown option '-mavx'
ggml\out\build\x64-Release-CUDA-Ninja_x64_x64\cl : Command line warning D9002: ignoring unknown option '-mavx2'
  [2/9] Building CXX object examples\CMakeFiles\common-ggml.dir\common-ggml.cpp.obj
  [3/9] Building CXX object examples\mpt\CMakeFiles\mpt.dir\main.cpp.obj
  [4/9] Building CXX object examples\CMakeFiles\common.dir\common.cpp.obj
  [5/9] Linking CXX static library examples\common.lib
  [6/9] Building CUDA object src\CMakeFiles\ggml.dir\ggml-cuda.cu.obj
  ggml-cuda.cu
  
  tmpxft_00009f6c_00000000-10_ggml-cuda.cudafe1.cpp
  
  [7/9] Linking CUDA static library src\ggml.lib
  [8/9] Linking CXX static library examples\common-ggml.lib
  [9/9] Linking CXX executable bin\mpt.exe
  FAILED: bin/mpt.exe 
  cmd.exe /C "cd . && "C:\Program Files\Microsoft Visual Studio\2022\Preview\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe" -E vs_link_exe --intdir=examples\mpt\CMakeFiles\mpt.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100203~1.0\x64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100203~1.0\x64\mt.exe --manifests  -- C:\PROGRA~1\MICROS~2\2022\Preview\VC\Tools\MSVC\1437~1.327\bin\Hostx64\x64\link.exe /nologo examples\mpt\CMakeFiles\mpt.dir\main.cpp.obj  /out:bin\mpt.exe /implib:examples\mpt\mpt.lib /pdb:bin\mpt.pdb /version:0.0 /machine:x64 /INCREMENTAL:NO /subsystem:console  src\ggml.lib  examples\common.lib  examples\common-ggml.lib  src\ggml.lib  "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2\lib\x64\cudart.lib"  "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2\lib\x64\cublas.lib"  "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2\lib\x64\cublasLt.lib"  stdc++.lib  kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib && cd ."
  LINK: command "C:\PROGRA~1\MICROS~2\2022\Preview\VC\Tools\MSVC\1437~1.327\bin\Hostx64\x64\link.exe /nologo examples\mpt\CMakeFiles\mpt.dir\main.cpp.obj /out:bin\mpt.exe /implib:examples\mpt\mpt.lib /pdb:bin\mpt.pdb /version:0.0 /machine:x64 /INCREMENTAL:NO /subsystem:console src\ggml.lib examples\common.lib examples\common-ggml.lib src\ggml.lib C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2\lib\x64\cudart.lib C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2\lib\x64\cublas.lib C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2\lib\x64\cublasLt.lib stdc++.lib kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib /MANIFEST /MANIFESTFILE:bin\mpt.exe.manifest" failed (exit code 1181) with the following output:
ggml\out\build\x64-Release-CUDA-Ninja_x64_x64\LINK : fatal error LNK1181: cannot open input file 'stdc++.lib'
  
  ninja: build stopped: subcommand failed.

Build failed.
```