### PR TITLE
Fixed CUDA arch: OFF -> 52;61

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -255,7 +255,7 @@ endif()
 
 if (GGML_CUDA_SOURCES)
     message(STATUS "GGML CUDA sources found, configuring CUDA architecture")
-    set_property(TARGET ggml  PROPERTY CUDA_ARCHITECTURES OFF)
+    set_property(TARGET ggml  PROPERTY CUDA_ARCHITECTURES "52;61")
     set_property(TARGET ggml  PROPERTY CUDA_SELECT_NVCC_ARCH_FLAGS "Auto")
     target_link_libraries(ggml PUBLIC stdc++)
 endif()


### PR DESCRIPTION
Fixes the issue described in https://github.com/ggerganov/ggml/pull/338 where the `__dp4a` based CUDA kernels cause the model to produce garbage. The problem is that the cmake CUDA compute capabilities set in llama.cpp and ggml are different. In llama.cpp they are set to `52;61`, the lowest allowed compute capability and the minimum compute capability for `__dp4a`. A GPU will automatically use the highest compute capability PTX code that was compiled. If only 5.2 PTX code is generated (the default) the fallback implementation in which 0 is returned is used for GPUs with compute capability >= 6.1 which causes the model to produce garbage outputs. Ideally I would have put the `__CUDA_ARCH__` check outside the kernels but unfortunately this is not possible; `__CUDA_ARCH__` is only available in device code.