### PR TITLE
tests : undefine NDEBUG so the asserts always work

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -129,6 +129,9 @@ if (GGML_OPENBLAS)
     endif()
 endif()
 
+# undefine NDEBUG so asserts don't get disabled in tests
+add_definitions(-UNDEBUG)
+
 #
 # test-vec0
 


### PR DESCRIPTION
I noticed that some tests such as 'test-customop.c' did nothing in release builds, because they rely on asserts in order to function. Undefining NDEBUG makes sure they work correctly for all build types.

I tested this by inserting `assert(0)` at the top of main in test-customop.c. On Linux I used gcc and `cmake -DCMAKE_BUILD_TYPE=Release`, on Windows I used MSVC and `cmake --build --config Release`. Without this change, the assertion is ignored.