### PR TITLE
fix MSVC build issues

### DIFF
--- a/examples/whisper/CMakeLists.txt
+++ b/examples/whisper/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # whisper
 
-add_library(whisper-cpp
+add_library(whisper-cpp STATIC
     whisper.cpp
     )
 

--- a/include/ggml/ggml-backend.h
+++ b/include/ggml/ggml-backend.h
@@ -31,7 +31,7 @@ extern "C" {
 
     // TODO: hide behind API
     struct ggml_backend_buffer {
-        struct ggml_backend_buffer_i interface;
+        struct ggml_backend_buffer_i iface;
 
         ggml_backend_t                backend;
         ggml_backend_buffer_context_t context;
@@ -42,7 +42,7 @@ extern "C" {
     // backend buffer functions
     GGML_API ggml_backend_buffer_t ggml_backend_buffer_init(
             struct ggml_backend                  * backend,
-            struct ggml_backend_buffer_i           interface,
+            struct ggml_backend_buffer_i           iface,
                    ggml_backend_buffer_context_t   context,
                    size_t                          size);
 
@@ -93,7 +93,7 @@ extern "C" {
 
     // TODO: hide behind API
     struct ggml_backend {
-        struct ggml_backend_i interface;
+        struct ggml_backend_i iface;
 
         ggml_backend_context_t context;
     };

--- a/include/ggml/ggml.h
+++ b/include/ggml/ggml.h
@@ -1360,7 +1360,7 @@ extern "C" {
 
     // alibi position embedding
     // in-place, returns view(a)
-    struct ggml_tensor * ggml_alibi(
+    GGML_API struct ggml_tensor * ggml_alibi(
             struct ggml_context * ctx,
             struct ggml_tensor  * a,
             int                   n_past,
@@ -1369,7 +1369,7 @@ extern "C" {
 
     // clamp
     // in-place, returns view(a)
-    struct ggml_tensor * ggml_clamp(
+    GGML_API struct ggml_tensor * ggml_clamp(
             struct ggml_context * ctx,
             struct ggml_tensor  * a,
             float                 min,
@@ -2104,7 +2104,7 @@ extern "C" {
         enum ggml_type    vec_dot_type;
     } ggml_type_traits_t;
 
-    ggml_type_traits_t ggml_internal_get_type_traits(enum ggml_type type);
+    GGML_API ggml_type_traits_t ggml_internal_get_type_traits(enum ggml_type type);
 
 #ifdef  __cplusplus
 }

--- a/src/ggml-backend.c
+++ b/src/ggml-backend.c
@@ -15,15 +15,15 @@
 
 ggml_backend_buffer_t ggml_backend_buffer_init(
         struct ggml_backend                  * backend,
-        struct ggml_backend_buffer_i           interface,
+        struct ggml_backend_buffer_i           iface,
                ggml_backend_buffer_context_t   context,
                size_t                          size) {
     ggml_backend_buffer_t buffer = malloc(sizeof(struct ggml_backend_buffer));
 
-    GGML_ASSERT(interface.get_base != NULL);
+    GGML_ASSERT(iface.get_base != NULL);
 
     (*buffer) = (struct ggml_backend_buffer) {
-        /* .interface = */ interface,
+        /* .interface = */ iface,
         /* .backend   = */ backend,
         /* .context   = */ context,
         /* .size      = */ size,
@@ -33,8 +33,8 @@ ggml_backend_buffer_t ggml_backend_buffer_init(
 }
 
 void ggml_backend_buffer_free(ggml_backend_buffer_t buffer) {
-    if (buffer->interface.free_buffer != NULL) {
-        buffer->interface.free_buffer(buffer);
+    if (buffer->iface.free_buffer != NULL) {
+        buffer->iface.free_buffer(buffer);
     }
     free(buffer);
 }
@@ -44,7 +44,7 @@ size_t ggml_backend_buffer_get_alignment(ggml_backend_buffer_t buffer) {
 }
 
 void * ggml_backend_buffer_get_base(ggml_backend_buffer_t buffer) {
-    return buffer->interface.get_base(buffer);
+    return buffer->iface.get_base(buffer);
 }
 
 size_t ggml_backend_buffer_get_size(ggml_backend_buffer_t buffer) {
@@ -52,21 +52,21 @@ size_t ggml_backend_buffer_get_size(ggml_backend_buffer_t buffer) {
 }
 
 size_t ggml_backend_buffer_get_alloc_size(ggml_backend_buffer_t buffer, struct ggml_tensor * tensor) {
-    if (buffer->interface.get_alloc_size) {
-        return buffer->interface.get_alloc_size(buffer, tensor);
+    if (buffer->iface.get_alloc_size) {
+        return buffer->iface.get_alloc_size(buffer, tensor);
     }
     return ggml_nbytes(tensor);
 }
 
 void ggml_backend_buffer_init_tensor(ggml_backend_buffer_t buffer, struct ggml_tensor * tensor) {
-    if (buffer->interface.init_tensor) {
-        buffer->interface.init_tensor(buffer, tensor);
+    if (buffer->iface.init_tensor) {
+        buffer->iface.init_tensor(buffer, tensor);
     }
 }
 
 void ggml_backend_buffer_free_tensor(ggml_backend_buffer_t buffer, struct ggml_tensor * tensor) {
-    if (buffer->interface.free_tensor) {
-        buffer->interface.free_tensor(buffer, tensor);
+    if (buffer->iface.free_tensor) {
+        buffer->iface.free_tensor(buffer, tensor);
     }
 }
 
@@ -77,61 +77,61 @@ ggml_backend_t ggml_get_backend(const struct ggml_tensor * tensor) {
 }
 
 const char * ggml_backend_name(ggml_backend_t backend) {
-    return backend->interface.get_name(backend);
+    return backend->iface.get_name(backend);
 }
 
 void ggml_backend_free(ggml_backend_t backend) {
-    backend->interface.free(backend);
+    backend->iface.free(backend);
 }
 
 ggml_backend_buffer_t ggml_backend_alloc_buffer(ggml_backend_t backend, size_t size) {
-    return backend->interface.alloc_buffer(backend, size);
+    return backend->iface.alloc_buffer(backend, size);
 }
 
 size_t ggml_backend_get_alignment(ggml_backend_t backend) {
-    return backend->interface.get_alignment(backend);
+    return backend->iface.get_alignment(backend);
 }
 
 void ggml_backend_tensor_set_async(struct ggml_tensor * tensor, const void * data, size_t offset, size_t size) {
-    ggml_get_backend(tensor)->interface.set_tensor_async(ggml_get_backend(tensor), tensor, data, offset, size);
+    ggml_get_backend(tensor)->iface.set_tensor_async(ggml_get_backend(tensor), tensor, data, offset, size);
 }
 
 void ggml_backend_tensor_get_async(const struct ggml_tensor * tensor, void * data, size_t offset, size_t size) {
-    ggml_get_backend(tensor)->interface.get_tensor_async(ggml_get_backend(tensor), tensor, data, offset, size);
+    ggml_get_backend(tensor)->iface.get_tensor_async(ggml_get_backend(tensor), tensor, data, offset, size);
 }
 
 void ggml_backend_tensor_set(struct ggml_tensor * tensor, const void * data, size_t offset, size_t size) {
-    ggml_get_backend(tensor)->interface.set_tensor_async(ggml_get_backend(tensor), tensor, data, offset, size);
-    ggml_get_backend(tensor)->interface.synchronize(ggml_get_backend(tensor));
+    ggml_get_backend(tensor)->iface.set_tensor_async(ggml_get_backend(tensor), tensor, data, offset, size);
+    ggml_get_backend(tensor)->iface.synchronize(ggml_get_backend(tensor));
 }
 
 void ggml_backend_tensor_get(const struct ggml_tensor * tensor, void * data, size_t offset, size_t size) {
-    ggml_get_backend(tensor)->interface.get_tensor_async(ggml_get_backend(tensor), tensor, data, offset, size);
-    ggml_get_backend(tensor)->interface.synchronize(ggml_get_backend(tensor));
+    ggml_get_backend(tensor)->iface.get_tensor_async(ggml_get_backend(tensor), tensor, data, offset, size);
+    ggml_get_backend(tensor)->iface.synchronize(ggml_get_backend(tensor));
 }
 
 void ggml_backend_synchronize(ggml_backend_t backend) {
-    backend->interface.synchronize(backend);
+    backend->iface.synchronize(backend);
 }
 
 ggml_backend_graph_plan_t ggml_backend_graph_plan_create(ggml_backend_t backend, struct ggml_cgraph * cgraph) {
-    return backend->interface.graph_plan_create(backend, cgraph);
+    return backend->iface.graph_plan_create(backend, cgraph);
 }
 
 void ggml_backend_graph_plan_free(ggml_backend_t backend, ggml_backend_graph_plan_t plan) {
-    backend->interface.graph_plan_free(backend, plan);
+    backend->iface.graph_plan_free(backend, plan);
 }
 
 void ggml_backend_graph_plan_compute(ggml_backend_t backend, ggml_backend_graph_plan_t plan) {
-    backend->interface.graph_plan_compute(backend, plan);
+    backend->iface.graph_plan_compute(backend, plan);
 }
 
 void ggml_backend_graph_compute(ggml_backend_t backend, struct ggml_cgraph * cgraph) {
-    backend->interface.graph_compute(backend, cgraph);
+    backend->iface.graph_compute(backend, cgraph);
 }
 
 bool ggml_backend_supports_op(ggml_backend_t backend, const struct ggml_tensor * op) {
-    return backend->interface.supports_op(backend, op);
+    return backend->iface.supports_op(backend, op);
 }
 
 // backend copy
@@ -164,10 +164,10 @@ void ggml_backend_tensor_copy(struct ggml_tensor * src, struct ggml_tensor * dst
 
     // TODO: allow backends to support copy to/from same backend
 
-    if (ggml_get_backend(dst)->interface.cpy_tensor_from != NULL) {
-        ggml_get_backend(dst)->interface.cpy_tensor_from(ggml_get_backend(dst)->context, src, dst);
-    } else if (ggml_get_backend(src)->interface.cpy_tensor_to != NULL) {
-        ggml_get_backend(src)->interface.cpy_tensor_to(ggml_get_backend(src)->context, src, dst);
+    if (ggml_get_backend(dst)->iface.cpy_tensor_from != NULL) {
+        ggml_get_backend(dst)->iface.cpy_tensor_from(ggml_get_backend(dst)->context, src, dst);
+    } else if (ggml_get_backend(src)->iface.cpy_tensor_to != NULL) {
+        ggml_get_backend(src)->iface.cpy_tensor_to(ggml_get_backend(src)->context, src, dst);
     } else {
         // shouldn't be hit when copying from/to CPU
         #ifndef NDEBUG
@@ -370,7 +370,7 @@ ggml_backend_t ggml_backend_cpu_init(void) {
 }
 
 bool ggml_backend_is_cpu(ggml_backend_t backend) {
-    return backend->interface.get_name == ggml_backend_cpu_name;
+    return backend->iface.get_name == ggml_backend_cpu_name;
 }
 
 void ggml_backend_cpu_set_n_threads(ggml_backend_t backend_cpu, int n_threads) {

--- a/src/ggml-cuda.cu
+++ b/src/ggml-cuda.cu
@@ -7640,6 +7640,8 @@ static struct ggml_backend_buffer_i cuda_backend_buffer_interface = {
 };
 
 static ggml_backend_buffer_t ggml_backend_cuda_alloc_buffer(ggml_backend_t backend, size_t size) {
+    ggml_cuda_set_device(g_main_device);
+
     ggml_backend_buffer_context_cuda * ctx = new ggml_backend_buffer_context_cuda;
     CUDA_CHECK(cudaMalloc(&ctx->device, size));
     return ggml_backend_buffer_init(backend, cuda_backend_buffer_interface, ctx, size);
@@ -7700,6 +7702,8 @@ static void ggml_backend_cuda_graph_plan_compute(ggml_backend_t backend, ggml_ba
 }
 
 static void ggml_backend_cuda_graph_compute(ggml_backend_t backend, ggml_cgraph * cgraph) {
+    ggml_cuda_set_device(g_main_device);
+
     ggml_compute_params params = {};
     params.type = GGML_TASK_COMPUTE;
     params.ith = 0;
@@ -7768,8 +7772,7 @@ ggml_backend_t ggml_backend_cuda_init() {
 
     ggml_backend_context_cuda * ctx = new ggml_backend_context_cuda;
 
-    ggml_backend_t cuda_backend = new ggml_backend;
-    *cuda_backend = (ggml_backend){
+    ggml_backend_t cuda_backend = new ggml_backend {
         /* .interface = */ cuda_backend_i,
         /* .context   = */ ctx
     };

--- a/src/ggml-metal.m
+++ b/src/ggml-metal.m
@@ -1498,7 +1498,7 @@ ggml_backend_t ggml_backend_metal_init(void) {
 }
 
 bool ggml_backend_is_metal(ggml_backend_t backend) {
-    return backend->interface.get_name == ggml_backend_metal_name;
+    return backend->iface.get_name == ggml_backend_metal_name;
 }
 
 void ggml_backend_metal_set_n_cb(ggml_backend_t backend, int n_cb) {


### PR DESCRIPTION
Fixes:
- Remove `struct` literal in C++ code in `ggml-cuda`
- `interface` in `ggml-backend` is a reserved word in MSVC, renamed to `iface`
- Some `ggml.h` functions were missing `GGML_API`, and were not being exported in dynamic library builds
- `whisper-cpp` link failed due to being built as a dynamic library without exported symbols, changed to static library
- Issues with multiple GPU in the `ggml-backend` implementation of `ggml-cuda`