### PR TITLE
FEAT: Complete implementation of `GGML_OP_CONV_1D`

### DIFF
--- a/include/ggml/ggml.h
+++ b/include/ggml/ggml.h
@@ -397,6 +397,9 @@ extern "C" {
         GGML_OP_POOL_1D,
         GGML_OP_POOL_2D,
 
+        GGML_OP_CONV_1D_STAGE_0,  // internal
+        GGML_OP_CONV_1D_STAGE_1,  // internal
+
         GGML_OP_UPSCALE, // nearest interpolate
 
         GGML_OP_FLASH_ATTN,

--- a/src/ggml.c
+++ b/src/ggml.c
@@ -13295,7 +13295,7 @@ static void ggml_compute_forward_conv_1d(
     switch(src0->type) {
         case GGML_TYPE_F16:
             {
-                ggml_compute_forward_conv_1d_f16(params, src0, src1, dst);
+                ggml_compute_forward_conv_1d_f16_f32(params, src0, src1, dst);
             } break;
         case GGML_TYPE_F32:
             {


### PR DESCRIPTION
Currently, the 1d convolution is only implemented for half padding and stride 1 and 2. Yet, the 1d convolution is a crucial operation, needed for instance in [bark.cpp](https://github.com/PABannier/bark.cpp) and [encodec.cpp](https://github.com/PABannier/encodec.cpp) .

This PR completes the implementation of the 1d convolution (for f32 and f16 src types). It also updates the computation of the size needed for the work buffer.