### PR TITLE
pkg-config: Fix typo in includedir

### DIFF
--- a/ggml.pc.in
+++ b/ggml.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-includrdir=${prefix}/include
+includedir=${prefix}/include
 libdir=${prefix}/lib
 
 Name: ggml


### PR DESCRIPTION
On ubuntu-latest this field is validated, unlike on my virtual machine, so didn't catch it earlier.