### PR TITLE
ggml : fix mul_mat src1 indexing when src1 is not contiguous

### DIFF
--- a/src/ggml.c
+++ b/src/ggml.c
@@ -10684,6 +10684,8 @@ static void ggml_compute_forward_mul_mat(
 
     const enum ggml_type type = src0->type;
 
+    const bool src1_cont = ggml_is_contiguous(src1);
+
     ggml_vec_dot_t    const vec_dot               = type_traits[type].vec_dot;
     enum ggml_type    const vec_dot_type          = type_traits[type].vec_dot_type;
     ggml_from_float_t const from_float_to_vec_dot = type_traits[vec_dot_type].from_float;
@@ -10747,7 +10749,7 @@ static void ggml_compute_forward_mul_mat(
                 float * d = (float *) ((char *) dst->data + i02*nb2 + i03*nb3);
 
                 if (type != GGML_TYPE_F32) {
-                    float * const wdata = params->wdata;
+                            float * const wdata    = params->wdata;
                     ggml_to_float_t const to_float = type_traits[type].to_float;
 
                     size_t id = 0;
@@ -10805,7 +10807,7 @@ static void ggml_compute_forward_mul_mat(
     // src1 rows
     const int64_t nr1 = ne11*ne12*ne13;
 
-    void * wdata = (src1->type == vec_dot_type) ? src1->data : params->wdata;
+    const void * wdata    = (src1->type == vec_dot_type) ? src1->data : params->wdata;
     const size_t row_size = ne10*GGML_TYPE_SIZE[vec_dot_type]/GGML_BLCK_SIZE[vec_dot_type];
 
     for (int64_t ir1 = 0; ir1 < nr1; ++ir1) {
@@ -10828,7 +10830,15 @@ static void ggml_compute_forward_mul_mat(
         const int64_t i3 = i13;
 
         const char * src0_row = (const char *) src0->data + (  0 + i02*nb02 + i03*nb03     );
-        const char * src1_col = (const char *)      wdata + (i11 + i12*ne11 + i13*ne12*ne11)*row_size;
+
+        // desc: when src1 is not a contiguous memory block we have to calculate the offset using the strides
+        //       if it is, then we have either copied the data to params->wdata and made it contiguous or we are using
+        //       the original src1 data pointer, so we should index using the indices directly
+        // TODO: this is a bit of a hack, we should probably have a better way to handle this
+        const char * src1_col = (const char *) wdata +
+            (src1_cont
+             ? (i11      + i12*ne11 + i13*ne12*ne11)*row_size
+             : (i11*nb11 + i12*nb12 + i13*nb13));
 
         float * dst_col = (float *) ((char *) dst->data + (i1*nb1 + i2*nb2 + i3*nb3));
 


### PR DESCRIPTION
fix #385 

Sample run before fix:

<details>

```bash
$ ▶ ./bin/gpt-2 -m models/gpt-2-117M/ggml-model-f32.bin -p 'The meaning of life is:' -s 12 --top_k 1
main: seed = 12
gpt2_model_load: loading model from 'models/gpt-2-117M/ggml-model-f32.bin'
gpt2_model_load: n_vocab = 50257
gpt2_model_load: n_ctx   = 1024
gpt2_model_load: n_embd  = 768
gpt2_model_load: n_head  = 12
gpt2_model_load: n_layer = 12
gpt2_model_load: ftype   = 0
gpt2_model_load: qntvr   = 0
gpt2_model_load: ggml tensor size = 240 bytes
gpt2_model_load: ggml ctx size = 694.01 MB
gpt2_model_load: memory size =    72.00 MB, n_mem = 12288
gpt2_model_load: model size  =   474.70 MB
extract_tests_from_file : No test file found.
test_gpt_tokenizer : 0 tests failed out of 0 tests.
main: prompt: 'The meaning of life is:'
main: number of tokens in prompt = 6, first 8 tokens: 464 3616 286 1204 318 25 

The meaning of life is: life


"I'm

"I'm

"I'm

"I'm

"I'm

"I'm

"I'm

"I'm

"I'm

"I'm

"I'm

"I'm

"I'm

"I'm

"I'm

"I'm

"I'm

"I'm

"I'm

"I'm

"I'm

"I'm

"I'm

"I'm

"I'm

"I'm

"I'm

"I'm

"I'm

"I'm

"I'm

"I'm

"I'm

"I'm

"I'm

"I'm

"I'm

"I'm

"I'm

"

main: mem per token =  2010732 bytes
main:     load time =   194.41 ms
main:   sample time =    51.89 ms
main:  predict time =  2533.62 ms / 12.36 ms per token
main:    total time =  2810.71 ms
```
</details>

Sample run after fix:

<details>

```bash
$ ▶ ./bin/gpt-2 -m models/gpt-2-117M/ggml-model-f32.bin -p 'The meaning of life is:' -s 12 --top_k 1
main: seed = 12
gpt2_model_load: loading model from 'models/gpt-2-117M/ggml-model-f32.bin'
gpt2_model_load: n_vocab = 50257
gpt2_model_load: n_ctx   = 1024
gpt2_model_load: n_embd  = 768
gpt2_model_load: n_head  = 12
gpt2_model_load: n_layer = 12
gpt2_model_load: ftype   = 0
gpt2_model_load: qntvr   = 0
gpt2_model_load: ggml tensor size = 240 bytes
gpt2_model_load: ggml ctx size = 694.01 MB
gpt2_model_load: memory size =    72.00 MB, n_mem = 12288
gpt2_model_load: model size  =   474.70 MB
extract_tests_from_file : No test file found.
test_gpt_tokenizer : 0 tests failed out of 0 tests.
main: prompt: 'The meaning of life is:'
main: number of tokens in prompt = 6, first 8 tokens: 464 3616 286 1204 318 25 

The meaning of life is: to live in a world of abundance, and to live in a world of abundance.

The meaning of life is: to live in a world of abundance, and to live in a world of abundance.

The meaning of life is: to live in a world of abundance, and to live in a world of abundance.

The meaning of life is: to live in a world of abundance, and to live in a world of abundance.

The meaning of life is: to live in a world of abundance, and to live in a world of abundance.

The meaning of life is: to live in a world of abundance, and to live in a world of abundance.

The meaning of life is: to live in a world of abundance, and to live in a world of abundance.

The meaning of life is: to live in a world of abundance, and to live in a world of abundance.

The meaning of life is:

main: mem per token =  2010732 bytes
main:     load time =   190.43 ms
main:   sample time =    50.85 ms
main:  predict time =  2490.53 ms / 12.15 ms per token
main:    total time =  2761.98 ms
```
</details>