### PR TITLE
fix starcoder/convert-hf-to-ggml.py to handle current-folder output file - as in README example

### DIFF
--- a/examples/starcoder/convert-hf-to-ggml.py
+++ b/examples/starcoder/convert-hf-to-ggml.py
@@ -46,7 +46,9 @@ args = parser.parse_args()
 use_f16 = not args.use_f32
 
 fname_out = args.outfile
-os.makedirs(os.path.dirname(fname_out), exist_ok=True)
+fname_dir = os.path.dirname(fname_out)
+if fname_dir:
+    os.makedirs(fname_dir, exist_ok=True)
 
 print("Loading model: ", args.model_name_or_path)
 tokenizer = AutoTokenizer.from_pretrained(args.model_name_or_path)


### PR DESCRIPTION
fix from bug introduced in https://github.com/ggerganov/ggml/pull/363

for when there is no folder specified in the output file, as is the default

this makes the example code in the README work as-is.  otherwise, there is an error when the script attempts to create folders for an empty string