### PR TITLE
make ggml_conv_2d faster

### DIFF
--- a/include/ggml/ggml.h
+++ b/include/ggml/ggml.h
@@ -380,6 +380,8 @@ extern "C" {
         GGML_OP_CLAMP,
         GGML_OP_CONV_1D,
         GGML_OP_CONV_2D,
+        GGML_OP_CONV_2D_STAGE_0, // internal
+        GGML_OP_CONV_2D_STAGE_1, // internal
         GGML_OP_CONV_TRANSPOSE_2D,
         GGML_OP_POOL_1D,
         GGML_OP_POOL_2D,
@@ -952,9 +954,9 @@ extern "C" {
             struct ggml_tensor  * a,
             struct ggml_tensor  * b);
 
-    // A: n columns, m rows
-    // B: n columns, p rows  (i.e. we transpose it internally)
-    // result is m columns, p rows
+    // A: k columns, n rows => [ne03, ne02, n, k]
+    // B: k columns, m rows  (i.e. we transpose it internally) => [ne03 * x, ne02 * y, m, k]
+    // result is n columns, m rows => [ne03 * x, ne02 * y, m, n]
     GGML_API struct ggml_tensor * ggml_mul_mat(
             struct ggml_context * ctx,
             struct ggml_tensor  * a,

--- a/src/ggml.c
+++ b/src/ggml.c
@@ -571,7 +571,6 @@ int64_t ggml_cycles_per_ms(void) {
 #define ggml_perf_cycles_per_ms() 0
 #endif
 
-
 //
 // cache line
 //
@@ -1827,7 +1826,6 @@ ggml_type_traits_t ggml_internal_get_type_traits(enum ggml_type type) {
     GGML_ASSERT(type < GGML_TYPE_COUNT);
     return type_traits[type];
 }
-
 
 //
 // simd mappings
@@ -5925,7 +5923,6 @@ struct ggml_tensor * ggml_sqrt_inplace(
     return ggml_sqrt_impl(ctx, a, true);
 }
 
-
 // ggml_log
 
 static struct ggml_tensor * ggml_log_impl(
@@ -5978,7 +5975,6 @@ struct ggml_tensor * ggml_sum(
 
     return result;
 }
-
 
 // ggml_sum_rows
 
@@ -6611,7 +6607,6 @@ struct ggml_tensor * ggml_set_2d_inplace(
     return ggml_set_impl(ctx, a, b, nb1, a->nb[2], a->nb[3], offset, false);
 }
 
-
 // ggml_cpy
 
 static struct ggml_tensor * ggml_cpy_impl(
@@ -6690,7 +6685,6 @@ struct ggml_tensor * ggml_cont_inplace(
         struct ggml_tensor * a) {
     return ggml_cont_impl(ctx, a, true);
 }
-
 
 // make contiguous, with new shape
 GGML_API struct ggml_tensor * ggml_cont_1d(
@@ -7144,7 +7138,6 @@ struct ggml_tensor * ggml_diag(
     return result;
 }
 
-
 // ggml_diag_mask_inf
 
 static struct ggml_tensor * ggml_diag_mask_inf_impl(
@@ -7255,7 +7248,6 @@ struct ggml_tensor * ggml_soft_max_inplace(
         struct ggml_tensor  * a) {
     return ggml_soft_max_impl(ctx, a, true);
 }
-
 
 // ggml_soft_max_back
 
@@ -7773,7 +7765,6 @@ struct ggml_tensor * ggml_conv_2d(
 
 }
 
-
 // ggml_conv_2d_sk_p0
 struct ggml_tensor * ggml_conv_2d_sk_p0(
         struct ggml_context * ctx,
@@ -8212,7 +8203,6 @@ static struct ggml_tensor * ggml_add_rel_pos_impl(
 
     return result;
 }
-
 
 struct ggml_tensor * ggml_add_rel_pos(
         struct ggml_context * ctx,
@@ -8657,8 +8647,6 @@ struct ggml_tensor * ggml_map_custom3_inplace(
         void                         * userdata) {
     return ggml_map_custom3_impl(ctx, a, b, c, fun, n_tasks, userdata, true);
 }
-
-
 
 // ggml_cross_entropy_loss
 
@@ -9860,7 +9848,6 @@ static void ggml_compute_forward_add1(
     }
 }
 
-
 // ggml_compute_forward_acc
 
 static void ggml_compute_forward_acc_f32(
@@ -9999,7 +9986,6 @@ static void ggml_compute_forward_sub_f32(
             const int i3 = ir/(ne2*ne1);
             const int i2 = (ir - i3*ne2*ne1)/ne1;
             const int i1 = (ir - i3*ne2*ne1 - i2*ne1);
-
 
 #ifdef GGML_USE_ACCELERATE
             vDSP_vsub(
@@ -10181,7 +10167,6 @@ static void ggml_compute_forward_div_f32(
             const int i2 = (ir - i3*ne2*ne1)/ne1;
             const int i1 = (ir - i3*ne2*ne1 - i2*ne1);
 
-
 #ifdef GGML_USE_ACCELERATE
             UNUSED(ggml_vec_div_f32);
 
@@ -10318,7 +10303,6 @@ static void ggml_compute_forward_sqrt(
             } break;
     }
 }
-
 
 // ggml_compute_forward_log
 
@@ -12152,7 +12136,6 @@ static void ggml_compute_forward_out_prod_f32(
         }
     }
 
-
     //int64_t t1 = ggml_perf_time_us();
     //static int64_t acc = 0;
     //acc += t1 - t0;
@@ -12347,7 +12330,6 @@ static void ggml_compute_forward_scale_f32(
     const size_t nb01 = src0->nb[1];
 
     const size_t nb1 = dst->nb[1];
-
 
     for (int i1 = ir0; i1 < ir1; i1++) {
         if (dst->data != src0->data) {
@@ -12745,7 +12727,6 @@ static void ggml_compute_forward_get_rows_back_f32(
                 (float *) ((char *) src0->data + i*src0->nb[1]));
     }
 }
-
 
 static void ggml_compute_forward_get_rows_back(
         const struct ggml_compute_params * params,
@@ -14032,6 +14013,7 @@ static void ggml_compute_forward_conv_1d_f32(
     }
 }
 
+// TODO: reuse ggml_mul_mat or implement ggml_im2col and remove stage_0 and stage_1
 static void gemm_f16_out_f32(int64_t m, int64_t n, int64_t k,
                              ggml_fp16_t * A,
                              ggml_fp16_t * B,
@@ -16360,7 +16342,6 @@ static void ggml_compute_forward_add_rel_pos_f32(
     const int ip0 = dp*ith;
     const int ip1 = MIN(ip0 + dp, np);
 
-
     for (int64_t i13 = ip0; i13 < ip1; ++i13) {
         for (int64_t i12 = 0; i12 < ne12; ++i12) {
             for (int64_t i11 = 0; i11 < ne11; ++i11) {
@@ -16427,7 +16408,6 @@ static void ggml_compute_forward_map_unary_f32(
     }
 }
 
-
 static void ggml_compute_forward_map_unary(
         const struct ggml_compute_params * params,
         const struct ggml_tensor * src0,
@@ -16474,7 +16454,6 @@ static void ggml_compute_forward_map_binary_f32(
                 (float *) ((char *) src1->data + i*(src1->nb[1])));
     }
 }
-
 
 static void ggml_compute_forward_map_binary(
         const struct ggml_compute_params * params,
@@ -16526,7 +16505,6 @@ static void ggml_compute_forward_map_custom2_f32(
 
     fun(dst, a, b);
 }
-
 
 // ggml_compute_forward_map_custom3
 
@@ -16802,7 +16780,6 @@ static void ggml_compute_forward_cross_entropy_loss_back_f32(
         ggml_vec_sub_f32(nc, ds0, ds0, s1);
         ggml_vec_scale_f32(nc, ds0, d[0] / (float) nr);
 
-
 #ifndef NDEBUG
         for (int i = 0; i < nc; ++i) {
             assert(!isnan(ds0[i]));
@@ -16829,7 +16806,6 @@ static void ggml_compute_forward_cross_entropy_loss_back(
             } break;
     }
 }
-
 
 /////////////////////////////////
 
@@ -20132,7 +20108,6 @@ static enum ggml_opt_result ggml_opt_adam(
         fx *= accum_norm;
 
         opt->loss_after = fx;
-
 
         // check convergence
         if (fabsf(fx - fx_prev[0])/fx < params.adam.eps_f) {

--- a/src/ggml.c
+++ b/src/ggml.c
@@ -13526,18 +13526,18 @@ static void ggml_compute_forward_conv_2d_stage_0_f32(
 
     GGML_TENSOR_BINARY_OP_LOCALS;
 
-    const int N = ne13;
-    const int IC = ne12;
-    const int IH = ne11;
-    const int IW = ne10;
+    const int64_t N = ne13;
+    const int64_t IC = ne12;
+    const int64_t IH = ne11;
+    const int64_t IW = ne10;
 
-    // const int OC = ne03;
-    // const int IC = ne02;
-    const int KH = ne01;
-    const int KW = ne00;
+    // const int64_t OC = ne03;
+    // const int64_t IC = ne02;
+    const int64_t KH = ne01;
+    const int64_t KW = ne00;
 
-    const int OH = ne2;
-    const int OW = ne1;
+    const int64_t OH = ne2;
+    const int64_t OW = ne1;
 
     const int ith = params->ith;
     const int nth = params->nth;
@@ -13565,19 +13565,19 @@ static void ggml_compute_forward_conv_2d_stage_0_f32(
     {
         ggml_fp16_t * const wdata = (ggml_fp16_t *) dst->data;
 
-        for (int in = 0; in < N; in++) {
-            for (int ioh = 0; ioh < OH; ioh++) {
-                for (int iow = 0; iow < OW; iow++) {
-                    for (int iic = ith; iic < IC; iic+=nth) {
+        for (int64_t in = 0; in < N; in++) {
+            for (int64_t ioh = 0; ioh < OH; ioh++) {
+                for (int64_t iow = 0; iow < OW; iow++) {
+                    for (int64_t iic = ith; iic < IC; iic+=nth) {
 
                         // micro kernel
                         ggml_fp16_t * dst_data = wdata + (in*OH*OW + ioh*OW + iow)*(IC*KH*KW); // [IC, KH, KW]
                         const float * const src_data = (float *)((char *) src1->data + in*nb13 + iic*nb12); // [IH, IW]
 
-                        for (int ikh = 0; ikh < KH; ikh++) {
-                            for (int ikw = 0; ikw < KW; ikw++) {
-                                const int iiw = iow*s0 + ikw*d0 - p0;
-                                const int iih = ioh*s1 + ikh*d1 - p1;
+                        for (int64_t ikh = 0; ikh < KH; ikh++) {
+                            for (int64_t ikw = 0; ikw < KW; ikw++) {
+                                const int64_t iiw = iow*s0 + ikw*d0 - p0;
+                                const int64_t iih = ioh*s1 + ikh*d1 - p1;
 
                                 if (!(iih < 0 || iih >= IH || iiw < 0 || iiw >= IW)) {
                                     dst_data[iic*(KH*KW) + ikh*KW + ikw] = GGML_FP32_TO_FP16(src_data[iih*IW + iiw]);


### PR DESCRIPTION
I've split the `CONV_2D` operation into two parts: im2col(`CONV_2D_STAGE_0`) and GEMM(`CONV_2D_STAGE_1`). I've enabled multi-threading for im2col and restructured the loops to make the cache more friendly. For clarity, I've used more intuitive and general variable names.

Taking the decode_first_stage phase in stable-diffusion as an example, when generating a 512x512 image.
For a detailed comparison, you can refer to the information provided here https://github.com/leejet/stable-diffusion.cpp/discussions/30

before:
```
perf_total_per_op_us[             ADD] = 1590.776 ms
perf_total_per_op_us[             MUL] = 708.338 ms
perf_total_per_op_us[          REPEAT] = 3385.188 ms
perf_total_per_op_us[      GROUP_NORM] = 754.513 ms
perf_total_per_op_us[         MUL_MAT] = 244.121 ms
perf_total_per_op_us[           SCALE] =  11.161 ms
perf_total_per_op_us[            CONT] =  16.623 ms
perf_total_per_op_us[         RESHAPE] =   0.111 ms
perf_total_per_op_us[         PERMUTE] =   0.003 ms
perf_total_per_op_us[        SOFT_MAX] =  12.856 ms
perf_total_per_op_us[         CONV_2D] = 43098.730 ms
perf_total_per_op_us[         UPSCALE] = 313.308 ms
perf_total_per_op_us[           UNARY] = 254.900 ms
```
after:
```
perf_total_per_op_us[             ADD] = 1595.238 ms
perf_total_per_op_us[             MUL] = 698.069 ms
perf_total_per_op_us[          REPEAT] = 3551.963 ms
perf_total_per_op_us[      GROUP_NORM] = 760.794 ms
perf_total_per_op_us[         MUL_MAT] = 219.111 ms
perf_total_per_op_us[           SCALE] =   9.338 ms
perf_total_per_op_us[            CONT] =  15.030 ms
perf_total_per_op_us[         RESHAPE] =   0.106 ms
perf_total_per_op_us[         PERMUTE] =   0.003 ms
perf_total_per_op_us[        SOFT_MAX] =  10.828 ms
perf_total_per_op_us[ CONV_2D_STAGE_0] = 5607.402 ms
perf_total_per_op_us[ CONV_2D_STAGE_1] = 12835.200 ms
perf_total_per_op_us[         UPSCALE] = 317.210 ms
perf_total_per_op_us[           UNARY] = 289.982 ms
```

The time for `CONV_2D` has been reduced from the original 43098.730 ms to 18442.602 ms (`CONV_2D_STAGE_0` + `CONV_2D_STAGE_1`).