### PR TITLE
CUDA: fix build and enable warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 3.3)
 project(ggml VERSION 0.1.0)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS "on")
@@ -84,7 +84,11 @@ if (GGML_ALL_WARNINGS)
 endif()
 
 if (NOT MSVC)
-    add_compile_options(-Werror=vla)
+    add_compile_options(
+        "$<$<COMPILE_LANGUAGE:C>:-Werror=vla>"
+        "$<$<COMPILE_LANGUAGE:CXX>:-Werror=vla>"
+        "$<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler;-Werror=vla>"
+    )
 endif()
 
 # dependencies

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,14 +1,7 @@
 if (GGML_ALL_WARNINGS)
     if (NOT MSVC)
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} \
-            -Wunused                        \
-            -Wextra                         \
-            -Wshadow                        \
-            -Wcast-qual                     \
-            -Wdouble-promotion              \
-            -Wno-unused-function            \
-            -Wmissing-prototypes            \
-        ")
+        add_compile_options(-Wunused -Wextra -Wcast-qual -Wdouble-promotion)
+        add_compile_options("$<$<COMPILE_LANGUAGE:C>:-Wshadow;-Wno-unused-function;-Wmissing-prototypes>")
     else()
         # todo : windows
     endif()

--- a/src/ggml-cuda.cu
+++ b/src/ggml-cuda.cu
@@ -5721,6 +5721,7 @@ inline void ggml_cuda_op_alibi(
     (void) src1;
     (void) src0_ddq_i;
     (void) src1_ddf_i;
+    (void) i02;
     (void) i1;
 }
 

--- a/src/ggml.c
+++ b/src/ggml.c
@@ -1292,6 +1292,7 @@ static void quantize_row_q8_0(const float * restrict x, void * restrict vy, int 
 #endif
     }
 #else
+    (void)nb;
     // scalar
     quantize_row_q8_0_reference(x, y, k);
 #endif
@@ -1510,6 +1511,7 @@ static void quantize_row_q8_1(const float * restrict x, void * restrict vy, int 
 #endif
     }
 #else
+    (void)nb;
     // scalar
     quantize_row_q8_1_reference(x, y, k);
 #endif


### PR DESCRIPTION
PR #479 broke the CUDA build, as nvcc does not understand `-Werror=vla`. Fix this, and enable other warnings for ggml-cuda.cu by using add_compile_options.