### PR TITLE
Add metal kernel to target resources when built as shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ option(GGML_NO_ACCELERATE           "ggml: disable Accelerate framework" OFF)
 option(GGML_OPENBLAS                "ggml: use OpenBLAS"                 OFF)
 option(GGML_CLBLAST                 "ggml: use clBLAST"                  OFF)
 option(GGML_CUBLAS                  "ggml: use cuBLAS"                   OFF)
+option(GGML_METAL                   "ggml: use Metal"                    OFF)
 
 # sanitizers
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -209,7 +209,7 @@ if (GGML_METAL)
     find_library(METALKIT_FRAMEWORK         MetalKit                REQUIRED)
     find_library(METALPERFORMANCE_FRAMEWORK MetalPerformanceShaders REQUIRED)
 
-    set(GGML_METAL_SOURCES ggml-metal.m ggml-metal.h)
+    set(GGML_METAL_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/ggml-metal.m ${CMAKE_CURRENT_SOURCE_DIR}/ggml-metal.h)
 
     add_compile_definitions(GGML_METAL_NDEBUG)
 
@@ -217,7 +217,7 @@ if (GGML_METAL)
     #add_compile_definitions(GGML_METAL_DIR_KERNELS="${CMAKE_CURRENT_SOURCE_DIR}/")
 
     # copy ggml-metal.metal to bin directory
-    configure_file(ggml-metal.metal bin/ggml-metal.metal COPYONLY)
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/ggml-metal.metal bin/ggml-metal.metal COPYONLY)
 
     set(GGML_EXTRA_LIBS ${GGML_EXTRA_LIBS}
         ${FOUNDATION_LIBRARY}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -209,7 +209,7 @@ if (GGML_METAL)
     find_library(METALKIT_FRAMEWORK         MetalKit                REQUIRED)
     find_library(METALPERFORMANCE_FRAMEWORK MetalPerformanceShaders REQUIRED)
 
-    set(GGML_SOURCES_METAL ggml-metal.m ggml-metal.h)
+    set(GGML_METAL_SOURCES ggml-metal.m ggml-metal.h)
 
     add_compile_definitions(GGML_METAL_NDEBUG)
 
@@ -235,7 +235,8 @@ add_library(${TARGET}
     ggml.c
     ../include/ggml/ggml.h
     ${GGML_CUDA_SOURCES}
-    ${GGML_OPENCL_SOURCES})
+    ${GGML_OPENCL_SOURCES}
+    ${GGML_METAL_SOURCES}})
 
 target_include_directories(${TARGET} PUBLIC
     .
@@ -264,6 +265,10 @@ if (BUILD_SHARED_LIBS)
     target_compile_definitions(${TARGET} PRIVATE
         GGML_BUILD
         )
+
+    if (GGML_METAL)
+        set_target_properties(${TARGET} PROPERTIES RESOURCE "${CMAKE_CURRENT_SOURCE_DIR}/ggml-metal.metal")
+    endif()
 endif()
 
 target_compile_definitions(${TARGET} PUBLIC

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -203,6 +203,29 @@ if (GGML_CUBLAS)
     endif()
 endif()
 
+if (GGML_METAL)
+    find_library(FOUNDATION_LIBRARY         Foundation              REQUIRED)
+    find_library(METAL_FRAMEWORK            Metal                   REQUIRED)
+    find_library(METALKIT_FRAMEWORK         MetalKit                REQUIRED)
+    find_library(METALPERFORMANCE_FRAMEWORK MetalPerformanceShaders REQUIRED)
+
+    set(GGML_SOURCES_METAL ggml-metal.m ggml-metal.h)
+
+    add_compile_definitions(GGML_METAL_NDEBUG)
+
+    # get full path to the file
+    #add_compile_definitions(GGML_METAL_DIR_KERNELS="${CMAKE_CURRENT_SOURCE_DIR}/")
+
+    # copy ggml-metal.metal to bin directory
+    configure_file(ggml-metal.metal bin/ggml-metal.metal COPYONLY)
+
+    set(GGML_EXTRA_LIBS ${GGML_EXTRA_LIBS}
+        ${FOUNDATION_LIBRARY}
+        ${METAL_FRAMEWORK}
+        ${METALKIT_FRAMEWORK}
+        ${METALPERFORMANCE_FRAMEWORK}
+        )
+endif()
 
 if (GGML_PERF)
     set(GGML_EXTRA_FLAGS ${GGML_EXTRA_FLAGS} -DGGML_PERF)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -236,7 +236,7 @@ add_library(${TARGET}
     ../include/ggml/ggml.h
     ${GGML_CUDA_SOURCES}
     ${GGML_OPENCL_SOURCES}
-    ${GGML_METAL_SOURCES}})
+    ${GGML_METAL_SOURCES})
 
 target_include_directories(${TARGET} PUBLIC
     .


### PR DESCRIPTION
Adds the option to compile ggml with the metal source files similar to how it's done in llama.cpp. Should help in the implementation of #397