### PR TITLE
`fix`: memset dst to 0 in `ggml_conv_transpose_1d`

### DIFF
--- a/src/ggml.c
+++ b/src/ggml.c
@@ -14850,6 +14850,8 @@ static void ggml_compute_forward_conv_transpose_2d(
             }
         }
 
+        memset(dst->data, 0, ggml_nbytes(dst));
+
         return;
     }
 

--- a/src/ggml.c
+++ b/src/ggml.c
@@ -14315,6 +14315,9 @@ static void ggml_compute_forward_conv_transpose_1d_f16_f32(
             }
         }
 
+        // need to zero dst since we are accumulating into it
+        memset(dst->data, 0, ggml_nbytes(dst));
+
         return;
     }
 
@@ -14405,6 +14408,9 @@ static void ggml_compute_forward_conv_transpose_1d_f32(
                 }
             }
         }
+
+        // need to zero dst since we are accumulating into it
+        memset(dst->data, 0, ggml_nbytes(dst));
 
         return;
     }

--- a/src/ggml.c
+++ b/src/ggml.c
@@ -14387,7 +14387,7 @@ static void ggml_compute_forward_conv_transpose_1d_f32(
                     const float * const src = (float *)((char *) src0->data + i02*nb02 + i01*nb01);
                     float * dst_data = wdata + i01*ne00*ne02;
                     for (int64_t i00 = 0; i00 < ne00; i00++) {
-                        dst_data[i01*ne00*ne02 + i00*ne02 + i02] = src[i00];
+                        dst_data[i00*ne02 + i02] = src[i00];
                     }
                 }
             }


### PR DESCRIPTION
I came across a nasty bug in the Encodec.cpp library using `ggml_conv_transpose_1d`.

If the `dst->data` is not `memset` to 0, pre-existing values can be stored there, resulting in the wrong output.
This is due to the fact that values are accumulated into `dst->data`: `dst_data[i10*s0 + i00] += v;`.

This PR introduces two fixes: 
- [x] `memset` of `dst->data` to 0
- [x] Fix wrong indexation of `wdata` buffer in `ggml_compute_forward_conv_transpose_1d_f32`.