### PR TITLE
ggml-backend : code style suggestions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ build-sanitize-thread/
 build-cov/
 build-ci-debug/
 build-ci-release/
+build-cublas/
 out/
 tmp/
 models/

--- a/examples/gpt-2/main.cpp
+++ b/examples/gpt-2/main.cpp
@@ -75,9 +75,11 @@ struct gpt2_model {
 
     //
     struct ggml_context * ctx;
-    ggml_backend_t backend = NULL;
-    ggml_backend_buffer_t buffer_w;
-    ggml_backend_buffer_t buffer_kv;
+    struct ggml_backend * backend = NULL;
+
+    struct ggml_backend_buffer * buffer_w;
+    struct ggml_backend_buffer * buffer_kv;
+
     std::map<std::string, struct ggml_tensor *> tensors;
 };
 
@@ -826,7 +828,7 @@ int main(int argc, char ** argv) {
     }
 
     // keep this buffer alive while evaluating the model
-    ggml_backend_buffer_t buf_compute;
+    struct ggml_backend_buffer * buf_compute;
 
     struct ggml_allocr * allocr = NULL;
     // allocate the compute buffer

--- a/examples/gpt-2/main.cpp
+++ b/examples/gpt-2/main.cpp
@@ -75,10 +75,11 @@ struct gpt2_model {
 
     //
     struct ggml_context * ctx;
-    struct ggml_backend * backend = NULL;
 
-    struct ggml_backend_buffer * buffer_w;
-    struct ggml_backend_buffer * buffer_kv;
+    ggml_backend_t backend = NULL;
+
+    ggml_backend_buffer_t buffer_w;
+    ggml_backend_buffer_t buffer_kv;
 
     std::map<std::string, struct ggml_tensor *> tensors;
 };
