### PR TITLE
update examples and tests to use ggml_allocr_new_measure_from_backend

### DIFF
--- a/examples/gpt-2/main-backend.cpp
+++ b/examples/gpt-2/main-backend.cpp
@@ -878,7 +878,7 @@ int main(int argc, char ** argv) {
     struct ggml_allocr * allocr = NULL;
     // allocate the compute buffer
     {
-         // alignment required by the backend
+        // create an allocator to measure the memory usage
         allocr = ggml_allocr_new_measure_from_backend(model.backend);
 
         // create the worst case graph for memory usage estimation

--- a/examples/gpt-2/main-backend.cpp
+++ b/examples/gpt-2/main-backend.cpp
@@ -879,8 +879,7 @@ int main(int argc, char ** argv) {
     // allocate the compute buffer
     {
          // alignment required by the backend
-        size_t align = ggml_backend_get_alignment(model.backend);
-        allocr = ggml_allocr_new_measure(align);
+        allocr = ggml_allocr_new_measure_from_backend(model.backend);
 
         // create the worst case graph for memory usage estimation
         int n_tokens = std::min(model.hparams.n_ctx, params.n_batch);

--- a/examples/gpt-2/main-batched.cpp
+++ b/examples/gpt-2/main-batched.cpp
@@ -1043,8 +1043,7 @@ int main(int argc, char ** argv) {
     struct ggml_allocr * allocr = NULL;
     {
         // alignment required by the backend
-        size_t align = ggml_backend_get_alignment(model.backend);
-        allocr = ggml_allocr_new_measure(align);
+        allocr = ggml_allocr_new_measure_from_backend(model.backend);
 
         batch.n_tokens = n_batch_max;
 

--- a/examples/gpt-2/main-batched.cpp
+++ b/examples/gpt-2/main-batched.cpp
@@ -1042,7 +1042,7 @@ int main(int argc, char ** argv) {
     // prepare required memory and allocate the compute buffer
     struct ggml_allocr * allocr = NULL;
     {
-        // alignment required by the backend
+        // create an allocator to measure the memory usage
         allocr = ggml_allocr_new_measure_from_backend(model.backend);
 
         batch.n_tokens = n_batch_max;

--- a/tests/test-conv1d.cpp
+++ b/tests/test-conv1d.cpp
@@ -204,8 +204,7 @@ int main(void)
     struct ggml_allocr * allocr = NULL;
 
     {
-        size_t align = ggml_backend_get_alignment(model.backend);
-        allocr = ggml_allocr_new_measure(align);
+        allocr = ggml_allocr_new_measure_from_backend(model.backend);
 
         //create the worst case graph for memory usage estimation
         struct ggml_cgraph * gf = build_graph(model, allocr);

--- a/tests/test-conv2d.cpp
+++ b/tests/test-conv2d.cpp
@@ -208,8 +208,7 @@ int main(void)
     struct ggml_allocr * allocr = NULL;
 
     {
-        size_t align = ggml_backend_get_alignment(model.backend);
-        allocr = ggml_allocr_new_measure(align);
+        allocr = ggml_allocr_new_measure_from_backend(model.backend);
 
         //create the worst case graph for memory usage estimation
         struct ggml_cgraph * gf = build_graph(model, allocr);

--- a/tests/test-mul-mat.cpp
+++ b/tests/test-mul-mat.cpp
@@ -314,8 +314,7 @@ int main(void)
     struct ggml_allocr * allocr = NULL;
 
     {
-        size_t align = ggml_backend_get_alignment(model.backend);
-        allocr = ggml_allocr_new_measure(align);
+        allocr = ggml_allocr_new_measure_from_backend(model.backend);
 
         //create the worst case graph for memory usage estimation
         struct ggml_cgraph * gf = build_graph(model, allocr);


### PR DESCRIPTION
`ggml_allocr_new_measure_from_backend` was added in v2 to handle alignment and padding requirements of the backends with ggml-alloc measure allocators, but the examples and tests were not updated to use it.