### PR TITLE
Disable ggml-alloc assert for views without buffer when using ggml-backend API

### DIFF
--- a/src/ggml-alloc.c
+++ b/src/ggml-alloc.c
@@ -386,7 +386,7 @@ static void init_view(struct ggml_allocr * alloc, struct ggml_tensor * view) {
 
     // FIXME: the view should be initialized by the owning buffer, but currently this breaks the CUDA backend
     // due to the ggml_tensor_extra_gpu ring buffer overwriting the KV cache extras
-    assert(ggml_allocr_is_measure(alloc) || view->buffer->backend == alloc->buffer->backend);
+    assert(ggml_allocr_is_measure(alloc) || !view->buffer || view->buffer->backend == alloc->buffer->backend);
     ggml_backend_buffer_init_tensor(alloc->buffer, view);
 }
 


### PR DESCRIPTION
I hit this assert while testing the ggml-backend CPU version of Sam.cpp