@@ -335,6 +336,7 @@ bool gpt2_model_load(const std::string & fname, gpt2_model & model, gpt_vocab & 
 
         // allocate buffer and tensors
         model.buffer_kv = ggml_backend_alloc_buffer(model.backend, memory_size + 256);
+
         ggml_allocr * alloc = ggml_allocr_new_from_buffer(model.buffer_kv);
         ggml_allocr_alloc(alloc, model.memory_k);
         ggml_allocr_alloc(alloc, model.memory_v);
@@ -828,7 +830,7 @@ int main(int argc, char ** argv) {
     }
 
     // keep this buffer alive while evaluating the model
-    struct ggml_backend_buffer * buf_compute;
+    ggml_backend_buffer_t buf_compute;
 
     struct ggml_allocr * allocr = NULL;
     // allocate the compute buffer

--- a/include/ggml/ggml-alloc.h
+++ b/include/ggml/ggml-alloc.h
@@ -16,17 +16,17 @@ GGML_API struct ggml_allocr * ggml_allocr_new_from_buffer(struct ggml_backend_bu
 // you should call this if your graph are optimized to execute out-of-order
 GGML_API void   ggml_allocr_set_parse_seq(struct ggml_allocr * alloc, const int * list, int n);
 
-GGML_API void   ggml_allocr_free(struct ggml_allocr * alloc);
-GGML_API bool   ggml_allocr_is_measure(struct ggml_allocr * alloc);
-GGML_API void   ggml_allocr_reset(struct ggml_allocr * alloc);
-GGML_API void   ggml_allocr_alloc(struct ggml_allocr * alloc, struct ggml_tensor * tensor);
+GGML_API void   ggml_allocr_free       (struct ggml_allocr * alloc);
+GGML_API bool   ggml_allocr_is_measure (struct ggml_allocr * alloc);
+GGML_API void   ggml_allocr_reset      (struct ggml_allocr * alloc);
+GGML_API void   ggml_allocr_alloc      (struct ggml_allocr * alloc, struct ggml_tensor * tensor);
 GGML_API size_t ggml_allocr_alloc_graph(struct ggml_allocr * alloc, struct ggml_cgraph * graph);
-GGML_API size_t ggml_allocr_max_size(struct ggml_allocr * alloc);
+GGML_API size_t ggml_allocr_max_size   (struct ggml_allocr * alloc);
+
 GGML_API size_t ggml_allocr_alloc_graph_n(
                     struct ggml_allocr * alloc,
                     struct ggml_cgraph ** graphs, int n_graphs,
                     struct ggml_tensor *** inputs, struct ggml_tensor *** outputs);
-
 
 #ifdef  __cplusplus
 }

--- a/include/ggml/ggml-backend.h
+++ b/include/ggml/ggml-backend.h
@@ -5,6 +5,7 @@
 #ifdef  __cplusplus
 extern "C" {
 #endif
+    struct ggml_backend;
     struct ggml_backend_buffer;
 
     // type-erased backend-specific types / wrappers
@@ -12,22 +13,16 @@ extern "C" {
     typedef void * ggml_backend_context_t;
     typedef void * ggml_backend_buffer_context_t;
 
+    //
+    // backend buffer
+    //
+
     struct ggml_backend_buffer_i {
         void   (*free_buffer)   (struct ggml_backend_buffer * buffer);
         void * (*get_base)      (struct ggml_backend_buffer * buffer); // get base pointer
         size_t (*get_alloc_size)(struct ggml_backend_buffer * buffer, struct ggml_tensor * tensor); // pre-allocation callback
         void   (*init_tensor)   (struct ggml_backend_buffer * buffer, struct ggml_tensor * tensor); // post-allocation callback
         void   (*free_tensor)   (struct ggml_backend_buffer * buffer, struct ggml_tensor * tensor); // pre-free callback
-    };
-
-    struct ggml_backend_buffer {
-        struct ggml_backend * backend;
-
-        struct ggml_backend_buffer_i interface;
-
-        ggml_backend_buffer_context_t context;
-
-        size_t size; // GG: can we absorb the size inside the context?
     };
 
     // backend buffer functions
@@ -40,11 +35,14 @@ extern "C" {
     GGML_API void   ggml_backend_buffer_free          (struct ggml_backend_buffer * buffer);
     GGML_API size_t ggml_backend_buffer_get_alignment (struct ggml_backend_buffer * buffer);
     GGML_API void * ggml_backend_buffer_get_base      (struct ggml_backend_buffer * buffer);
+    GGML_API size_t ggml_backend_buffer_get_size      (struct ggml_backend_buffer * buffer);
     GGML_API size_t ggml_backend_buffer_get_alloc_size(struct ggml_backend_buffer * buffer, struct ggml_tensor * tensor);
     GGML_API void   ggml_backend_buffer_init_tensor   (struct ggml_backend_buffer * buffer, struct ggml_tensor * tensor);
     GGML_API void   ggml_backend_buffer_free_tensor   (struct ggml_backend_buffer * buffer, struct ggml_tensor * tensor);
 
+    //
     // backend
+    //
 
     struct ggml_backend_i {
         const char * (*get_name)(struct ggml_backend * backend);
@@ -79,41 +77,37 @@ extern "C" {
         bool (*supports_op)(struct ggml_backend * backend, const struct ggml_tensor * op);
     };
 
-    struct ggml_backend {
-        struct ggml_backend_i interface;
-
-        ggml_backend_context_t context;
-    };
-
     // backend helper functions
-    // TODO: we should move these implementations in the source file
-    static inline struct ggml_backend * ggml_get_backend(const struct ggml_tensor * tensor) { return tensor->buffer->backend; }
+    GGML_API struct ggml_backend * ggml_get_backend(const struct ggml_tensor * tensor);
 
-    static inline const char * ggml_backend_name(struct ggml_backend * backend) { return backend->interface.get_name(backend); }
-    static inline void         ggml_backend_free(struct ggml_backend * backend) { backend->interface.free(backend); }
+    GGML_API const char * ggml_backend_name(struct ggml_backend * backend);
+    GGML_API void         ggml_backend_free(struct ggml_backend * backend);
 
-    static inline struct ggml_backend_buffer * ggml_backend_alloc_buffer(struct ggml_backend * backend, size_t size) { return backend->interface.alloc_buffer(backend, size); }
+    GGML_API struct ggml_backend_buffer * ggml_backend_alloc_buffer(struct ggml_backend * backend, size_t size);
 
-    static inline size_t ggml_backend_get_alignment(struct ggml_backend * backend) { return backend->interface.get_alignment(backend); }
+    GGML_API size_t ggml_backend_get_alignment(struct ggml_backend * backend);
 
-    static inline void ggml_backend_tensor_set_async(      struct ggml_tensor * tensor, const void * data, size_t offset, size_t size) { ggml_get_backend(tensor)->interface.set_tensor_async(ggml_get_backend(tensor), tensor, data, offset, size); }
-    static inline void ggml_backend_tensor_get_async(const struct ggml_tensor * tensor,       void * data, size_t offset, size_t size) { ggml_get_backend(tensor)->interface.get_tensor_async(ggml_get_backend(tensor), tensor, data, offset, size); }
+    GGML_API void ggml_backend_tensor_set_async(      struct ggml_tensor * tensor, const void * data, size_t offset, size_t size);
+    GGML_API void ggml_backend_tensor_get_async(const struct ggml_tensor * tensor,       void * data, size_t offset, size_t size);
 
-    static inline void ggml_backend_tensor_set(      struct ggml_tensor * tensor, const void * data, size_t offset, size_t size) { ggml_get_backend(tensor)->interface.set_tensor_async(ggml_get_backend(tensor), tensor, data, offset, size); ggml_get_backend(tensor)->interface.synchronize(ggml_get_backend(tensor)); }
-    static inline void ggml_backend_tensor_get(const struct ggml_tensor * tensor,       void * data, size_t offset, size_t size) { ggml_get_backend(tensor)->interface.get_tensor_async(ggml_get_backend(tensor), tensor, data, offset, size); ggml_get_backend(tensor)->interface.synchronize(ggml_get_backend(tensor)); }
+    GGML_API void ggml_backend_tensor_set(      struct ggml_tensor * tensor, const void * data, size_t offset, size_t size);
+    GGML_API void ggml_backend_tensor_get(const struct ggml_tensor * tensor,       void * data, size_t offset, size_t size);
 
-    static inline void ggml_backend_synchronize(struct ggml_backend * backend) { backend->interface.synchronize(backend); }
+    GGML_API void ggml_backend_synchronize(struct ggml_backend * backend);
 
-    static inline ggml_backend_plan_t ggml_backend_graph_plan_create (struct ggml_backend * backend, struct ggml_cgraph * cgraph)   { return backend->interface.graph_plan_create(backend, cgraph); }
-    static inline void                ggml_backend_graph_plan_free   (struct ggml_backend * backend, ggml_backend_plan_t plan)      { backend->interface.graph_plan_free(backend, plan); }
-    static inline void                ggml_backend_graph_plan_compute(struct ggml_backend * backend, ggml_backend_plan_t plan)      { backend->interface.graph_plan_compute(backend, plan); }
-    static inline void                ggml_backend_graph_compute     (struct ggml_backend * backend, struct ggml_cgraph * cgraph)   { backend->interface.graph_compute(backend, cgraph); }
-    static inline bool                ggml_backend_supports_op       (struct ggml_backend * backend, const struct ggml_tensor * op) { return backend->interface.supports_op(backend, op); }
+    GGML_API ggml_backend_plan_t ggml_backend_graph_plan_create (struct ggml_backend * backend, struct ggml_cgraph * cgraph);
+    GGML_API void                ggml_backend_graph_plan_free   (struct ggml_backend * backend, ggml_backend_plan_t plan);
+    GGML_API void                ggml_backend_graph_plan_compute(struct ggml_backend * backend, ggml_backend_plan_t plan);
+    GGML_API void                ggml_backend_graph_compute     (struct ggml_backend * backend, struct ggml_cgraph * cgraph);
+    GGML_API bool                ggml_backend_supports_op       (struct ggml_backend * backend, const struct ggml_tensor * op);
 
     // tensor copy between different backends
     GGML_API void ggml_backend_tensor_copy(struct ggml_tensor * src, struct ggml_tensor * dst);
 
+    //
     // CPU backend
+    //
+
     GGML_API struct ggml_backend * ggml_backend_cpu_init(void);
 
     GGML_API void ggml_backend_cpu_set_n_threads(struct ggml_backend * backend_cpu, int n_threads);

--- a/include/ggml/ggml-backend.h
+++ b/include/ggml/ggml-backend.h
@@ -13,80 +13,85 @@ extern "C" {
     typedef void * ggml_backend_graph_plan_t;
     typedef void * ggml_backend_buffer_context_t;
 
+    // avoid accessing internals of these types
+    typedef struct ggml_backend        * ggml_backend_t;
+    typedef struct ggml_backend_buffer * ggml_backend_buffer_t;
+
     //
     // backend buffer
     //
 
     struct ggml_backend_buffer_i {
-        void   (*free_buffer)   (struct ggml_backend_buffer * buffer);
-        void * (*get_base)      (struct ggml_backend_buffer * buffer); // get base pointer
-        size_t (*get_alloc_size)(struct ggml_backend_buffer * buffer, struct ggml_tensor * tensor); // pre-allocation callback
-        void   (*init_tensor)   (struct ggml_backend_buffer * buffer, struct ggml_tensor * tensor); // post-allocation callback
-        void   (*free_tensor)   (struct ggml_backend_buffer * buffer, struct ggml_tensor * tensor); // pre-free callback
+        void   (*free_buffer)   (ggml_backend_buffer_t buffer);
+        void * (*get_base)      (ggml_backend_buffer_t buffer); // get base pointer
+        size_t (*get_alloc_size)(ggml_backend_buffer_t buffer, struct ggml_tensor * tensor); // pre-allocation callback
+        void   (*init_tensor)   (ggml_backend_buffer_t buffer, struct ggml_tensor * tensor); // post-allocation callback
+        void   (*free_tensor)   (ggml_backend_buffer_t buffer, struct ggml_tensor * tensor); // pre-free callback
     };
 
+    // TODO: hide behind API
     struct ggml_backend_buffer {
-        struct ggml_backend * backend;
-
         struct ggml_backend_buffer_i interface;
 
+        ggml_backend_t                backend;
         ggml_backend_buffer_context_t context;
 
         size_t size;
     };
 
     // backend buffer functions
-    GGML_API struct ggml_backend_buffer * ggml_backend_buffer_init(
+    GGML_API ggml_backend_buffer_t ggml_backend_buffer_init(
             struct ggml_backend                  * backend,
             struct ggml_backend_buffer_i           interface,
                    ggml_backend_buffer_context_t   context,
                    size_t                          size);
 
-    GGML_API void   ggml_backend_buffer_free          (struct ggml_backend_buffer * buffer);
-    GGML_API size_t ggml_backend_buffer_get_alignment (struct ggml_backend_buffer * buffer);
-    GGML_API void * ggml_backend_buffer_get_base      (struct ggml_backend_buffer * buffer);
-    GGML_API size_t ggml_backend_buffer_get_size      (struct ggml_backend_buffer * buffer);
-    GGML_API size_t ggml_backend_buffer_get_alloc_size(struct ggml_backend_buffer * buffer, struct ggml_tensor * tensor);
-    GGML_API void   ggml_backend_buffer_init_tensor   (struct ggml_backend_buffer * buffer, struct ggml_tensor * tensor);
-    GGML_API void   ggml_backend_buffer_free_tensor   (struct ggml_backend_buffer * buffer, struct ggml_tensor * tensor);
+    GGML_API void   ggml_backend_buffer_free          (ggml_backend_buffer_t buffer);
+    GGML_API size_t ggml_backend_buffer_get_alignment (ggml_backend_buffer_t buffer);
+    GGML_API void * ggml_backend_buffer_get_base      (ggml_backend_buffer_t buffer);
+    GGML_API size_t ggml_backend_buffer_get_size      (ggml_backend_buffer_t buffer);
+    GGML_API size_t ggml_backend_buffer_get_alloc_size(ggml_backend_buffer_t buffer, struct ggml_tensor * tensor);
+    GGML_API void   ggml_backend_buffer_init_tensor   (ggml_backend_buffer_t buffer, struct ggml_tensor * tensor);
+    GGML_API void   ggml_backend_buffer_free_tensor   (ggml_backend_buffer_t buffer, struct ggml_tensor * tensor);
 
     //
     // backend
     //
 
     struct ggml_backend_i {
-        const char * (*get_name)(struct ggml_backend * backend);
+        const char * (*get_name)(ggml_backend_t backend);
 
-        void (*free)(struct ggml_backend * backend);
+        void (*free)(ggml_backend_t backend);
 
         // buffer allocation
-        struct ggml_backend_buffer * (*alloc_buffer)(struct ggml_backend * backend, size_t size);
+        ggml_backend_buffer_t (*alloc_buffer)(ggml_backend_t backend, size_t size);
 
         // get buffer alignment
-        size_t (*get_alignment)(struct ggml_backend * backend);
+        size_t (*get_alignment)(ggml_backend_t backend);
 
         // tensor data access
         // these functions can be asynchronous, helper functions are provided for synchronous access that automatically call synchronize
-        void (*set_tensor_async)(struct ggml_backend * backend,       struct ggml_tensor * tensor, const void * data, size_t offset, size_t size);
-        void (*get_tensor_async)(struct ggml_backend * backend, const struct ggml_tensor * tensor,       void * data, size_t offset, size_t size);
-        void (*synchronize)     (struct ggml_backend * backend);
+        void (*set_tensor_async)(ggml_backend_t backend,       struct ggml_tensor * tensor, const void * data, size_t offset, size_t size);
+        void (*get_tensor_async)(ggml_backend_t backend, const struct ggml_tensor * tensor,       void * data, size_t offset, size_t size);
+        void (*synchronize)     (ggml_backend_t backend);
 
         // (optional) copy tensor between different backends, allow for single-copy tranfers
-        void (*cpy_tensor_from)(struct ggml_backend * backend, struct ggml_tensor * src, struct ggml_tensor * dst);
-        void (*cpy_tensor_to)  (struct ggml_backend * backend, struct ggml_tensor * src, struct ggml_tensor * dst);
+        void (*cpy_tensor_from)(ggml_backend_t backend, struct ggml_tensor * src, struct ggml_tensor * dst);
+        void (*cpy_tensor_to)  (ggml_backend_t backend, struct ggml_tensor * src, struct ggml_tensor * dst);
 
         // compute graph with a plan
-        ggml_backend_graph_plan_t (*graph_plan_create) (struct ggml_backend * backend, struct ggml_cgraph * cgraph);
-        void                      (*graph_plan_free)   (struct ggml_backend * backend, ggml_backend_graph_plan_t plan);
-        void                      (*graph_plan_compute)(struct ggml_backend * backend, ggml_backend_graph_plan_t plan);
+        ggml_backend_graph_plan_t (*graph_plan_create) (ggml_backend_t backend, struct ggml_cgraph * cgraph);
+        void                      (*graph_plan_free)   (ggml_backend_t backend, ggml_backend_graph_plan_t plan);
+        void                      (*graph_plan_compute)(ggml_backend_t backend, ggml_backend_graph_plan_t plan);
 
         // compute graph without a plan
-        void (*graph_compute)(struct ggml_backend * backend, struct ggml_cgraph * cgraph);
+        void (*graph_compute)(ggml_backend_t backend, struct ggml_cgraph * cgraph);
 
         // check if the backend supports an operation
-        bool (*supports_op)(struct ggml_backend * backend, const struct ggml_tensor * op);
+        bool (*supports_op)(ggml_backend_t backend, const struct ggml_tensor * op);
     };
 
+    // TODO: hide behind API
     struct ggml_backend {
         struct ggml_backend_i interface;
 
@@ -94,14 +99,14 @@ extern "C" {
     };
 
     // backend helper functions
-    GGML_API struct ggml_backend * ggml_get_backend(const struct ggml_tensor * tensor);
+    GGML_API ggml_backend_t ggml_get_backend(const struct ggml_tensor * tensor);
 
-    GGML_API const char * ggml_backend_name(struct ggml_backend * backend);
-    GGML_API void         ggml_backend_free(struct ggml_backend * backend);
+    GGML_API const char * ggml_backend_name(ggml_backend_t backend);
+    GGML_API void         ggml_backend_free(ggml_backend_t backend);
 
-    GGML_API struct ggml_backend_buffer * ggml_backend_alloc_buffer(struct ggml_backend * backend, size_t size);
+    GGML_API ggml_backend_buffer_t ggml_backend_alloc_buffer(ggml_backend_t backend, size_t size);
 
-    GGML_API size_t ggml_backend_get_alignment(struct ggml_backend * backend);
+    GGML_API size_t ggml_backend_get_alignment(ggml_backend_t backend);
 
     GGML_API void ggml_backend_tensor_set_async(      struct ggml_tensor * tensor, const void * data, size_t offset, size_t size);
     GGML_API void ggml_backend_tensor_get_async(const struct ggml_tensor * tensor,       void * data, size_t offset, size_t size);
@@ -109,14 +114,14 @@ extern "C" {
     GGML_API void ggml_backend_tensor_set(      struct ggml_tensor * tensor, const void * data, size_t offset, size_t size);
     GGML_API void ggml_backend_tensor_get(const struct ggml_tensor * tensor,       void * data, size_t offset, size_t size);
 
-    GGML_API void ggml_backend_synchronize(struct ggml_backend * backend);
+    GGML_API void ggml_backend_synchronize(ggml_backend_t backend);
 
-    GGML_API ggml_backend_graph_plan_t ggml_backend_graph_plan_create (struct ggml_backend * backend, struct ggml_cgraph * cgraph);
+    GGML_API ggml_backend_graph_plan_t ggml_backend_graph_plan_create (ggml_backend_t backend, struct ggml_cgraph * cgraph);
 
-    GGML_API void ggml_backend_graph_plan_free   (struct ggml_backend * backend, ggml_backend_graph_plan_t plan);
-    GGML_API void ggml_backend_graph_plan_compute(struct ggml_backend * backend, ggml_backend_graph_plan_t plan);
-    GGML_API void ggml_backend_graph_compute     (struct ggml_backend * backend, struct ggml_cgraph * cgraph);
-    GGML_API bool ggml_backend_supports_op       (struct ggml_backend * backend, const struct ggml_tensor * op);
+    GGML_API void ggml_backend_graph_plan_free   (ggml_backend_t backend, ggml_backend_graph_plan_t plan);
+    GGML_API void ggml_backend_graph_plan_compute(ggml_backend_t backend, ggml_backend_graph_plan_t plan);
+    GGML_API void ggml_backend_graph_compute     (ggml_backend_t backend, struct ggml_cgraph * cgraph);
+    GGML_API bool ggml_backend_supports_op       (ggml_backend_t backend, const struct ggml_tensor * op);
 
     // tensor copy between different backends
     GGML_API void ggml_backend_tensor_copy(struct ggml_tensor * src, struct ggml_tensor * dst);
@@ -125,11 +130,11 @@ extern "C" {
     // CPU backend
     //
 
-    GGML_API struct ggml_backend * ggml_backend_cpu_init(void);
+    GGML_API ggml_backend_t ggml_backend_cpu_init(void);
 
-    GGML_API void ggml_backend_cpu_set_n_threads(struct ggml_backend * backend_cpu, int n_threads);
+    GGML_API void ggml_backend_cpu_set_n_threads(ggml_backend_t backend_cpu, int n_threads);
 
-    GGML_API struct ggml_backend_buffer * ggml_backend_cpu_buffer_from_ptr(void * ptr, size_t size);
+    GGML_API ggml_backend_buffer_t ggml_backend_cpu_buffer_from_ptr(void * ptr, size_t size);
 
     ///////////////////////////
 

--- a/include/ggml/ggml-backend.h
+++ b/include/ggml/ggml-backend.h
@@ -32,7 +32,7 @@ extern "C" {
 
         ggml_backend_buffer_context_t context;
 
-        size_t size; // GG: can we absorb the size inside the context?
+        size_t size;
     };
 
     // backend buffer functions

--- a/include/ggml/ggml-backend.h
+++ b/include/ggml/ggml-backend.h
@@ -5,102 +5,120 @@
 #ifdef  __cplusplus
 extern "C" {
 #endif
-    typedef struct ggml_backend_s * ggml_backend_t;
-
-    // backend buffer
     struct ggml_backend_buffer;
-    typedef struct ggml_backend_buffer * ggml_backend_buffer_t;
-    typedef void * ggml_buffer_context_t;
 
-    struct ggml_backend_buffer_interface {
-        void   (*free_buffer)   (ggml_backend_buffer_t buffer);
-        void * (*get_base)      (ggml_backend_buffer_t buffer); // get base pointer
-        size_t (*get_alloc_size)(ggml_backend_buffer_t buffer, struct ggml_tensor * tensor); // pre-allocation callback
-        void   (*init_tensor)   (ggml_backend_buffer_t buffer, struct ggml_tensor * tensor); // post-allocation callback
-        void   (*free_tensor)   (ggml_backend_buffer_t buffer, struct ggml_tensor * tensor); // pre-free callback
+    // type-erased backend-specific types / wrappers
+    typedef void * ggml_backend_plan_t;
+    typedef void * ggml_backend_context_t;
+    typedef void * ggml_backend_buffer_context_t;
 
+    struct ggml_backend_buffer_i {
+        void   (*free_buffer)   (struct ggml_backend_buffer * buffer);
+        void * (*get_base)      (struct ggml_backend_buffer * buffer); // get base pointer
+        size_t (*get_alloc_size)(struct ggml_backend_buffer * buffer, struct ggml_tensor * tensor); // pre-allocation callback
+        void   (*init_tensor)   (struct ggml_backend_buffer * buffer, struct ggml_tensor * tensor); // post-allocation callback
+        void   (*free_tensor)   (struct ggml_backend_buffer * buffer, struct ggml_tensor * tensor); // pre-free callback
     };
 
     struct ggml_backend_buffer {
-        struct ggml_backend_buffer_interface interface;
-        ggml_backend_t backend;
-        ggml_buffer_context_t context;
-        size_t size;
+        struct ggml_backend * backend;
+
+        struct ggml_backend_buffer_i interface;
+
+        ggml_backend_buffer_context_t context;
+
+        size_t size; // GG: can we absorb the size inside the context?
     };
 
     // backend buffer functions
-    GGML_API ggml_backend_buffer_t ggml_backend_buffer_init(struct ggml_backend_buffer_interface interface, ggml_backend_t backend, ggml_buffer_context_t context, size_t size);
-    GGML_API void   ggml_backend_buffer_free(ggml_backend_buffer_t buffer);
-    GGML_API size_t ggml_backend_buffer_get_alignment(ggml_backend_buffer_t buffer);
-    GGML_API void * ggml_backend_buffer_get_base(ggml_backend_buffer_t buffer);
-    GGML_API size_t ggml_backend_buffer_get_alloc_size(ggml_backend_buffer_t buffer, struct ggml_tensor * tensor);
-    GGML_API void   ggml_backend_buffer_init_tensor(ggml_backend_buffer_t buffer, struct ggml_tensor * tensor);
-    GGML_API void   ggml_backend_buffer_free_tensor(ggml_backend_buffer_t buffer, struct ggml_tensor * tensor);
+    GGML_API struct ggml_backend_buffer * ggml_backend_buffer_init(
+            struct ggml_backend                  * backend,
+            struct ggml_backend_buffer_i           interface,
+                   ggml_backend_buffer_context_t   context,
+                   size_t                          size);
+
+    GGML_API void   ggml_backend_buffer_free          (struct ggml_backend_buffer * buffer);
+    GGML_API size_t ggml_backend_buffer_get_alignment (struct ggml_backend_buffer * buffer);
+    GGML_API void * ggml_backend_buffer_get_base      (struct ggml_backend_buffer * buffer);
+    GGML_API size_t ggml_backend_buffer_get_alloc_size(struct ggml_backend_buffer * buffer, struct ggml_tensor * tensor);
+    GGML_API void   ggml_backend_buffer_init_tensor   (struct ggml_backend_buffer * buffer, struct ggml_tensor * tensor);
+    GGML_API void   ggml_backend_buffer_free_tensor   (struct ggml_backend_buffer * buffer, struct ggml_tensor * tensor);
 
     // backend
-    typedef void * ggml_backend_context_t;
-    typedef void * ggml_graph_plan_t;
 
-    struct ggml_backend_interface {
-        const char * (*get_name)(ggml_backend_t backend);
+    struct ggml_backend_i {
+        const char * (*get_name)(struct ggml_backend * backend);
 
-        void (*free)(ggml_backend_t backend);
+        void (*free)(struct ggml_backend * backend);
 
         // buffer allocation
-        ggml_backend_buffer_t (*alloc_buffer)(ggml_backend_t backend, size_t size);
-        size_t                (*get_alignment)(ggml_backend_t backend);
+        struct ggml_backend_buffer * (*alloc_buffer)(struct ggml_backend * backend, size_t size);
+
+        // get buffer alignment
+        size_t (*get_alignment)(struct ggml_backend * backend);
 
         // tensor data access
         // these functions can be asynchronous, helper functions are provided for synchronous access that automatically call synchronize
-        void (*set_tensor_async)(ggml_backend_t backend, struct ggml_tensor * tensor, const void * data, size_t offset, size_t size);
-        void (*get_tensor_async)(ggml_backend_t backend, const struct ggml_tensor * tensor, void * data, size_t offset, size_t size);
-        void (*synchronize)     (ggml_backend_t backend);
+        void (*set_tensor_async)(struct ggml_backend * backend,       struct ggml_tensor * tensor, const void * data, size_t offset, size_t size);
+        void (*get_tensor_async)(struct ggml_backend * backend, const struct ggml_tensor * tensor,       void * data, size_t offset, size_t size);
+        void (*synchronize)     (struct ggml_backend * backend);
 
         // (optional) copy tensor between different backends, allow for single-copy tranfers
-        void (*cpy_tensor_from)(ggml_backend_t backend, struct ggml_tensor * src, struct ggml_tensor * dst);
-        void (*cpy_tensor_to)  (ggml_backend_t backend, struct ggml_tensor * src, struct ggml_tensor * dst);
+        void (*cpy_tensor_from)(struct ggml_backend * backend, struct ggml_tensor * src, struct ggml_tensor * dst);
+        void (*cpy_tensor_to)  (struct ggml_backend * backend, struct ggml_tensor * src, struct ggml_tensor * dst);
 
         // compute graph with a plan
-        ggml_graph_plan_t (*graph_plan_create) (ggml_backend_t backend, struct ggml_cgraph * cgraph);
-        void              (*graph_plan_free)   (ggml_backend_t backend, ggml_graph_plan_t plan);
-        void              (*graph_plan_compute)(ggml_backend_t backend, ggml_graph_plan_t plan);
+        ggml_backend_plan_t (*graph_plan_create) (struct ggml_backend * backend, struct ggml_cgraph * cgraph);
+        void                (*graph_plan_free)   (struct ggml_backend * backend, ggml_backend_plan_t plan);
+        void                (*graph_plan_compute)(struct ggml_backend * backend, ggml_backend_plan_t plan);
+
         // compute graph without a plan
-        void (*graph_compute)(ggml_backend_t backend, struct ggml_cgraph * cgraph);
+        void (*graph_compute)(struct ggml_backend * backend, struct ggml_cgraph * cgraph);
 
         // check if the backend supports an operation
-        bool (*supports_op)(ggml_backend_t backend, const struct ggml_tensor * op);
+        bool (*supports_op)(struct ggml_backend * backend, const struct ggml_tensor * op);
     };
 
-    struct ggml_backend_s {
-        struct ggml_backend_interface interface;
+    struct ggml_backend {
+        struct ggml_backend_i interface;
+
         ggml_backend_context_t context;
     };
 
     // backend helper functions
-    static inline ggml_backend_t get_backend(const struct ggml_tensor * tensor) { return tensor->buffer->backend; }
+    // TODO: we should move these implementations in the source file
+    static inline struct ggml_backend * ggml_get_backend(const struct ggml_tensor * tensor) { return tensor->buffer->backend; }
 
-    static inline const char * ggml_backend_name(ggml_backend_t backend) { return backend->interface.get_name(backend); }
-    static inline void ggml_backend_free(ggml_backend_t backend) { backend->interface.free(backend); }
-    static inline ggml_backend_buffer_t ggml_backend_alloc_buffer(ggml_backend_t backend, size_t size) { return backend->interface.alloc_buffer(backend, size); }
-    static inline size_t ggml_backend_get_alignment(ggml_backend_t backend) { return backend->interface.get_alignment(backend); }
-    static inline void ggml_backend_tensor_set_async(struct ggml_tensor * tensor, const void * data, size_t offset, size_t size) { get_backend(tensor)->interface.set_tensor_async(get_backend(tensor), tensor, data, offset, size); }
-    static inline void ggml_backend_tensor_get_async(const struct ggml_tensor * tensor, void * data, size_t offset, size_t size) { get_backend(tensor)->interface.get_tensor_async(get_backend(tensor), tensor, data, offset, size); }
-    static inline void ggml_backend_tensor_set(struct ggml_tensor * tensor, const void * data, size_t offset, size_t size) { get_backend(tensor)->interface.set_tensor_async(get_backend(tensor), tensor, data, offset, size); get_backend(tensor)->interface.synchronize(get_backend(tensor)); }
-    static inline void ggml_backend_tensor_get(const struct ggml_tensor * tensor, void * data, size_t offset, size_t size) { get_backend(tensor)->interface.get_tensor_async(get_backend(tensor), tensor, data, offset, size); get_backend(tensor)->interface.synchronize(get_backend(tensor)); }
-    static inline void ggml_backend_synchronize(ggml_backend_t backend) { backend->interface.synchronize(backend); }
-    static inline ggml_graph_plan_t ggml_backend_graph_plan_create(ggml_backend_t backend, struct ggml_cgraph * cgraph) { return backend->interface.graph_plan_create(backend, cgraph); }
-    static inline void ggml_backend_graph_plan_free(ggml_backend_t backend, ggml_graph_plan_t plan) { backend->interface.graph_plan_free(backend, plan); }
-    static inline void ggml_backend_graph_plan_compute(ggml_backend_t backend, ggml_graph_plan_t plan) { backend->interface.graph_plan_compute(backend, plan); }
-    static inline void ggml_backend_graph_compute(ggml_backend_t backend, struct ggml_cgraph * cgraph) { backend->interface.graph_compute(backend, cgraph); }
-    static inline bool ggml_backend_supports_op(ggml_backend_t backend, const struct ggml_tensor * op) { return backend->interface.supports_op(backend, op); }
+    static inline const char * ggml_backend_name(struct ggml_backend * backend) { return backend->interface.get_name(backend); }
+    static inline void         ggml_backend_free(struct ggml_backend * backend) { backend->interface.free(backend); }
+
+    static inline struct ggml_backend_buffer * ggml_backend_alloc_buffer(struct ggml_backend * backend, size_t size) { return backend->interface.alloc_buffer(backend, size); }
+
+    static inline size_t ggml_backend_get_alignment(struct ggml_backend * backend) { return backend->interface.get_alignment(backend); }
+
+    static inline void ggml_backend_tensor_set_async(      struct ggml_tensor * tensor, const void * data, size_t offset, size_t size) { ggml_get_backend(tensor)->interface.set_tensor_async(ggml_get_backend(tensor), tensor, data, offset, size); }
+    static inline void ggml_backend_tensor_get_async(const struct ggml_tensor * tensor,       void * data, size_t offset, size_t size) { ggml_get_backend(tensor)->interface.get_tensor_async(ggml_get_backend(tensor), tensor, data, offset, size); }
+
+    static inline void ggml_backend_tensor_set(      struct ggml_tensor * tensor, const void * data, size_t offset, size_t size) { ggml_get_backend(tensor)->interface.set_tensor_async(ggml_get_backend(tensor), tensor, data, offset, size); ggml_get_backend(tensor)->interface.synchronize(ggml_get_backend(tensor)); }
+    static inline void ggml_backend_tensor_get(const struct ggml_tensor * tensor,       void * data, size_t offset, size_t size) { ggml_get_backend(tensor)->interface.get_tensor_async(ggml_get_backend(tensor), tensor, data, offset, size); ggml_get_backend(tensor)->interface.synchronize(ggml_get_backend(tensor)); }
+
+    static inline void ggml_backend_synchronize(struct ggml_backend * backend) { backend->interface.synchronize(backend); }
+
+    static inline ggml_backend_plan_t ggml_backend_graph_plan_create (struct ggml_backend * backend, struct ggml_cgraph * cgraph)   { return backend->interface.graph_plan_create(backend, cgraph); }
+    static inline void                ggml_backend_graph_plan_free   (struct ggml_backend * backend, ggml_backend_plan_t plan)      { backend->interface.graph_plan_free(backend, plan); }
+    static inline void                ggml_backend_graph_plan_compute(struct ggml_backend * backend, ggml_backend_plan_t plan)      { backend->interface.graph_plan_compute(backend, plan); }
+    static inline void                ggml_backend_graph_compute     (struct ggml_backend * backend, struct ggml_cgraph * cgraph)   { backend->interface.graph_compute(backend, cgraph); }
+    static inline bool                ggml_backend_supports_op       (struct ggml_backend * backend, const struct ggml_tensor * op) { return backend->interface.supports_op(backend, op); }
 
     // tensor copy between different backends
     GGML_API void ggml_backend_tensor_copy(struct ggml_tensor * src, struct ggml_tensor * dst);
 
     // CPU backend
-    GGML_API ggml_backend_t ggml_backend_cpu_init(void);
-    GGML_API void ggml_backend_cpu_set_n_threads(ggml_backend_t backend_cpu, int n_threads);
-    GGML_API ggml_backend_buffer_t ggml_backend_cpu_buffer_from_ptr(void * ptr, size_t size);
+    GGML_API struct ggml_backend * ggml_backend_cpu_init(void);
+
+    GGML_API void ggml_backend_cpu_set_n_threads(struct ggml_backend * backend_cpu, int n_threads);
+
+    GGML_API struct ggml_backend_buffer * ggml_backend_cpu_buffer_from_ptr(void * ptr, size_t size);
 
     ///////////////////////////
 

--- a/include/ggml/ggml.h
+++ b/include/ggml/ggml.h
@@ -326,7 +326,7 @@ extern "C" {
         GGML_TYPE_COUNT,
     };
 
-    enum ggml_backend {
+    enum ggml_backend_type {
         GGML_BACKEND_CPU = 0,
         GGML_BACKEND_GPU = 10,
         GGML_BACKEND_GPU_SPLIT = 20,
@@ -479,8 +479,9 @@ extern "C" {
 
     // n-dimensional tensor
     struct ggml_tensor {
-        enum ggml_type    type;
-        enum ggml_backend backend;
+        enum ggml_type         type;
+        enum ggml_backend_type backend;
+
         struct ggml_backend_buffer * buffer;
 
         int     n_dims;

--- a/src/ggml-alloc.c
+++ b/src/ggml-alloc.c
@@ -62,7 +62,7 @@ struct free_block {
 #define MAX_FREE_BLOCKS 256
 
 struct ggml_allocr {
-    ggml_backend_buffer_t buffer;
+    struct ggml_backend_buffer * buffer;
     bool buffer_owned;
     void * data;
     size_t alignment;

--- a/src/ggml-alloc.c
+++ b/src/ggml-alloc.c
@@ -265,7 +265,7 @@ void ggml_allocr_reset(struct ggml_allocr * alloc) {
     alloc->n_free_blocks = 1;
     size_t align_offset = aligned_offset(alloc->data, 0, alloc->alignment);
     alloc->free_blocks[0].addr = (char *)alloc->data + align_offset;
-    alloc->free_blocks[0].size = alloc->buffer->size - align_offset;
+    alloc->free_blocks[0].size = ggml_backend_buffer_get_size(alloc->buffer) - align_offset;
 }
 
 struct ggml_allocr * ggml_allocr_new(void * data, size_t size, size_t alignment) {

--- a/src/ggml-backend.c
+++ b/src/ggml-backend.c
@@ -11,22 +11,6 @@
 
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 
-struct ggml_backend {
-    struct ggml_backend_i interface;
-
-    ggml_backend_context_t context;
-};
-
-struct ggml_backend_buffer {
-    struct ggml_backend * backend;
-
-    struct ggml_backend_buffer_i interface;
-
-    ggml_backend_buffer_context_t context;
-
-    size_t size; // GG: can we absorb the size inside the context?
-};
-
 // backend buffer
 
 struct ggml_backend_buffer * ggml_backend_buffer_init(
@@ -129,15 +113,15 @@ void ggml_backend_synchronize(struct ggml_backend * backend) {
     backend->interface.synchronize(backend);
 }
 
-ggml_backend_plan_t ggml_backend_graph_plan_create(struct ggml_backend * backend, struct ggml_cgraph * cgraph) {
+ggml_backend_graph_plan_t ggml_backend_graph_plan_create(struct ggml_backend * backend, struct ggml_cgraph * cgraph) {
     return backend->interface.graph_plan_create(backend, cgraph);
 }
 
-void ggml_backend_graph_plan_free(struct ggml_backend * backend, ggml_backend_plan_t plan) {
+void ggml_backend_graph_plan_free(struct ggml_backend * backend, ggml_backend_graph_plan_t plan) {
     backend->interface.graph_plan_free(backend, plan);
 }
 
-void ggml_backend_graph_plan_compute(struct ggml_backend * backend, ggml_backend_plan_t plan) {
+void ggml_backend_graph_plan_compute(struct ggml_backend * backend, ggml_backend_graph_plan_t plan) {
     backend->interface.graph_plan_compute(backend, plan);
 }
 
@@ -296,7 +280,7 @@ struct ggml_backend_plan_cpu {
     struct ggml_cgraph cgraph;
 };
 
-static ggml_backend_plan_t ggml_backend_cpu_graph_plan_create(struct ggml_backend * backend, struct ggml_cgraph * cgraph) {
+static ggml_backend_graph_plan_t ggml_backend_cpu_graph_plan_create(struct ggml_backend * backend, struct ggml_cgraph * cgraph) {
     struct ggml_backend_cpu_context * cpu_ctx = (struct ggml_backend_cpu_context *)backend->context;
 
     struct ggml_backend_plan_cpu * cpu_plan = malloc(sizeof(struct ggml_backend_plan_cpu));
@@ -311,7 +295,7 @@ static ggml_backend_plan_t ggml_backend_cpu_graph_plan_create(struct ggml_backen
     return cpu_plan;
 }
 
-static void ggml_backend_cpu_graph_plan_free(struct ggml_backend * backend, ggml_backend_plan_t plan) {
+static void ggml_backend_cpu_graph_plan_free(struct ggml_backend * backend, ggml_backend_graph_plan_t plan) {
     struct ggml_backend_plan_cpu * cpu_plan = (struct ggml_backend_plan_cpu *)plan;
 
     free(cpu_plan->cplan.work_data);
@@ -320,7 +304,7 @@ static void ggml_backend_cpu_graph_plan_free(struct ggml_backend * backend, ggml
     UNUSED(backend);
 }
 
-static void ggml_backend_cpu_graph_plan_compute(struct ggml_backend * backend, ggml_backend_plan_t plan) {
+static void ggml_backend_cpu_graph_plan_compute(struct ggml_backend * backend, ggml_backend_graph_plan_t plan) {
     struct ggml_backend_plan_cpu * cpu_plan = (struct ggml_backend_plan_cpu *)plan;
 
     ggml_graph_compute(&cpu_plan->cgraph, &cpu_plan->cplan);

--- a/src/ggml-backend.c
+++ b/src/ggml-backend.c
@@ -36,6 +36,7 @@ void ggml_backend_buffer_free(struct ggml_backend_buffer * buffer) {
     if (buffer->interface.free_buffer != NULL) {
         buffer->interface.free_buffer(buffer);
     }
+    free(buffer);
 }
 
 size_t ggml_backend_buffer_get_alignment(struct ggml_backend_buffer * buffer) {

--- a/src/ggml-cuda.cu
+++ b/src/ggml-cuda.cu
@@ -7147,7 +7147,7 @@ void ggml_cuda_transform_tensor(void * data, struct ggml_tensor * tensor) {
 
     const size_t nb1 = tensor->nb[1];
 
-    ggml_backend backend = tensor->backend;
+    ggml_backend_type backend = tensor->backend;
     ggml_tensor_extra_gpu * extra = new struct ggml_tensor_extra_gpu;
     memset(extra, 0, sizeof(*extra));
 
@@ -7525,30 +7525,30 @@ void ggml_cuda_get_device_description(int device, char * description, size_t des
 
 // backend interface
 
-#define UNUSED(x) (void)(x)
+#define UNUSED GGML_UNUSED
 
-struct ggml_backend_cuda_context {
+struct ggml_backend_context_cuda {
 };
 
-static const char * ggml_backend_cuda_name(ggml_backend_t backend) {
+static const char * ggml_backend_cuda_name(struct ggml_backend * backend) {
     return GGML_CUDA_NAME;
 
     UNUSED(backend);
 }
 
-static void ggml_backend_cuda_free(ggml_backend_t backend) {
-    ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *)backend->context;
+static void ggml_backend_cuda_free(struct ggml_backend * backend) {
+    ggml_backend_context_cuda * cuda_ctx = (ggml_backend_context_cuda *)backend->context;
     delete cuda_ctx;
     delete backend;
 }
 
-struct ggml_cuda_buffer_context {
+struct ggml_backend_buffer_context_cuda {
     void * device;
 
     ggml_tensor_extra_gpu * temp_tensor_extras = nullptr;
     size_t temp_tensor_extra_index = 0;
 
-    ~ggml_cuda_buffer_context() {
+    ~ggml_backend_buffer_context_cuda() {
         delete[] temp_tensor_extras;
     }
 
@@ -7566,18 +7566,18 @@ struct ggml_cuda_buffer_context {
     }
 };
 
-static void ggml_backend_cuda_buffer_free_buffer(ggml_backend_buffer_t buffer) {
-    ggml_cuda_buffer_context * ctx = (ggml_cuda_buffer_context *)buffer->context;
+static void ggml_backend_cuda_buffer_free_buffer(struct ggml_backend_buffer * buffer) {
+    ggml_backend_buffer_context_cuda * ctx = (ggml_backend_buffer_context_cuda *)buffer->context;
     CUDA_CHECK(cudaFree(ctx->device));
     delete ctx;
 }
 
-static void * ggml_backend_cuda_buffer_get_base(ggml_backend_buffer_t buffer) {
-    ggml_cuda_buffer_context * ctx = (ggml_cuda_buffer_context *)buffer->context;
+static void * ggml_backend_cuda_buffer_get_base(struct ggml_backend_buffer * buffer) {
+    ggml_backend_buffer_context_cuda * ctx = (ggml_backend_buffer_context_cuda *)buffer->context;
     return ctx->device;
 }
 
-static size_t ggml_backend_cuda_buffer_get_alloc_size(ggml_backend_buffer_t buffer, ggml_tensor * tensor) {
+static size_t ggml_backend_cuda_buffer_get_alloc_size(struct ggml_backend_buffer * buffer, ggml_tensor * tensor) {
     int64_t row_low = 0;
     int64_t row_high = ggml_nrows(tensor);
     int64_t nrows_split = row_high - row_low;
@@ -7596,8 +7596,8 @@ static size_t ggml_backend_cuda_buffer_get_alloc_size(ggml_backend_buffer_t buff
     UNUSED(buffer);
 }
 
-static void ggml_backend_cuda_buffer_init_tensor(ggml_backend_buffer_t buffer, ggml_tensor * tensor) {
-    ggml_cuda_buffer_context * ctx = (ggml_cuda_buffer_context *)buffer->context;
+static void ggml_backend_cuda_buffer_init_tensor(struct ggml_backend_buffer * buffer, ggml_tensor * tensor) {
+    ggml_backend_buffer_context_cuda * ctx = (ggml_backend_buffer_context_cuda *)buffer->context;
     ggml_tensor_extra_gpu * extra = ctx->ggml_cuda_alloc_temp_tensor_extra();
 
     extra->data_device[g_main_device] = tensor->data;
@@ -7624,18 +7624,18 @@ static struct ggml_backend_buffer_interface cuda_backend_buffer_interface = {
     /* .free_tensor    = */ NULL,
 };
 
-static ggml_backend_buffer_t ggml_backend_cuda_alloc_buffer(ggml_backend_t backend, size_t size) {
-    ggml_cuda_buffer_context * ctx = new ggml_cuda_buffer_context;
+static struct ggml_backend_buffer * ggml_backend_cuda_alloc_buffer(struct ggml_backend * backend, size_t size) {
+    ggml_backend_buffer_context_cuda * ctx = new ggml_backend_buffer_context_cuda;
     CUDA_CHECK(cudaMalloc(&ctx->device, size));
-    return ggml_backend_buffer_init(cuda_backend_buffer_interface, backend, ctx, size);
+    return ggml_backend_buffer_init(backend, cuda_backend_buffer_interface, ctx, size);
 }
 
-static size_t ggml_backend_cuda_get_alignment(ggml_backend_t backend) {
+static size_t ggml_backend_cuda_get_alignment(struct ggml_backend * backend) {
     return 128;
     UNUSED(backend);
 }
 
-static void ggml_backend_cuda_set_tensor_async(ggml_backend_t backend, ggml_tensor * tensor, const void * data, size_t offset, size_t size) {
+static void ggml_backend_cuda_set_tensor_async(struct ggml_backend * backend, ggml_tensor * tensor, const void * data, size_t offset, size_t size) {
     GGML_ASSERT(offset + size <= ggml_nbytes(tensor) && "tensor write out of bounds");
     GGML_ASSERT(tensor->data != NULL && "tensor not allocated");
     GGML_ASSERT(tensor->backend == GGML_BACKEND_GPU);
@@ -7645,7 +7645,7 @@ static void ggml_backend_cuda_set_tensor_async(ggml_backend_t backend, ggml_tens
     UNUSED(backend);
 }
 
-static void ggml_backend_cuda_get_tensor_async(ggml_backend_t backend, const ggml_tensor * tensor, void * data, size_t offset, size_t size) {
+static void ggml_backend_cuda_get_tensor_async(struct ggml_backend * backend, const ggml_tensor * tensor, void * data, size_t offset, size_t size) {
     GGML_ASSERT(offset + size <= ggml_nbytes(tensor) && "tensor read out of bounds");
     GGML_ASSERT(tensor->data != NULL && "tensor not allocated");
     GGML_ASSERT(tensor->backend == GGML_BACKEND_GPU);
@@ -7655,13 +7655,13 @@ static void ggml_backend_cuda_get_tensor_async(ggml_backend_t backend, const ggm
     UNUSED(backend);
 }
 
-static void ggml_backend_cuda_synchronize(ggml_backend_t backend) {
+static void ggml_backend_cuda_synchronize(struct ggml_backend * backend) {
     CUDA_CHECK(cudaStreamSynchronize(g_cudaStreams[g_main_device][0]));
 
     UNUSED(backend);
 }
 
-static ggml_graph_plan_t ggml_backend_cuda_graph_plan_create(ggml_backend_t backend, ggml_cgraph * cgraph) {
+static ggml_graph_plan_t ggml_backend_cuda_graph_plan_create(struct ggml_backend * backend, ggml_cgraph * cgraph) {
     GGML_ASSERT(!"not implemented");
 
     return nullptr;
@@ -7670,21 +7670,21 @@ static ggml_graph_plan_t ggml_backend_cuda_graph_plan_create(ggml_backend_t back
     UNUSED(cgraph);
 }
 
-static void ggml_backend_cuda_graph_plan_free(ggml_backend_t backend, ggml_graph_plan_t plan) {
+static void ggml_backend_cuda_graph_plan_free(struct ggml_backend * backend, ggml_graph_plan_t plan) {
     GGML_ASSERT(!"not implemented");
 
     UNUSED(backend);
     UNUSED(plan);
 }
 
-static void ggml_backend_cuda_graph_plan_compute(ggml_backend_t backend, ggml_graph_plan_t plan) {
+static void ggml_backend_cuda_graph_plan_compute(struct ggml_backend * backend, ggml_graph_plan_t plan) {
     GGML_ASSERT(!"not implemented");
 
     UNUSED(backend);
     UNUSED(plan);
 }
 
-static void ggml_backend_cuda_graph_compute(ggml_backend_t backend, ggml_cgraph * cgraph) {
+static void ggml_backend_cuda_graph_compute(struct ggml_backend * backend, ggml_cgraph * cgraph) {
     ggml_compute_params params = {};
     params.type = GGML_TASK_COMPUTE;
     params.ith = 0;
@@ -7738,7 +7738,7 @@ static void ggml_backend_cuda_graph_compute(ggml_backend_t backend, ggml_cgraph 
     UNUSED(backend);
 }
 
-static ggml_backend_interface cuda_backend_interface = {
+static ggml_backend_i cuda_backend_i = {
     /* .get_name            = */ ggml_backend_cuda_name,
     /* .free                = */ ggml_backend_cuda_free,
     /* .alloc_buffer        = */ ggml_backend_cuda_alloc_buffer,
@@ -7755,15 +7755,16 @@ static ggml_backend_interface cuda_backend_interface = {
     /* .supports_op         = */ nullptr,
 };
 
-ggml_backend_t ggml_backend_cuda_init() {
+struct ggml_backend * ggml_backend_cuda_init() {
     ggml_init_cublas(); // TODO: remove from ggml.c
 
-    ggml_backend_cuda_context * ctx = new ggml_backend_cuda_context;
+    ggml_backend_context_cuda * ctx = new ggml_backend_context_cuda;
 
-    ggml_backend_t cuda_backend = new ggml_backend_s;
-    *cuda_backend = (ggml_backend_s){
-        /* .interface = */ cuda_backend_interface,
+    struct ggml_backend * cuda_backend = new ggml_backend;
+    *cuda_backend = (ggml_backend){
+        /* .interface = */ cuda_backend_i,
         /* .context   = */ ctx
     };
+
     return cuda_backend;
 }

--- a/src/ggml-cuda.cu
+++ b/src/ggml-cuda.cu
@@ -7530,13 +7530,13 @@ void ggml_cuda_get_device_description(int device, char * description, size_t des
 struct ggml_backend_context_cuda {
 };
 
-static const char * ggml_backend_cuda_name(struct ggml_backend * backend) {
+static const char * ggml_backend_cuda_name(ggml_backend_t backend) {
     return GGML_CUDA_NAME;
 
     UNUSED(backend);
 }
 
-static void ggml_backend_cuda_free(struct ggml_backend * backend) {
+static void ggml_backend_cuda_free(ggml_backend_t backend) {
     ggml_backend_context_cuda * cuda_ctx = (ggml_backend_context_cuda *)backend->context;
     delete cuda_ctx;
     delete backend;
@@ -7566,18 +7566,18 @@ struct ggml_backend_buffer_context_cuda {
     }
 };
 
-static void ggml_backend_cuda_buffer_free_buffer(struct ggml_backend_buffer * buffer) {
+static void ggml_backend_cuda_buffer_free_buffer(ggml_backend_buffer_t buffer) {
     ggml_backend_buffer_context_cuda * ctx = (ggml_backend_buffer_context_cuda *)buffer->context;
     CUDA_CHECK(cudaFree(ctx->device));
     delete ctx;
 }
 
-static void * ggml_backend_cuda_buffer_get_base(struct ggml_backend_buffer * buffer) {
+static void * ggml_backend_cuda_buffer_get_base(ggml_backend_buffer_t buffer) {
     ggml_backend_buffer_context_cuda * ctx = (ggml_backend_buffer_context_cuda *)buffer->context;
     return ctx->device;
 }
 
-static size_t ggml_backend_cuda_buffer_get_alloc_size(struct ggml_backend_buffer * buffer, ggml_tensor * tensor) {
+static size_t ggml_backend_cuda_buffer_get_alloc_size(ggml_backend_buffer_t buffer, ggml_tensor * tensor) {
     int64_t row_low = 0;
     int64_t row_high = ggml_nrows(tensor);
     int64_t nrows_split = row_high - row_low;
@@ -7596,7 +7596,7 @@ static size_t ggml_backend_cuda_buffer_get_alloc_size(struct ggml_backend_buffer
     UNUSED(buffer);
 }
 
-static void ggml_backend_cuda_buffer_init_tensor(struct ggml_backend_buffer * buffer, ggml_tensor * tensor) {
+static void ggml_backend_cuda_buffer_init_tensor(ggml_backend_buffer_t buffer, ggml_tensor * tensor) {
     ggml_backend_buffer_context_cuda * ctx = (ggml_backend_buffer_context_cuda *)buffer->context;
     ggml_tensor_extra_gpu * extra = ctx->ggml_cuda_alloc_temp_tensor_extra();
 
@@ -7624,18 +7624,18 @@ static struct ggml_backend_buffer_i cuda_backend_buffer_interface = {
     /* .free_tensor    = */ NULL,
 };
 
-static struct ggml_backend_buffer * ggml_backend_cuda_alloc_buffer(struct ggml_backend * backend, size_t size) {
+static ggml_backend_buffer_t ggml_backend_cuda_alloc_buffer(ggml_backend_t backend, size_t size) {
     ggml_backend_buffer_context_cuda * ctx = new ggml_backend_buffer_context_cuda;
     CUDA_CHECK(cudaMalloc(&ctx->device, size));
     return ggml_backend_buffer_init(backend, cuda_backend_buffer_interface, ctx, size);
 }
 
-static size_t ggml_backend_cuda_get_alignment(struct ggml_backend * backend) {
+static size_t ggml_backend_cuda_get_alignment(ggml_backend_t backend) {
     return 128;
     UNUSED(backend);
 }
 
-static void ggml_backend_cuda_set_tensor_async(struct ggml_backend * backend, ggml_tensor * tensor, const void * data, size_t offset, size_t size) {
+static void ggml_backend_cuda_set_tensor_async(ggml_backend_t backend, ggml_tensor * tensor, const void * data, size_t offset, size_t size) {
     GGML_ASSERT(offset + size <= ggml_nbytes(tensor) && "tensor write out of bounds");
     GGML_ASSERT(tensor->data != NULL && "tensor not allocated");
     GGML_ASSERT(tensor->backend == GGML_BACKEND_GPU);
@@ -7645,7 +7645,7 @@ static void ggml_backend_cuda_set_tensor_async(struct ggml_backend * backend, gg
     UNUSED(backend);
 }
 
-static void ggml_backend_cuda_get_tensor_async(struct ggml_backend * backend, const ggml_tensor * tensor, void * data, size_t offset, size_t size) {
+static void ggml_backend_cuda_get_tensor_async(ggml_backend_t backend, const ggml_tensor * tensor, void * data, size_t offset, size_t size) {
     GGML_ASSERT(offset + size <= ggml_nbytes(tensor) && "tensor read out of bounds");
     GGML_ASSERT(tensor->data != NULL && "tensor not allocated");
     GGML_ASSERT(tensor->backend == GGML_BACKEND_GPU);
@@ -7655,13 +7655,13 @@ static void ggml_backend_cuda_get_tensor_async(struct ggml_backend * backend, co
     UNUSED(backend);
 }
 
-static void ggml_backend_cuda_synchronize(struct ggml_backend * backend) {
+static void ggml_backend_cuda_synchronize(ggml_backend_t backend) {
     CUDA_CHECK(cudaStreamSynchronize(g_cudaStreams[g_main_device][0]));
 
     UNUSED(backend);
 }
 
-static ggml_backend_graph_plan_t ggml_backend_cuda_graph_plan_create(struct ggml_backend * backend, ggml_cgraph * cgraph) {
+static ggml_backend_graph_plan_t ggml_backend_cuda_graph_plan_create(ggml_backend_t backend, ggml_cgraph * cgraph) {
     GGML_ASSERT(!"not implemented");
 
     return nullptr;
@@ -7670,21 +7670,21 @@ static ggml_backend_graph_plan_t ggml_backend_cuda_graph_plan_create(struct ggml
     UNUSED(cgraph);
 }
 
-static void ggml_backend_cuda_graph_plan_free(struct ggml_backend * backend, ggml_backend_graph_plan_t plan) {
+static void ggml_backend_cuda_graph_plan_free(ggml_backend_t backend, ggml_backend_graph_plan_t plan) {
     GGML_ASSERT(!"not implemented");
 
     UNUSED(backend);
     UNUSED(plan);
 }
 
-static void ggml_backend_cuda_graph_plan_compute(struct ggml_backend * backend, ggml_backend_graph_plan_t plan) {
+static void ggml_backend_cuda_graph_plan_compute(ggml_backend_t backend, ggml_backend_graph_plan_t plan) {
     GGML_ASSERT(!"not implemented");
 
     UNUSED(backend);
     UNUSED(plan);
 }
 
-static void ggml_backend_cuda_graph_compute(struct ggml_backend * backend, ggml_cgraph * cgraph) {
+static void ggml_backend_cuda_graph_compute(ggml_backend_t backend, ggml_cgraph * cgraph) {
     ggml_compute_params params = {};
     params.type = GGML_TASK_COMPUTE;
     params.ith = 0;
@@ -7755,12 +7755,12 @@ static ggml_backend_i cuda_backend_i = {
     /* .supports_op         = */ nullptr,
 };
 
-struct ggml_backend * ggml_backend_cuda_init() {
+ggml_backend_t ggml_backend_cuda_init() {
     ggml_init_cublas(); // TODO: remove from ggml.c
 
     ggml_backend_context_cuda * ctx = new ggml_backend_context_cuda;
 
-    struct ggml_backend * cuda_backend = new ggml_backend;
+    ggml_backend_t cuda_backend = new ggml_backend;
     *cuda_backend = (ggml_backend){
         /* .interface = */ cuda_backend_i,
         /* .context   = */ ctx

--- a/src/ggml-cuda.cu
+++ b/src/ggml-cuda.cu
@@ -7616,7 +7616,7 @@ static void ggml_backend_cuda_buffer_init_tensor(struct ggml_backend_buffer * bu
     UNUSED(buffer);
 }
 
-static struct ggml_backend_buffer_interface cuda_backend_buffer_interface = {
+static struct ggml_backend_buffer_i cuda_backend_buffer_interface = {
     /* .free_buffer    = */ ggml_backend_cuda_buffer_free_buffer,
     /* .get_base       = */ ggml_backend_cuda_buffer_get_base,
     /* .get_alloc_size = */ ggml_backend_cuda_buffer_get_alloc_size,
@@ -7661,7 +7661,7 @@ static void ggml_backend_cuda_synchronize(struct ggml_backend * backend) {
     UNUSED(backend);
 }
 
-static ggml_graph_plan_t ggml_backend_cuda_graph_plan_create(struct ggml_backend * backend, ggml_cgraph * cgraph) {
+static ggml_backend_graph_plan_t ggml_backend_cuda_graph_plan_create(struct ggml_backend * backend, ggml_cgraph * cgraph) {
     GGML_ASSERT(!"not implemented");
 
     return nullptr;
@@ -7670,14 +7670,14 @@ static ggml_graph_plan_t ggml_backend_cuda_graph_plan_create(struct ggml_backend
     UNUSED(cgraph);
 }
 
-static void ggml_backend_cuda_graph_plan_free(struct ggml_backend * backend, ggml_graph_plan_t plan) {
+static void ggml_backend_cuda_graph_plan_free(struct ggml_backend * backend, ggml_backend_graph_plan_t plan) {
     GGML_ASSERT(!"not implemented");
 
     UNUSED(backend);
     UNUSED(plan);
 }
 
-static void ggml_backend_cuda_graph_plan_compute(struct ggml_backend * backend, ggml_graph_plan_t plan) {
+static void ggml_backend_cuda_graph_plan_compute(struct ggml_backend * backend, ggml_backend_graph_plan_t plan) {
     GGML_ASSERT(!"not implemented");
 
     UNUSED(backend);

--- a/src/ggml-cuda.h
+++ b/src/ggml-cuda.h
@@ -44,7 +44,7 @@ GGML_API int    ggml_cuda_get_device_count(void);
 GGML_API void   ggml_cuda_get_device_description(int device, char * description, size_t description_size);
 
 // backend API
-GGML_API ggml_backend_t ggml_backend_cuda_init(void); // TODO: take a list of devices to use
+GGML_API struct ggml_backend * ggml_backend_cuda_init(void); // TODO: take a list of devices to use
 
 
 #ifdef  __cplusplus

--- a/src/ggml-cuda.h
+++ b/src/ggml-cuda.h
@@ -44,7 +44,7 @@ GGML_API int    ggml_cuda_get_device_count(void);
 GGML_API void   ggml_cuda_get_device_description(int device, char * description, size_t description_size);
 
 // backend API
-GGML_API struct ggml_backend * ggml_backend_cuda_init(void); // TODO: take a list of devices to use
+GGML_API ggml_backend_t ggml_backend_cuda_init(void); // TODO: take a list of devices to use
 
 
 #ifdef  __cplusplus


### PR DESCRIPTION
@slaren I'm still reviewing - will continue after lunch

Here are some suggestions about normalizing the style to be more inline with the core `ggml` implementation.
Let me know if you agree.

Main changes are:
- more systematic prefixes (i.e. `ggml_buffer_context_t` -> `ggml_backend_buffer_context_t`
- avoid `typedef` for `struct *` - I prefer to have the type spelled out