### PR TITLE
ggml-backend update: buffer types, backend registry, graph compare, tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
 
     - name: Configure CMake
       working-directory: ./build
-      run: cmake -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DGGML_TEST_COVERAGE=ON -DGGML_METAL=ON ..
+      run: cmake -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DGGML_TEST_COVERAGE=ON ..
 
     - name: Build
       working-directory: ./build
@@ -67,7 +67,7 @@ jobs:
 
     - name: Test
       working-directory: ./build
-      run: GGML_METAL_PATH_RESOURCES=./bin ctest --verbose --timeout 900
+      run: ctest --verbose --timeout 900
 
     - name: Test Coverage
       working-directory: ./build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Dependencies
       run: |
         wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
-        echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list  
+        echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends llvm intel-oneapi-runtime-opencl intel-oneapi-runtime-compilers libclblast-dev
     - name: Create Build Environment
@@ -67,7 +67,7 @@ jobs:
 
     - name: Test
       working-directory: ./build
-      run: ctest --verbose --timeout 900
+      run: GGML_METAL_PATH_RESOURCES=./bin ctest --verbose --timeout 900
 
     - name: Test Coverage
       working-directory: ./build

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -94,6 +94,10 @@ function gg_run_ctest_debug {
     (time cmake -DCMAKE_BUILD_TYPE=Debug ${CMAKE_EXTRA} ..     ) 2>&1 | tee -a $OUT/${ci}-cmake.log
     (time make -j                                              ) 2>&1 | tee -a $OUT/${ci}-make.log
 
+    if [ ! -z ${GG_BUILD_METAL} ]; then
+        export GGML_METAL_PATH_RESOURCES="$(pwd)/bin"
+    fi
+
     (time ctest --output-on-failure -E test-opt ) 2>&1 | tee -a $OUT/${ci}-ctest.log
 
     set +e
@@ -121,6 +125,10 @@ function gg_run_ctest_release {
 
     (time cmake -DCMAKE_BUILD_TYPE=Release ${CMAKE_EXTRA} ..   ) 2>&1 | tee -a $OUT/${ci}-cmake.log
     (time make -j                                              ) 2>&1 | tee -a $OUT/${ci}-make.log
+
+    if [ ! -z ${GG_BUILD_METAL} ]; then
+        export GGML_METAL_PATH_RESOURCES="$(pwd)/bin"
+    fi
 
     if [ -z $GG_BUILD_LOW_PERF ]; then
         (time ctest --output-on-failure ) 2>&1 | tee -a $OUT/${ci}-ctest.log

--- a/examples/gpt-2/main-backend.cpp
+++ b/examples/gpt-2/main-backend.cpp
@@ -805,9 +805,10 @@ bool gpt2_eval(
         //printf("done\n");
     } else
 #endif
-
-    // run the computation
-    ggml_backend_graph_compute(model.backend, gf);
+    {
+        // run the computation
+        ggml_backend_graph_compute(model.backend, gf);
+    }
 
     //if (n_past%100 == 0) {
     //    ggml_graph_print   (&gf);

--- a/examples/gpt-2/main-backend.cpp
+++ b/examples/gpt-2/main-backend.cpp
@@ -197,7 +197,7 @@ bool gpt2_model_load(const std::string & fname, gpt2_model & model, gpt_vocab & 
 #ifdef GGML_USE_CUBLAS
     if (n_gpu_layers > 0) {
         fprintf(stderr, "%s: using CUDA backend\n", __func__);
-        model.backend = ggml_backend_cuda_init();
+        model.backend = ggml_backend_cuda_init(0);
         if (!model.backend) {
             fprintf(stderr, "%s: ggml_backend_cuda_init() failed\n", __func__);
         }

--- a/examples/gpt-2/main-backend.cpp
+++ b/examples/gpt-2/main-backend.cpp
@@ -26,6 +26,8 @@
 #pragma warning(disable: 4244 4267) // possible loss of data
 #endif
 
+#define GPT2_MAX_NODES 4096
+
 static void ggml_log_callback_default(ggml_log_level level, const char * text, void * user_data) {
     (void) level;
     (void) user_data;
@@ -452,7 +454,7 @@ struct ggml_cgraph * gpt2_graph(
     const int n_head  = hparams.n_head;
 
     // since we are using ggml-alloc, this buffer only needs enough space to hold the ggml_tensor and ggml_cgraph structs, but not the tensor data
-    static size_t buf_size = ggml_tensor_overhead()*GGML_DEFAULT_GRAPH_SIZE + ggml_graph_overhead();
+    static size_t buf_size = ggml_tensor_overhead()*GPT2_MAX_NODES + ggml_graph_overhead_custom(GPT2_MAX_NODES, false);
     static std::vector<uint8_t> buf(buf_size);
 
     struct ggml_init_params params = {
@@ -463,7 +465,7 @@ struct ggml_cgraph * gpt2_graph(
 
     struct ggml_context * ctx0 = ggml_init(params);
 
-    struct ggml_cgraph  * gf = ggml_new_graph(ctx0);
+    struct ggml_cgraph  * gf = ggml_new_graph_custom(ctx0, GPT2_MAX_NODES, false);
 
     struct ggml_tensor * embd = ggml_new_tensor_1d(ctx0, GGML_TYPE_I32, N);
     ggml_allocr_alloc(allocr, embd);

--- a/examples/gpt-2/main-batched.cpp
+++ b/examples/gpt-2/main-batched.cpp
@@ -27,6 +27,8 @@
 #pragma warning(disable: 4244 4267) // possible loss of data
 #endif
 
+#define GPT2_MAX_NODES 4096
+
 static void ggml_log_callback_default(ggml_log_level level, const char * text, void * user_data) {
     (void) level;
     (void) user_data;
@@ -551,7 +553,7 @@ struct ggml_cgraph * gpt2_graph(
     const int32_t kv_head  = ggml_allocr_is_measure(allocr) ? n_ctx - n_tokens : kv_cache.head;
 
     // since we are using ggml-alloc, this buffer only needs enough space to hold the ggml_tensor and ggml_cgraph structs, but not the tensor data
-    static size_t buf_size = ggml_tensor_overhead()*GGML_DEFAULT_GRAPH_SIZE + ggml_graph_overhead();
+    static size_t buf_size = ggml_tensor_overhead()*GPT2_MAX_NODES + ggml_graph_overhead_custom(GPT2_MAX_NODES, false);
     static std::vector<uint8_t> buf(buf_size);
 
     struct ggml_init_params params = {
@@ -562,7 +564,7 @@ struct ggml_cgraph * gpt2_graph(
 
     struct ggml_context * ctx0 = ggml_init(params);
 
-    struct ggml_cgraph  * gf = ggml_new_graph(ctx0);
+    struct ggml_cgraph  * gf = ggml_new_graph_custom(ctx0, GPT2_MAX_NODES, false);
 
     struct ggml_tensor * inpL;
     if (batch.token) {

--- a/examples/gpt-2/main-batched.cpp
+++ b/examples/gpt-2/main-batched.cpp
@@ -286,7 +286,7 @@ bool gpt2_model_load(const std::string & fname, gpt2_model & model, gpt_vocab & 
 #ifdef GGML_USE_CUBLAS
     if (n_gpu_layers > 0) {
         fprintf(stderr, "%s: using CUDA backend\n", __func__);
-        model.backend = ggml_backend_cuda_init();
+        model.backend = ggml_backend_cuda_init(0);
         if (!model.backend) {
             fprintf(stderr, "%s: ggml_backend_cuda_init() failed\n", __func__);
         }

--- a/examples/gpt-2/main.cpp
+++ b/examples/gpt-2/main.cpp
@@ -107,7 +107,7 @@ void init_backends(gpt2_model & model, const gpt_params & params) {
 #ifdef GGML_USE_CUBLAS
     if (params.n_gpu_layers > 0) {
         fprintf(stderr, "%s: using CUDA backend\n", __func__);
-        gpu_backend = ggml_backend_cuda_init();
+        gpu_backend = ggml_backend_cuda_init(0);
         if (!gpu_backend) {
             fprintf(stderr, "%s: ggml_backend_cuda_init() failed\n", __func__);
         }

--- a/examples/gpt-2/main.cpp
+++ b/examples/gpt-2/main.cpp
@@ -26,6 +26,8 @@
 #pragma warning(disable: 4244 4267) // possible loss of data
 #endif
 
+#define GPT2_MAX_NODES 4096
+
 static void ggml_log_callback_default(ggml_log_level level, const char * text, void * user_data) {
     (void) level;
     (void) user_data;
@@ -553,7 +555,7 @@ struct ggml_cgraph * gpt2_graph(
     const int n_head  = hparams.n_head;
 
     // since we are using ggml-alloc, this buffer only needs enough space to hold the ggml_tensor and ggml_cgraph structs, but not the tensor data
-    static size_t buf_size = ggml_tensor_overhead()*GGML_DEFAULT_GRAPH_SIZE + ggml_graph_overhead();
+    static size_t buf_size = ggml_tensor_overhead()*GPT2_MAX_NODES + ggml_graph_overhead_custom(GPT2_MAX_NODES, false);
     static std::vector<uint8_t> buf(buf_size);
 
     struct ggml_init_params params = {
@@ -564,7 +566,7 @@ struct ggml_cgraph * gpt2_graph(
 
     struct ggml_context * ctx0 = ggml_init(params);
 
-    struct ggml_cgraph  * gf = ggml_new_graph(ctx0);
+    struct ggml_cgraph  * gf = ggml_new_graph_custom(ctx0, GPT2_MAX_NODES, false);
 
     struct ggml_tensor * embd = ggml_view_1d(ctx0, model.embd, N, 0);
 

--- a/examples/whisper/whisper.cpp
+++ b/examples/whisper/whisper.cpp
@@ -1063,7 +1063,7 @@ static ggml_backend_t whisper_backend_init(const whisper_context_params & params
 #ifdef GGML_USE_CUBLAS
     if (params.use_gpu && ggml_cublas_loaded()) {
         WHISPER_LOG_INFO("%s: using CUDA backend\n", __func__);
-        backend_gpu = ggml_backend_cuda_init();
+        backend_gpu = ggml_backend_cuda_init(0);
         if (!backend_gpu) {
             WHISPER_LOG_ERROR("%s: ggml_backend_cuda_init() failed\n", __func__);
         }

--- a/include/ggml/ggml-alloc.h
+++ b/include/ggml/ggml-alloc.h
@@ -8,6 +8,7 @@ extern "C" {
 
 struct ggml_backend;
 struct ggml_backend_buffer;
+struct ggml_backend_buffer_type;
 
 //
 // Legacy API
@@ -79,6 +80,12 @@ GGML_API void   ggml_gallocr_alloc_graph_n(
                     struct ggml_cgraph * graph,
                     struct ggml_hash_set hash_set,
                     ggml_tallocr_t * hash_node_talloc);
+
+
+// Utils
+// Create a buffer and allocate all the tensors in a ggml_context
+GGML_API struct ggml_backend_buffer * ggml_backend_alloc_ctx_tensors_from_buft(struct ggml_context * ctx, struct ggml_backend_buffer_type * buft);
+GGML_API struct ggml_backend_buffer * ggml_backend_alloc_ctx_tensors(struct ggml_context * ctx, struct ggml_backend * backend);
 
 #ifdef  __cplusplus
 }

--- a/include/ggml/ggml-backend.h
+++ b/include/ggml/ggml-backend.h
@@ -7,41 +7,44 @@
 extern "C" {
 #endif
 
+    typedef struct ggml_backend_buffer_type * ggml_backend_buffer_type_t;
+    typedef struct ggml_backend_buffer * ggml_backend_buffer_t;
+    typedef struct ggml_backend * ggml_backend_t;
+    typedef void * ggml_backend_graph_plan_t;
+
     //
     // Backend buffer
     //
 
-    struct ggml_backend_buffer;
-    typedef struct ggml_backend_buffer * ggml_backend_buffer_t;
+    // buffer type
+    GGML_API ggml_backend_buffer_t ggml_backend_buft_alloc_buffer(ggml_backend_buffer_type_t buft, size_t size);
+    GGML_API size_t ggml_backend_buft_get_alignment (ggml_backend_buffer_type_t buft);
+    GGML_API size_t ggml_backend_buft_get_alloc_size(ggml_backend_buffer_type_t buft, struct ggml_tensor * tensor);
+    GGML_API bool ggml_backend_buft_supports_backend(ggml_backend_buffer_type_t buft, ggml_backend_t backend);
 
-    // backend buffer functions
+    // buffer
     GGML_API void   ggml_backend_buffer_free          (ggml_backend_buffer_t buffer);
-    GGML_API size_t ggml_backend_buffer_get_alignment (ggml_backend_buffer_t buffer);
     GGML_API void * ggml_backend_buffer_get_base      (ggml_backend_buffer_t buffer);
     GGML_API size_t ggml_backend_buffer_get_size      (ggml_backend_buffer_t buffer);
-    GGML_API size_t ggml_backend_buffer_get_alloc_size(ggml_backend_buffer_t buffer, struct ggml_tensor * tensor);
     GGML_API void   ggml_backend_buffer_init_tensor   (ggml_backend_buffer_t buffer, struct ggml_tensor * tensor);
-    GGML_API void   ggml_backend_buffer_free_tensor   (ggml_backend_buffer_t buffer, struct ggml_tensor * tensor);
+    GGML_API size_t ggml_backend_buffer_get_alignment (ggml_backend_buffer_t buffer);
+    GGML_API size_t ggml_backend_buffer_get_alloc_size(ggml_backend_buffer_t buffer, struct ggml_tensor * tensor);
+    GGML_API ggml_backend_buffer_type_t ggml_backend_buffer_type(ggml_backend_buffer_t buffer);
 
     //
     // Backend
     //
 
-    struct ggml_backend;
-    typedef struct ggml_backend * ggml_backend_t;
-    typedef void * ggml_backend_graph_plan_t;
-
-    GGML_API ggml_backend_t ggml_get_backend(const struct ggml_tensor * tensor);
 
     GGML_API const char * ggml_backend_name(ggml_backend_t backend);
     GGML_API void         ggml_backend_free(ggml_backend_t backend);
 
-    GGML_API ggml_backend_buffer_t ggml_backend_alloc_buffer(ggml_backend_t backend, size_t size);
+    GGML_API ggml_backend_buffer_type_t ggml_backend_get_default_buffer_type(ggml_backend_t backend);
+    GGML_API ggml_backend_buffer_t      ggml_backend_alloc_buffer(ggml_backend_t backend, size_t size);
+    GGML_API size_t                     ggml_backend_get_alignment(ggml_backend_t backend);
 
-    GGML_API size_t ggml_backend_get_alignment(ggml_backend_t backend);
-
-    GGML_API void ggml_backend_tensor_set_async(      struct ggml_tensor * tensor, const void * data, size_t offset, size_t size);
-    GGML_API void ggml_backend_tensor_get_async(const struct ggml_tensor * tensor,       void * data, size_t offset, size_t size);
+    GGML_API void ggml_backend_tensor_set_async(ggml_backend_t backend,       struct ggml_tensor * tensor, const void * data, size_t offset, size_t size);
+    GGML_API void ggml_backend_tensor_get_async(ggml_backend_t backend, const struct ggml_tensor * tensor,       void * data, size_t offset, size_t size);
 
     GGML_API void ggml_backend_tensor_set(      struct ggml_tensor * tensor, const void * data, size_t offset, size_t size);
     GGML_API void ggml_backend_tensor_get(const struct ggml_tensor * tensor,       void * data, size_t offset, size_t size);
@@ -57,6 +60,7 @@ extern "C" {
 
     // tensor copy between different backends
     GGML_API void ggml_backend_tensor_copy(struct ggml_tensor * src, struct ggml_tensor * dst);
+    GGML_API void ggml_backend_tensor_copy_async(ggml_backend_t backend, struct ggml_tensor * src, struct ggml_tensor * dst); // automatic fallback to sync copy
 
     //
     // CPU backend
@@ -68,8 +72,23 @@ extern "C" {
     GGML_API void ggml_backend_cpu_set_n_threads(ggml_backend_t backend_cpu, int n_threads);
 
     // Create a backend buffer from an existing pointer
-    GGML_API ggml_backend_buffer_t ggml_backend_cpu_buffer_from_ptr(ggml_backend_t backend_cpu, void * ptr, size_t size);
+    GGML_API ggml_backend_buffer_t ggml_backend_cpu_buffer_from_ptr(void * ptr, size_t size);
 
+    GGML_API extern ggml_backend_buffer_type_t ggml_backend_buffer_type_cpu;
+
+    //
+    // Backend registry
+    //
+
+    // The backend registry is a registry of all the available backends, and allows initializing backends in a generic way
+
+    GGML_API size_t                     ggml_backend_reg_get_count(void);
+    GGML_API size_t                     ggml_backend_reg_find_by_name(const char * name);
+    GGML_API ggml_backend_t             ggml_backend_reg_init_backend_from_str(const char * backend_str); // str is name[:params]
+    GGML_API const char *               ggml_backend_reg_get_name(size_t i);
+    GGML_API ggml_backend_t             ggml_backend_reg_init_backend(size_t i, const char * params); // params is backend-specific
+    GGML_API ggml_backend_buffer_type_t ggml_backend_reg_get_default_buffer_type(size_t i);
+    GGML_API ggml_backend_buffer_t      ggml_backend_reg_alloc_buffer(size_t i, size_t size);
 
     //
     // Backend scheduler
@@ -130,6 +149,27 @@ extern "C" {
     GGML_API void ggml_backend_sched_graph_compute(
             ggml_backend_sched_t sched,
             struct ggml_cgraph * graph);
+
+
+    //
+    // Utils
+    //
+
+    struct ggml_backend_graph_copy {
+        ggml_backend_buffer_t buffer;
+        struct ggml_context * ctx_allocated;
+        struct ggml_context * ctx_unallocated;
+        struct ggml_cgraph * graph;
+    };
+
+    // Copy a graph to a different backend
+    GGML_API struct ggml_backend_graph_copy ggml_backend_graph_copy(ggml_backend_t backend, struct ggml_cgraph * graph);
+    GGML_API void                           ggml_backend_graph_copy_free(struct ggml_backend_graph_copy copy);
+
+    typedef bool (*ggml_backend_eval_callback)(int node_index, struct ggml_tensor * t1, struct ggml_tensor * t2, void * user_data);
+
+    // Compare the output of two backends
+    GGML_API void ggml_backend_compare_graph_backend(ggml_backend_t backend1, ggml_backend_t backend2, struct ggml_cgraph * graph, ggml_backend_eval_callback callback, void * user_data);
 
 #ifdef  __cplusplus
 }

--- a/include/ggml/ggml-backend.h
+++ b/include/ggml/ggml-backend.h
@@ -171,6 +171,11 @@ extern "C" {
     // Compare the output of two backends
     GGML_API void ggml_backend_compare_graph_backend(ggml_backend_t backend1, ggml_backend_t backend2, struct ggml_cgraph * graph, ggml_backend_eval_callback callback, void * user_data);
 
+    // Tensor initialization
+    GGML_API void ggml_backend_tensor_alloc(ggml_backend_buffer_t buffer, struct ggml_tensor * tensor, void * addr);
+    GGML_API void ggml_backend_view_init(ggml_backend_buffer_t buffer, struct ggml_tensor * tensor);
+
+
 #ifdef  __cplusplus
 }
 #endif

--- a/include/ggml/ggml-backend.h
+++ b/include/ggml/ggml-backend.h
@@ -74,7 +74,7 @@ extern "C" {
     // Create a backend buffer from an existing pointer
     GGML_API ggml_backend_buffer_t ggml_backend_cpu_buffer_from_ptr(void * ptr, size_t size);
 
-    GGML_API extern ggml_backend_buffer_type_t ggml_backend_buffer_type_cpu;
+    GGML_API ggml_backend_buffer_type_t ggml_backend_cpu_buffer_type(void);
 
     //
     // Backend registry

--- a/include/ggml/ggml.h
+++ b/include/ggml/ggml.h
@@ -449,7 +449,9 @@ extern "C" {
         GGML_UNARY_OP_GELU,
         GGML_UNARY_OP_GELU_QUICK,
         GGML_UNARY_OP_SILU,
-        GGML_UNARY_OP_LEAKY
+        GGML_UNARY_OP_LEAKY,
+
+        GGML_UNARY_OP_COUNT,
     };
 
     enum ggml_object_type {
@@ -631,6 +633,9 @@ extern "C" {
     GGML_API const char * ggml_type_name(enum ggml_type type);
     GGML_API const char * ggml_op_name  (enum ggml_op   op);
     GGML_API const char * ggml_op_symbol(enum ggml_op   op);
+
+    GGML_API const char * ggml_unary_op_name(enum ggml_unary_op op);
+    GGML_API const char * ggml_op_desc(const struct ggml_tensor * t); // unary or op name
 
     GGML_API size_t  ggml_element_size(const struct ggml_tensor * tensor);
 
@@ -1749,7 +1754,7 @@ extern "C" {
     GGML_API struct ggml_cgraph * ggml_new_graph         (struct ggml_context * ctx); // size = GGML_DEFAULT_GRAPH_SIZE, grads = false
     GGML_API struct ggml_cgraph * ggml_new_graph_custom  (struct ggml_context * ctx, size_t size, bool grads);
     GGML_API struct ggml_cgraph * ggml_graph_dup         (struct ggml_context * ctx, struct ggml_cgraph * cgraph);
-    GGML_API struct ggml_cgraph * ggml_graph_view        (struct ggml_context * ctx, struct ggml_cgraph * cgraph, int i0, int i1);
+    GGML_API struct ggml_cgraph   ggml_graph_view        (struct ggml_cgraph * cgraph, int i0, int i1);
     GGML_API void                 ggml_graph_cpy         (struct ggml_cgraph * src, struct ggml_cgraph * dst);
     GGML_API void                 ggml_graph_reset       (struct ggml_cgraph * cgraph);  // zero grads
     GGML_API void                 ggml_graph_clear       (struct ggml_cgraph * cgraph);

--- a/src/ggml-alloc.c
+++ b/src/ggml-alloc.c
@@ -135,6 +135,7 @@ void ggml_tallocr_alloc(ggml_tallocr_t alloc, struct ggml_tensor * tensor) {
         ggml_backend_buffer_init_tensor(alloc->buffer, tensor);
     }
 
+
 #ifdef GGML_ALLOCATOR_DEBUG
     add_allocated_tensor(alloc, tensor);
     size_t cur_max = (char*)addr - (char*)alloc->data + size;
@@ -787,11 +788,7 @@ ggml_backend_buffer_t ggml_backend_alloc_ctx_tensors_from_buft(struct ggml_conte
             if (t->view_src == NULL) {
                 ggml_tallocr_alloc(tallocr, t);
             } else {
-                // TODO: ggml_backend_init_view
-                t->backend = t->view_src->backend;
-                t->data = (char *)t->view_src->data + t->view_offs;
-                t->buffer = buffer;
-                ggml_backend_buffer_init_tensor(buffer, t);
+                ggml_backend_view_init(buffer, t);
             }
         }
     }

--- a/src/ggml-alloc.c
+++ b/src/ggml-alloc.c
@@ -168,10 +168,6 @@ static void ggml_tallocr_free_tensor(ggml_tallocr_t alloc, struct ggml_tensor * 
     size = aligned_offset(NULL, size, alloc->alignment);
     AT_PRINTF("%s: freeing %s at %p (%zu bytes) - n_free_blocks = %d\n", __func__, tensor->name, ptr, size, alloc->n_free_blocks);
 
-    if (!alloc->measure) {
-        ggml_backend_buffer_free_tensor(alloc->buffer, tensor);
-    }
-
 #ifdef GGML_ALLOCATOR_DEBUG
     remove_allocated_tensor(alloc, tensor);
 #endif
@@ -237,7 +233,7 @@ void ggml_tallocr_reset(ggml_tallocr_t alloc) {
 }
 
 ggml_tallocr_t ggml_tallocr_new(void * data, size_t size, size_t alignment) {
-    struct ggml_backend_buffer * buffer = ggml_backend_cpu_buffer_from_ptr(NULL, data, size);
+    struct ggml_backend_buffer * buffer = ggml_backend_cpu_buffer_from_ptr(data, size);
 
     ggml_tallocr_t alloc = (ggml_tallocr_t)malloc(sizeof(struct ggml_tallocr));
 
@@ -449,7 +445,6 @@ static ggml_tallocr_t node_tallocr(ggml_gallocr_t galloc, struct ggml_tensor * n
 static void init_view(ggml_gallocr_t galloc, struct ggml_tensor * view, bool update_backend) {
     ggml_tallocr_t alloc = node_tallocr(galloc, view);
 
-    //printf("init_view: %s from src %s\n", view->name, view->view_src->name);
     GGML_ASSERT(view->view_src != NULL && view->view_src->data != NULL);
     if (update_backend) {
         view->backend = view->view_src->backend;
@@ -459,7 +454,7 @@ static void init_view(ggml_gallocr_t galloc, struct ggml_tensor * view, bool upd
 
     // FIXME: the view should be initialized by the owning buffer, but currently this breaks the CUDA backend
     // due to the ggml_tensor_extra_gpu ring buffer overwriting the KV cache extras
-    assert(ggml_tallocr_is_measure(alloc) || !view->buffer || view->buffer->backend == alloc->buffer->backend);
+    assert(ggml_tallocr_is_measure(alloc) || !view->buffer || view->buffer->buft == alloc->buffer->buft);
 
     if (!alloc->measure) {
         ggml_backend_buffer_init_tensor(alloc->buffer, view);
@@ -764,4 +759,32 @@ size_t ggml_allocr_max_size(ggml_allocr_t alloc) {
 
 size_t ggml_allocr_alloc_graph(ggml_allocr_t alloc, struct ggml_cgraph * graph) {
     return ggml_gallocr_alloc_graph(alloc->galloc, alloc->talloc, graph);
+}
+
+// utils
+ggml_backend_buffer_t ggml_backend_alloc_ctx_tensors_from_buft(struct ggml_context * ctx, ggml_backend_buffer_type_t buft) {
+    GGML_ASSERT(ggml_get_no_alloc(ctx) == true);
+
+    size_t alignment = ggml_backend_buft_get_alignment(buft);
+
+    size_t nbytes = 0;
+    for (struct ggml_tensor * t = ggml_get_first_tensor(ctx); t != NULL; t = ggml_get_next_tensor(ctx, t)) {
+        GGML_ASSERT(t->data == NULL); // TODO: skip allocated tensors?
+        nbytes += GGML_PAD(ggml_backend_buft_get_alloc_size(buft, t), alignment);
+    }
+
+    ggml_backend_buffer_t buffer = ggml_backend_buft_alloc_buffer(buft, nbytes);
+    ggml_tallocr_t tallocr = ggml_tallocr_new_from_buffer(buffer);
+
+    for (struct ggml_tensor * t = ggml_get_first_tensor(ctx); t != NULL; t = ggml_get_next_tensor(ctx, t)) {
+        ggml_tallocr_alloc(tallocr, t);
+    }
+
+    ggml_tallocr_free(tallocr);
+
+    return buffer;
+}
+
+ggml_backend_buffer_t ggml_backend_alloc_ctx_tensors(struct ggml_context * ctx, ggml_backend_t backend) {
+    return ggml_backend_alloc_ctx_tensors_from_buft(ctx, ggml_backend_get_default_buffer_type(backend));
 }

--- a/src/ggml-backend-impl.h
+++ b/src/ggml-backend-impl.h
@@ -13,6 +13,8 @@ extern "C" {
     //
 
     // buffer type
+    typedef void * ggml_backend_buffer_type_context_t;
+
     struct ggml_backend_buffer_type_i {
         ggml_backend_buffer_t (*alloc_buffer)    (ggml_backend_buffer_type_t buft, size_t size);
         size_t                (*get_alignment)   (ggml_backend_buffer_type_t buft); // tensor alignment
@@ -21,7 +23,8 @@ extern "C" {
     };
 
     struct ggml_backend_buffer_type {
-        struct ggml_backend_buffer_type_i iface;
+        struct ggml_backend_buffer_type_i  iface;
+        ggml_backend_buffer_type_context_t context;
     };
 
     // buffer
@@ -100,9 +103,9 @@ extern "C" {
     // Backend registry
     //
 
-    typedef ggml_backend_t (*ggml_backend_init_fn)(const char * params);
+    typedef ggml_backend_t (*ggml_backend_init_fn)(const char * params, void * user_data);
 
-    size_t ggml_backend_register(const char * name, ggml_backend_init_fn init_fn, ggml_backend_buffer_type_t default_buffer_type);
+    size_t ggml_backend_register(const char * name, ggml_backend_init_fn init_fn, ggml_backend_buffer_type_t default_buffer_type, void * user_data);
 
 
     // Register a int function to be called at program startup
@@ -125,9 +128,9 @@ extern "C" {
 
 
     // Register a backend
-    #define GGML_BACKEND_REGISTER(name, init_fn, buft) \
+    #define GGML_BACKEND_REGISTER(name, init_fn, buft, user_data) \
         static void init_fn ## _backend_register(void) { \
-            ggml_backend_register(name, init_fn, buft); \
+            ggml_backend_register(name, init_fn, buft, user_data); \
         } \
         GGML_CONSTRUCTOR(init_fn ## _backend_register)
 

--- a/src/ggml-backend-impl.h
+++ b/src/ggml-backend-impl.h
@@ -12,30 +12,46 @@ extern "C" {
     // Backend buffer
     //
 
+    // buffer type
+    struct ggml_backend_buffer_type_i {
+        ggml_backend_buffer_t (*alloc_buffer)    (ggml_backend_buffer_type_t buft, size_t size);
+        size_t                (*get_alignment)   (ggml_backend_buffer_type_t buft); // tensor alignment
+        size_t                (*get_alloc_size)  (ggml_backend_buffer_type_t buft, struct ggml_tensor * tensor); // data size needed to allocate the tensor, including padding
+        bool                  (*supports_backend)(ggml_backend_buffer_type_t buft, ggml_backend_t backend); // check if the buffer type is usable by the backend
+    };
+
+    struct ggml_backend_buffer_type {
+        struct ggml_backend_buffer_type_i iface;
+    };
+
+    // buffer
     typedef void * ggml_backend_buffer_context_t;
 
     struct ggml_backend_buffer_i {
-        void   (*free_buffer)   (ggml_backend_buffer_t buffer);
-        void * (*get_base)      (ggml_backend_buffer_t buffer); // get base pointer
-        size_t (*get_alloc_size)(ggml_backend_buffer_t buffer, struct ggml_tensor * tensor); // pre-allocation callback
-        void   (*init_tensor)   (ggml_backend_buffer_t buffer, struct ggml_tensor * tensor); // post-allocation callback
-        void   (*free_tensor)   (ggml_backend_buffer_t buffer, struct ggml_tensor * tensor); // pre-free callback
+        void     (*free_buffer)(ggml_backend_buffer_t buffer);
+        //void     (*reset)      (ggml_backend_buffer_t buffer); // reset any internal state due to tensor initialization, such as tensor extras
+        void *   (*get_base)   (ggml_backend_buffer_t buffer);
+        void     (*init_tensor)(ggml_backend_buffer_t buffer, struct ggml_tensor * tensor);
+        void     (*set_tensor) (ggml_backend_buffer_t buffer,       struct ggml_tensor * tensor, const void * data, size_t offset, size_t size);
+        void     (*get_tensor) (ggml_backend_buffer_t buffer, const struct ggml_tensor * tensor,       void * data, size_t offset, size_t size);
+        // (optional) copy tensor between different buffer-type, allow for single-copy tranfers
+        void (*cpy_tensor_from)(ggml_backend_buffer_t buffer, struct ggml_tensor * src, struct ggml_tensor * dst);
+        void (*cpy_tensor_to)  (ggml_backend_buffer_t buffer, struct ggml_tensor * src, struct ggml_tensor * dst);
     };
 
     struct ggml_backend_buffer {
-        struct ggml_backend_buffer_i iface;
-
-        ggml_backend_t                backend;
+        struct ggml_backend_buffer_i  iface;
+        ggml_backend_buffer_type_t    buft;
         ggml_backend_buffer_context_t context;
-
         size_t size;
     };
 
-    GGML_API ggml_backend_buffer_t ggml_backend_buffer_init(
-            struct ggml_backend                  * backend,
+    ggml_backend_buffer_t ggml_backend_buffer_init(
+                   ggml_backend_buffer_type_t      buft,
             struct ggml_backend_buffer_i           iface,
                    ggml_backend_buffer_context_t   context,
                    size_t                          size);
+
 
     //
     // Backend
@@ -49,20 +65,17 @@ extern "C" {
         void (*free)(ggml_backend_t backend);
 
         // buffer allocation
-        ggml_backend_buffer_t (*alloc_buffer)(ggml_backend_t backend, size_t size);
+        ggml_backend_buffer_type_t (*get_default_buffer_type)(ggml_backend_t backend);
 
-        // get buffer alignment
-        size_t (*get_alignment)(ggml_backend_t backend);
-
-        // tensor data access
-        // these functions can be asynchronous, helper functions are provided for synchronous access that automatically call synchronize
+        // (optional) asynchroneous tensor data access
         void (*set_tensor_async)(ggml_backend_t backend,       struct ggml_tensor * tensor, const void * data, size_t offset, size_t size);
         void (*get_tensor_async)(ggml_backend_t backend, const struct ggml_tensor * tensor,       void * data, size_t offset, size_t size);
-        void (*synchronize)     (ggml_backend_t backend);
 
-        // (optional) copy tensor between different backends, allow for single-copy tranfers
-        void (*cpy_tensor_from)(ggml_backend_t backend, struct ggml_tensor * src, struct ggml_tensor * dst);
-        void (*cpy_tensor_to)  (ggml_backend_t backend, struct ggml_tensor * src, struct ggml_tensor * dst);
+        // (optional) asynchroneous tensor copy
+        void (*cpy_tensor_from_async)(ggml_backend_t backend, struct ggml_tensor * src, struct ggml_tensor * dst);
+        void (*cpy_tensor_to_async)  (ggml_backend_t backend, struct ggml_tensor * src, struct ggml_tensor * dst);
+
+        void (*synchronize)     (ggml_backend_t backend);
 
         // compute graph with a plan
         ggml_backend_graph_plan_t (*graph_plan_create) (ggml_backend_t backend, struct ggml_cgraph * cgraph);
@@ -81,6 +94,33 @@ extern "C" {
 
         ggml_backend_context_t context;
     };
+
+
+    //
+    // Backend registry
+    //
+
+    typedef ggml_backend_t (*ggml_backend_init_fn)(const char * params);
+
+    size_t ggml_backend_register(const char * name, ggml_backend_init_fn init_fn, ggml_backend_buffer_type_t default_buffer_type);
+
+#if defined(__GNUC__) || defined(__clang__)
+    #define GGML_BACKEND_REGISTER_CONS(name, init_fn, buft) \
+        static void __attribute__((constructor)) init_fn ## _backend_register_constructor(void) { \
+            ggml_backend_register(name, init_fn, buft); \
+        }
+#elif defined(_MSC_VER)
+    #define GGML_BACKEND_REGISTER_CONS(name, init_fn, buft) \
+        __declspec(allocate(".CRT$XCU")) void init_fn ## _backend_register_constructor(void) { \
+            ggml_backend_register(name, init_fn, buft); \
+        } \
+        __pragma(comment(linker, "/include:" #init_fn "_backend_register_constructor"))
+#else
+    // Fallback for other compilers
+    #define GGML_BACKEND_REGISTER_CONS(name, init_fn, buft) \
+        int init_fn ## _backend_register_dummy = ggml_backend_register(name, init_fn, buft);
+#endif
+
 
 #ifdef  __cplusplus
 }

--- a/src/ggml-backend.c
+++ b/src/ggml-backend.c
@@ -495,6 +495,7 @@ static void ggml_backend_cpu_graph_compute(ggml_backend_t backend, struct ggml_c
 
 static bool ggml_backend_cpu_supports_op(ggml_backend_t backend, const struct ggml_tensor * op) {
     return true;
+
     GGML_UNUSED(backend);
     GGML_UNUSED(op);
 }
@@ -548,6 +549,7 @@ ggml_backend_buffer_t ggml_backend_cpu_buffer_from_ptr(void * ptr, size_t size) 
 
 static ggml_backend_t ggml_backend_reg_cpu_init(const char * params) {
     return ggml_backend_cpu_init();
+
     GGML_UNUSED(params);
 }
 
@@ -643,7 +645,7 @@ static ggml_backend_t get_allocr_backend(ggml_backend_sched_t sched, ggml_talloc
             return sched->backends[i];
         }
     }
-    GGML_ASSERT(false); // should never happen
+    assert(false); // should never happen
 }
 
 // returns the backend that should be used for the node based on the current locations

--- a/src/ggml-backend.c
+++ b/src/ggml-backend.c
@@ -9,14 +9,36 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define UNUSED GGML_UNUSED
 
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
+
+
+// backend buffer type
+
+ggml_backend_buffer_t ggml_backend_buft_alloc_buffer(ggml_backend_buffer_type_t buft, size_t size) {
+    return buft->iface.alloc_buffer(buft, size);
+}
+
+size_t ggml_backend_buft_get_alignment(ggml_backend_buffer_type_t buft) {
+    return buft->iface.get_alignment(buft);
+}
+
+size_t ggml_backend_buft_get_alloc_size(ggml_backend_buffer_type_t buft, struct ggml_tensor * tensor) {
+    // get_alloc_size is optional, defaults to ggml_nbytes
+    if (buft->iface.get_alloc_size) {
+        return buft->iface.get_alloc_size(buft, tensor);
+    }
+    return ggml_nbytes(tensor);
+}
+
+bool ggml_backend_buft_supports_backend(ggml_backend_buffer_type_t buft, ggml_backend_t backend) {
+    return buft->iface.supports_backend(buft, backend);
+}
 
 // backend buffer
 
 ggml_backend_buffer_t ggml_backend_buffer_init(
-        struct ggml_backend                  * backend,
+               ggml_backend_buffer_type_t      buft,
         struct ggml_backend_buffer_i           iface,
                ggml_backend_buffer_context_t   context,
                size_t                          size) {
@@ -26,7 +48,7 @@ ggml_backend_buffer_t ggml_backend_buffer_init(
 
     (*buffer) = (struct ggml_backend_buffer) {
         /* .interface = */ iface,
-        /* .backend   = */ backend,
+        /* .buft      = */ buft,
         /* .context   = */ context,
         /* .size      = */ size,
     };
@@ -45,10 +67,6 @@ void ggml_backend_buffer_free(ggml_backend_buffer_t buffer) {
     free(buffer);
 }
 
-size_t ggml_backend_buffer_get_alignment(ggml_backend_buffer_t buffer) {
-    return ggml_backend_get_alignment(buffer->backend);
-}
-
 size_t ggml_backend_buffer_get_size(ggml_backend_buffer_t buffer) {
     return buffer->size;
 }
@@ -61,14 +79,6 @@ void * ggml_backend_buffer_get_base(ggml_backend_buffer_t buffer) {
     return base;
 }
 
-size_t ggml_backend_buffer_get_alloc_size(ggml_backend_buffer_t buffer, struct ggml_tensor * tensor) {
-    // get_alloc_size is optional, defaults to ggml_nbytes
-    if (buffer->iface.get_alloc_size) {
-        return buffer->iface.get_alloc_size(buffer, tensor);
-    }
-    return ggml_nbytes(tensor);
-}
-
 void ggml_backend_buffer_init_tensor(ggml_backend_buffer_t buffer, struct ggml_tensor * tensor) {
     // init_tensor is optional
     if (buffer->iface.init_tensor) {
@@ -76,18 +86,19 @@ void ggml_backend_buffer_init_tensor(ggml_backend_buffer_t buffer, struct ggml_t
     }
 }
 
-void ggml_backend_buffer_free_tensor(ggml_backend_buffer_t buffer, struct ggml_tensor * tensor) {
-    // free_tensor is optional
-    if (buffer->iface.free_tensor) {
-        buffer->iface.free_tensor(buffer, tensor);
-    }
+size_t ggml_backend_buffer_get_alignment (ggml_backend_buffer_t buffer) {
+    return ggml_backend_buft_get_alignment(ggml_backend_buffer_type(buffer));
+}
+
+size_t ggml_backend_buffer_get_alloc_size(ggml_backend_buffer_t buffer, struct ggml_tensor * tensor) {
+    return ggml_backend_buft_get_alloc_size(ggml_backend_buffer_type(buffer), tensor);
+}
+
+ggml_backend_buffer_type_t ggml_backend_buffer_type(ggml_backend_buffer_t buffer) {
+    return buffer->buft;
 }
 
 // backend
-
-ggml_backend_t ggml_get_backend(const struct ggml_tensor * tensor) {
-    return tensor->buffer ? tensor->buffer->backend : NULL;
-}
 
 const char * ggml_backend_name(ggml_backend_t backend) {
     if (backend == NULL) {
@@ -104,43 +115,53 @@ void ggml_backend_free(ggml_backend_t backend) {
     backend->iface.free(backend);
 }
 
+ggml_backend_buffer_type_t ggml_backend_get_default_buffer_type(ggml_backend_t backend) {
+    return backend->iface.get_default_buffer_type(backend);
+}
+
 ggml_backend_buffer_t ggml_backend_alloc_buffer(ggml_backend_t backend, size_t size) {
-    return backend->iface.alloc_buffer(backend, size);
+    return ggml_backend_buft_alloc_buffer(ggml_backend_get_default_buffer_type(backend), size);
 }
 
 size_t ggml_backend_get_alignment(ggml_backend_t backend) {
-    return backend->iface.get_alignment(backend);
+    return ggml_backend_buft_get_alignment(ggml_backend_get_default_buffer_type(backend));
 }
 
-void ggml_backend_tensor_set_async(struct ggml_tensor * tensor, const void * data, size_t offset, size_t size) {
-    ggml_get_backend(tensor)->iface.set_tensor_async(ggml_get_backend(tensor), tensor, data, offset, size);
+void ggml_backend_tensor_set_async(ggml_backend_t backend, struct ggml_tensor * tensor, const void * data, size_t offset, size_t size) {
+    GGML_ASSERT(tensor->data != NULL && "tensor not allocated");
+    GGML_ASSERT(offset + size <= ggml_nbytes(tensor) && "tensor write out of bounds");
+
+    backend->iface.set_tensor_async(backend, tensor, data, offset, size);
 }
 
-void ggml_backend_tensor_get_async(const struct ggml_tensor * tensor, void * data, size_t offset, size_t size) {
-    ggml_get_backend(tensor)->iface.get_tensor_async(ggml_get_backend(tensor), tensor, data, offset, size);
+void ggml_backend_tensor_get_async(ggml_backend_t backend, const struct ggml_tensor * tensor, void * data, size_t offset, size_t size) {
+    GGML_ASSERT(tensor->data != NULL && "tensor not allocated");
+    GGML_ASSERT(offset + size <= ggml_nbytes(tensor) && "tensor read out of bounds");
+
+    backend->iface.get_tensor_async(backend, tensor, data, offset, size);//
 }
 
 void ggml_backend_tensor_set(struct ggml_tensor * tensor, const void * data, size_t offset, size_t size) {
-    ggml_backend_t backend = ggml_get_backend(tensor);
-
     GGML_ASSERT(tensor->data != NULL && "tensor not allocated");
-    GGML_ASSERT(backend != NULL && "tensor backend not set");
+    GGML_ASSERT(tensor->buffer != NULL && "tensor buffer not set");
+    GGML_ASSERT(offset + size <= ggml_nbytes(tensor) && "tensor write out of bounds");
 
-    backend->iface.set_tensor_async(backend, tensor, data, offset, size);
-    backend->iface.synchronize(backend);
+    tensor->buffer->iface.set_tensor(tensor->buffer, tensor, data, offset, size);
 }
 
 void ggml_backend_tensor_get(const struct ggml_tensor * tensor, void * data, size_t offset, size_t size) {
-    ggml_backend_t backend = ggml_get_backend(tensor);
-
     GGML_ASSERT(tensor->data != NULL && "tensor not allocated");
-    GGML_ASSERT(backend != NULL && "tensor backend not set");
+    GGML_ASSERT(tensor->buffer != NULL && "tensor buffer not set");
+    GGML_ASSERT(offset + size <= ggml_nbytes(tensor) && "tensor read out of bounds");
 
-    backend->iface.get_tensor_async(backend, tensor, data, offset, size);
-    backend->iface.synchronize(backend);
+    tensor->buffer->iface.get_tensor(tensor->buffer, tensor, data, offset, size);
 }
 
 void ggml_backend_synchronize(ggml_backend_t backend) {
+    if (backend->iface.synchronize == NULL) {
+        return;
+    }
+
     backend->iface.synchronize(backend);
 }
 
@@ -154,10 +175,16 @@ void ggml_backend_graph_plan_free(ggml_backend_t backend, ggml_backend_graph_pla
 
 void ggml_backend_graph_plan_compute(ggml_backend_t backend, ggml_backend_graph_plan_t plan) {
     backend->iface.graph_plan_compute(backend, plan);
+
+    // TODO: optional sync
+    ggml_backend_synchronize(backend);
 }
 
 void ggml_backend_graph_compute(ggml_backend_t backend, struct ggml_cgraph * cgraph) {
     backend->iface.graph_compute(backend, cgraph);
+
+    // TODO: optional sync
+    ggml_backend_synchronize(backend);
 }
 
 bool ggml_backend_supports_op(ggml_backend_t backend, const struct ggml_tensor * op) {
@@ -194,14 +221,15 @@ void ggml_backend_tensor_copy(struct ggml_tensor * src, struct ggml_tensor * dst
 
     // TODO: allow backends to support copy to/from same backend
 
-    if (ggml_get_backend(dst)->iface.cpy_tensor_from != NULL) {
-        ggml_get_backend(dst)->iface.cpy_tensor_from(ggml_get_backend(dst)->context, src, dst);
-    } else if (ggml_get_backend(src)->iface.cpy_tensor_to != NULL) {
-        ggml_get_backend(src)->iface.cpy_tensor_to(ggml_get_backend(src)->context, src, dst);
+    if (dst->buffer->iface.cpy_tensor_from != NULL) {
+        dst->buffer->iface.cpy_tensor_from(dst->buffer, src, dst);
+    } else if (src->buffer->iface.cpy_tensor_to != NULL) {
+        src->buffer->iface.cpy_tensor_to(src->buffer, src, dst);
     } else {
         // shouldn't be hit when copying from/to CPU
         #ifndef NDEBUG
-        fprintf(stderr, "ggml_backend_tensor_copy: neither cpy_tensor_from nor cpy_tensor_to are implemented for backends %s and %s, falling back to get/set\n", ggml_backend_name(src->buffer->backend), ggml_backend_name(dst->buffer->backend));
+        fprintf(stderr, "ggml_backend_tensor_copy: neither cpy_tensor_from nor cpy_tensor_to "
+                        "are implemented for %s and %s, falling back to get/set\n", src->name, dst->name);
         #endif
         size_t nbytes = ggml_nbytes(src);
         void * data = malloc(nbytes);
@@ -211,7 +239,181 @@ void ggml_backend_tensor_copy(struct ggml_tensor * src, struct ggml_tensor * dst
     }
 }
 
+// backend registry
+
+struct ggml_backend_reg {
+    const char * name;
+    ggml_backend_init_fn init_fn;
+    ggml_backend_buffer_type_t default_buffer_type;
+};
+
+#define GGML_MAX_BACKENDS_REG 16
+static struct ggml_backend_reg ggml_backend_registry[GGML_MAX_BACKENDS_REG];
+static size_t ggml_backend_registry_count = 0;
+
+size_t ggml_backend_register(const char * name, ggml_backend_init_fn init_fn, ggml_backend_buffer_type_t default_buffer_type) {
+    GGML_ASSERT(ggml_backend_registry_count < GGML_MAX_BACKENDS_REG);
+    ggml_backend_registry[ggml_backend_registry_count++] = (struct ggml_backend_reg) {
+        /* .name                = */ name,
+        /* .fn                  = */ init_fn,
+        /* .default_buffer_type = */ default_buffer_type
+    };
+    fprintf(stderr, "%s: registered backend %s\n", __func__, name);
+    return ggml_backend_registry_count - 1;
+}
+
+
+size_t ggml_backend_reg_get_count(void) {
+    return ggml_backend_registry_count;
+}
+
+size_t ggml_backend_reg_find_by_name(const char * name) {
+    for (size_t i = 0; i < ggml_backend_registry_count; i++) {
+        // TODO: case insensitive in a portable way
+        if (strcmp(ggml_backend_registry[i].name, name) == 0) {
+            return i;
+        }
+    }
+    return SIZE_MAX;
+}
+
+// init from backend:params string
+ggml_backend_t ggml_backend_reg_init_backend_from_str(const char * backend_str) {
+    const char * params = strchr(backend_str, ':');
+    char backend_name[128];
+    if (params == NULL) {
+        strcpy(backend_name, backend_str);
+        params = "";
+    } else {
+        strncpy(backend_name, backend_str, params - backend_str);
+        backend_name[params - backend_str] = '\0';
+        params++;
+    }
+
+    size_t backend_i = ggml_backend_reg_find_by_name(backend_name);
+    if (backend_i == SIZE_MAX) {
+        fprintf(stderr, "%s: backend %s not found\n", __func__, backend_name);
+        return NULL;
+    }
+
+    return ggml_backend_reg_init_backend(backend_i, params);
+}
+
+const char * ggml_backend_reg_get_name(size_t i) {
+    GGML_ASSERT(i < ggml_backend_registry_count);
+    return ggml_backend_registry[i].name;
+}
+
+ggml_backend_t ggml_backend_reg_init_backend(size_t i, const char * params) {
+    GGML_ASSERT(i < ggml_backend_registry_count);
+    return ggml_backend_registry[i].init_fn(params);
+}
+
+ggml_backend_buffer_type_t ggml_backend_reg_get_default_buffer_type(size_t i) {
+    GGML_ASSERT(i < ggml_backend_registry_count);
+    return ggml_backend_registry[i].default_buffer_type;
+}
+
+ggml_backend_buffer_t ggml_backend_reg_alloc_buffer(size_t i, size_t size) {
+    GGML_ASSERT(i < ggml_backend_registry_count);
+    return ggml_backend_buft_alloc_buffer(ggml_backend_registry[i].default_buffer_type, size);
+}
+
 // backend CPU
+
+static void * ggml_backend_cpu_buffer_get_base(ggml_backend_buffer_t buffer) {
+    return (void *)buffer->context;
+}
+
+static void ggml_backend_cpu_buffer_free_buffer(ggml_backend_buffer_t buffer) {
+    free(buffer->context);
+    GGML_UNUSED(buffer);
+}
+
+static void ggml_backend_cpu_buffer_set_tensor(ggml_backend_buffer_t buffer, struct ggml_tensor * tensor, const void * data, size_t offset, size_t size) {
+    GGML_ASSERT(offset + size <= ggml_nbytes(tensor) && "tensor write out of bounds");
+    GGML_ASSERT(tensor->data != NULL && "tensor not allocated");
+
+    memcpy((char *)tensor->data + offset, data, size);
+
+    GGML_UNUSED(buffer);
+}
+
+static void ggml_backend_cpu_buffer_get_tensor(ggml_backend_buffer_t buffer, const struct ggml_tensor * tensor, void * data, size_t offset, size_t size) {
+    GGML_ASSERT(offset + size <= ggml_nbytes(tensor) && "tensor read out of bounds");
+    GGML_ASSERT(tensor->data != NULL && "tensor not allocated");
+
+    memcpy(data, (const char *)tensor->data + offset, size);
+
+    GGML_UNUSED(buffer);
+}
+
+static void ggml_backend_cpu_buffer_cpy_tensor_from(ggml_backend_buffer_t buffer, struct ggml_tensor * src, struct ggml_tensor * dst) {
+    ggml_backend_tensor_get(src, dst->data, 0, ggml_nbytes(src));
+
+    GGML_UNUSED(buffer);
+}
+
+static void ggml_backend_cpu_buffer_cpy_tensor_to(ggml_backend_buffer_t buffer, struct ggml_tensor * src, struct ggml_tensor * dst) {
+    ggml_backend_tensor_set(dst, src->data, 0, ggml_nbytes(src));
+
+    GGML_UNUSED(buffer);
+}
+
+static struct ggml_backend_buffer_i cpu_backend_buffer_i = {
+    /* .free_buffer     = */ ggml_backend_cpu_buffer_free_buffer,
+    /* .get_base        = */ ggml_backend_cpu_buffer_get_base,
+    /* .init_tensor     = */ NULL, // no initialization required
+    /* .set_tensor      = */ ggml_backend_cpu_buffer_set_tensor,
+    /* .get_tensor      = */ ggml_backend_cpu_buffer_get_tensor,
+    /* .cpy_tensor_from = */ ggml_backend_cpu_buffer_cpy_tensor_from,
+    /* .cpy_tensor_to   = */ ggml_backend_cpu_buffer_cpy_tensor_to,
+};
+
+// for buffers from ptr, free is not called
+static struct ggml_backend_buffer_i cpu_backend_buffer_i_from_ptr = {
+    /* .free_buffer     = */ NULL, // ptr is not owned by the buffer, so it does not need to be freed
+    /* .get_base        = */ ggml_backend_cpu_buffer_get_base,
+    /* .init_tensor     = */ NULL, // no initialization required
+    /* .set_tensor      = */ ggml_backend_cpu_buffer_set_tensor,
+    /* .get_tensor      = */ ggml_backend_cpu_buffer_get_tensor,
+    /* .cpy_tensor_from = */ ggml_backend_cpu_buffer_cpy_tensor_from,
+    /* .cpy_tensor_to   = */ ggml_backend_cpu_buffer_cpy_tensor_to,
+};
+
+static const size_t TENSOR_ALIGNMENT = 64; // should be enough for AVX 512
+
+static ggml_backend_buffer_t ggml_backend_cpu_buffer_type_alloc_buffer(ggml_backend_buffer_type_t buft, size_t size) {
+    size += TENSOR_ALIGNMENT;   // malloc may return an address that is not aligned
+    void * data = malloc(size); // TODO: maybe use GGML_ALIGNED_MALLOC?
+
+    GGML_ASSERT(data != NULL && "failed to allocate buffer");
+
+    return ggml_backend_buffer_init(buft, cpu_backend_buffer_i, data, size);
+}
+
+static size_t ggml_backend_cpu_buffer_type_get_alignment(ggml_backend_buffer_type_t buft) {
+    return TENSOR_ALIGNMENT;
+
+    GGML_UNUSED(buft);
+}
+
+static bool ggml_backend_cpu_buffer_type_supports_backend(ggml_backend_buffer_type_t buft, ggml_backend_t backend) {
+    return ggml_backend_is_cpu(backend);
+
+    GGML_UNUSED(buft);
+}
+
+static struct ggml_backend_buffer_type ggml_backend_buffer_type_cpu_inst = {
+    /* .iface = */ {
+        /* .alloc_buffer     = */ ggml_backend_cpu_buffer_type_alloc_buffer,
+        /* .get_alignment    = */ ggml_backend_cpu_buffer_type_get_alignment,
+        /* .get_alloc_size   = */ NULL, // defaults to ggml_nbytes
+        /* .supports_backend = */ ggml_backend_cpu_buffer_type_supports_backend,
+    }
+};
+
+ggml_backend_buffer_type_t ggml_backend_buffer_type_cpu = &ggml_backend_buffer_type_cpu_inst;
 
 struct ggml_backend_cpu_context {
     int n_threads;
@@ -222,7 +424,7 @@ struct ggml_backend_cpu_context {
 static const char * ggml_backend_cpu_name(ggml_backend_t backend) {
     return "CPU";
 
-    UNUSED(backend);
+    GGML_UNUSED(backend);
 }
 
 static void ggml_backend_cpu_free(ggml_backend_t backend) {
@@ -232,80 +434,10 @@ static void ggml_backend_cpu_free(ggml_backend_t backend) {
     free(backend);
 }
 
-static void * ggml_backend_cpu_buffer_get_base(ggml_backend_buffer_t buffer) {
-    return (void *)buffer->context;
-}
+static ggml_backend_buffer_type_t ggml_backend_cpu_get_default_buffer_type(ggml_backend_t backend) {
+    return ggml_backend_buffer_type_cpu;
 
-static void ggml_backend_cpu_buffer_free_buffer(ggml_backend_buffer_t buffer) {
-    free(buffer->context);
-    UNUSED(buffer);
-}
-
-static struct ggml_backend_buffer_i cpu_backend_buffer_i = {
-    /* .free_buffer    = */ ggml_backend_cpu_buffer_free_buffer,
-    /* .get_base       = */ ggml_backend_cpu_buffer_get_base,
-    /* .get_alloc_size = */ NULL, // defaults to ggml_nbytes
-    /* .init_tensor    = */ NULL, // no initialization required
-    /* .free_tensor    = */ NULL, // no cleanup required
-};
-
-// for buffers from ptr, free is not called
-static struct ggml_backend_buffer_i cpu_backend_buffer_i_from_ptr = {
-    /* .free_buffer    = */ NULL, // ptr is not owned by the buffer, so it does not need to be freed
-    /* .get_base       = */ ggml_backend_cpu_buffer_get_base,
-    /* .get_alloc_size = */ NULL, // defaults to ggml_nbytes
-    /* .init_tensor    = */ NULL,
-    /* .free_tensor    = */ NULL,
-};
-
-static const size_t TENSOR_ALIGNMENT = 64; // should be enough for AVX 512
-
-static ggml_backend_buffer_t ggml_backend_cpu_alloc_buffer(ggml_backend_t backend, size_t size) {
-    size += TENSOR_ALIGNMENT;   // malloc may return an address that is not aligned
-    void * data = malloc(size); // TODO: maybe use GGML_ALIGNED_MALLOC?
-
-    GGML_ASSERT(data != NULL && "failed to allocate buffer");
-
-    return ggml_backend_buffer_init(backend, cpu_backend_buffer_i, data, size);
-}
-
-static size_t ggml_backend_cpu_get_alignment(ggml_backend_t backend) {
-    return TENSOR_ALIGNMENT;
-    UNUSED(backend);
-}
-
-static void ggml_backend_cpu_set_tensor_async(ggml_backend_t backend, struct ggml_tensor * tensor, const void * data, size_t offset, size_t size) {
-    GGML_ASSERT(offset + size <= ggml_nbytes(tensor) && "tensor write out of bounds");
-    GGML_ASSERT(tensor->data != NULL && "tensor not allocated");
-
-    memcpy((char *)tensor->data + offset, data, size);
-
-    UNUSED(backend);
-}
-
-static void ggml_backend_cpu_get_tensor_async(ggml_backend_t backend, const struct ggml_tensor * tensor, void * data, size_t offset, size_t size) {
-    GGML_ASSERT(offset + size <= ggml_nbytes(tensor) && "tensor read out of bounds");
-    GGML_ASSERT(tensor->data != NULL && "tensor not allocated");
-
-    memcpy(data, (const char *)tensor->data + offset, size);
-
-    UNUSED(backend);
-}
-
-static void ggml_backend_cpu_synchronize(ggml_backend_t backend) {
-    UNUSED(backend);
-}
-
-static void ggml_backend_cpu_cpy_tensor_from(ggml_backend_t backend, struct ggml_tensor * src, struct ggml_tensor * dst) {
-    ggml_backend_tensor_get(src, dst->data, 0, ggml_nbytes(src));
-
-    UNUSED(backend);
-}
-
-static void ggml_backend_cpu_cpy_tensor_to(ggml_backend_t backend, struct ggml_tensor * src, struct ggml_tensor * dst) {
-    ggml_backend_tensor_set(dst, src->data, 0, ggml_nbytes(src));
-
-    UNUSED(backend);
+    GGML_UNUSED(backend);
 }
 
 struct ggml_backend_plan_cpu {
@@ -334,7 +466,7 @@ static void ggml_backend_cpu_graph_plan_free(ggml_backend_t backend, ggml_backen
     free(cpu_plan->cplan.work_data);
     free(cpu_plan);
 
-    UNUSED(backend);
+    GGML_UNUSED(backend);
 }
 
 static void ggml_backend_cpu_graph_plan_compute(ggml_backend_t backend, ggml_backend_graph_plan_t plan) {
@@ -342,7 +474,7 @@ static void ggml_backend_cpu_graph_plan_compute(ggml_backend_t backend, ggml_bac
 
     ggml_graph_compute(&cpu_plan->cgraph, &cpu_plan->cplan);
 
-    UNUSED(backend);
+    GGML_UNUSED(backend);
 }
 
 static void ggml_backend_cpu_graph_compute(ggml_backend_t backend, struct ggml_cgraph * cgraph) {
@@ -363,25 +495,24 @@ static void ggml_backend_cpu_graph_compute(ggml_backend_t backend, struct ggml_c
 
 static bool ggml_backend_cpu_supports_op(ggml_backend_t backend, const struct ggml_tensor * op) {
     return true;
-    UNUSED(backend);
-    UNUSED(op);
+    GGML_UNUSED(backend);
+    GGML_UNUSED(op);
 }
 
 static struct ggml_backend_i cpu_backend_i = {
-    /* .get_name            = */ ggml_backend_cpu_name,
-    /* .free                = */ ggml_backend_cpu_free,
-    /* .alloc_buffer        = */ ggml_backend_cpu_alloc_buffer,
-    /* .get_alignment       = */ ggml_backend_cpu_get_alignment,
-    /* .set_tensor_async    = */ ggml_backend_cpu_set_tensor_async,
-    /* .get_tensor_async    = */ ggml_backend_cpu_get_tensor_async,
-    /* .synchronize         = */ ggml_backend_cpu_synchronize,
-    /* .cpy_tensor_from     = */ ggml_backend_cpu_cpy_tensor_from,
-    /* .cpy_tensor_to       = */ ggml_backend_cpu_cpy_tensor_to,
-    /* .graph_plan_create   = */ ggml_backend_cpu_graph_plan_create,
-    /* .graph_plan_free     = */ ggml_backend_cpu_graph_plan_free,
-    /* .graph_plan_compute  = */ ggml_backend_cpu_graph_plan_compute,
-    /* .graph_compute       = */ ggml_backend_cpu_graph_compute,
-    /* .supports_op         = */ ggml_backend_cpu_supports_op,
+    /* .get_name                = */ ggml_backend_cpu_name,
+    /* .free                    = */ ggml_backend_cpu_free,
+    /* .get_default_buffer_type = */ ggml_backend_cpu_get_default_buffer_type,
+    /* .set_tensor_async        = */ NULL,
+    /* .get_tensor_async        = */ NULL,
+    /* .cpy_tensor_from_async   = */ NULL,
+    /* .cpy_tensor_to_async     = */ NULL,
+    /* .synchronize             = */ NULL,
+    /* .graph_plan_create       = */ ggml_backend_cpu_graph_plan_create,
+    /* .graph_plan_free         = */ ggml_backend_cpu_graph_plan_free,
+    /* .graph_plan_compute      = */ ggml_backend_cpu_graph_plan_compute,
+    /* .graph_compute           = */ ggml_backend_cpu_graph_compute,
+    /* .supports_op             = */ ggml_backend_cpu_supports_op,
 };
 
 ggml_backend_t ggml_backend_cpu_init(void) {
@@ -411,9 +542,16 @@ void ggml_backend_cpu_set_n_threads(ggml_backend_t backend_cpu, int n_threads) {
     ctx->n_threads = n_threads;
 }
 
-ggml_backend_buffer_t ggml_backend_cpu_buffer_from_ptr(ggml_backend_t backend_cpu, void * ptr, size_t size) {
-    return ggml_backend_buffer_init(backend_cpu, cpu_backend_buffer_i_from_ptr, ptr, size);
+ggml_backend_buffer_t ggml_backend_cpu_buffer_from_ptr(void * ptr, size_t size) {
+    return ggml_backend_buffer_init(ggml_backend_buffer_type_cpu, cpu_backend_buffer_i_from_ptr, ptr, size);
 }
+
+static ggml_backend_t ggml_backend_reg_cpu_init(const char * params) {
+    return ggml_backend_cpu_init();
+    GGML_UNUSED(params);
+}
+
+GGML_BACKEND_REGISTER_CONS("CPU", ggml_backend_reg_cpu_init, ggml_backend_buffer_type_cpu)
 
 // scheduler
 
@@ -427,7 +565,7 @@ struct ggml_backend_sched_split {
     int i_end;
     struct ggml_tensor * inputs[GGML_MAX_SPLIT_INPUTS];
     int n_inputs;
-    struct ggml_cgraph * graph;
+    struct ggml_cgraph graph;
 };
 
 struct ggml_backend_sched {
@@ -453,7 +591,7 @@ struct ggml_backend_sched {
     #else
     __attribute__((aligned(GGML_MEM_ALIGN)))
     #endif
-    char context_buffer[GGML_MAX_SPLITS*GGML_MAX_SPLIT_INPUTS*sizeof(struct ggml_tensor) + GGML_MAX_SPLITS*sizeof(struct ggml_cgraph)];
+    char context_buffer[GGML_MAX_SPLITS*GGML_MAX_SPLIT_INPUTS*sizeof(struct ggml_tensor) + sizeof(struct ggml_cgraph)];
 };
 
 #define hash_id(node) ggml_hash_find_or_insert(sched->hash_set, node)
@@ -482,6 +620,32 @@ static int sched_allocr_prio(ggml_backend_sched_t sched, ggml_tallocr_t allocr) 
     return INT_MAX;
 }
 
+static ggml_backend_t get_buffer_backend(ggml_backend_sched_t sched, ggml_backend_buffer_t buffer) {
+    if (buffer == NULL) {
+        return NULL;
+    }
+    // find highest prio backend that supports the buffer type
+    for (int i = 0; i < sched->n_backends; i++) {
+        if (ggml_backend_buft_supports_backend(buffer->buft, sched->backends[i])) {
+            return sched->backends[i];
+        }
+    }
+    GGML_ASSERT(false && "tensor buffer type not supported by any backend");
+}
+
+static ggml_backend_t get_allocr_backend(ggml_backend_sched_t sched, ggml_tallocr_t allocr) {
+    if (allocr == NULL) {
+        return NULL;
+    }
+    // find highest prio backend that supports the buffer type
+    for (int i = 0; i < sched->n_backends; i++) {
+        if (sched->tallocs[i] == allocr) {
+            return sched->backends[i];
+        }
+    }
+    GGML_ASSERT(false); // should never happen
+}
+
 // returns the backend that should be used for the node based on the current locations
 char causes[GGML_DEFAULT_GRAPH_SIZE*4 + GGML_MAX_SPLITS*GGML_MAX_SPLIT_INPUTS][128]; // debug, remove
 static ggml_backend_t sched_backend_from_cur(ggml_backend_sched_t sched, struct ggml_tensor * node) {
@@ -489,16 +653,16 @@ static ggml_backend_t sched_backend_from_cur(ggml_backend_sched_t sched, struct 
     // ie. kv cache updates
     // note that this doesn't allow fallback to CPU. need to add output tensors to the splits to copy the data back to the original backend.
     // dst
-    ggml_backend_t cur_backend = ggml_get_backend(node);
+    ggml_backend_t cur_backend = get_buffer_backend(sched, node->buffer);
     if (cur_backend != NULL) {
         sprintf(causes[hash_id(node)], "1.dst");
         return cur_backend;
     }
 
     // view_src
-    if (node->view_src != NULL && ggml_get_backend(node->view_src) != NULL) {
+    if (node->view_src != NULL && get_buffer_backend(sched, node->view_src->buffer) != NULL) {
         sprintf(causes[hash_id(node)], "1.vsrc");
-        return ggml_get_backend(node->view_src);
+        return get_buffer_backend(sched, node->view_src->buffer);
     }
 
     // src
@@ -510,7 +674,7 @@ static ggml_backend_t sched_backend_from_cur(ggml_backend_sched_t sched, struct 
         if (src == NULL) {
             break;
         }
-        ggml_backend_t src_backend = ggml_get_backend(src);
+        ggml_backend_t src_backend = get_buffer_backend(sched, src->buffer);
         if (src_backend != NULL) {
             int src_prio = sched_backend_prio(sched, src_backend);
             size_t src_size = ggml_nbytes(src);
@@ -539,10 +703,12 @@ static void sched_print_assignments(ggml_backend_sched_t sched, struct ggml_cgra
     int cur_split = 0;
     for (int i = 0; i < graph->n_nodes; i++) {
         if (cur_split < sched->n_splits && i == sched->splits[cur_split].i_start) {
-            ggml_backend_t split_backend = ggml_tallocr_get_buffer(sched->splits[cur_split].tallocr)->backend;
-            fprintf(stderr, "\n## SPLIT #%d: %s # %d inputs: ", cur_split, ggml_backend_name(split_backend), sched->splits[cur_split].n_inputs);
+            ggml_backend_t split_backend = get_allocr_backend(sched, sched->splits[cur_split].tallocr);
+            fprintf(stderr, "\n## SPLIT #%d: %s # %d inputs: ", cur_split, ggml_backend_name(split_backend),
+                sched->splits[cur_split].n_inputs);
             for (int j = 0; j < sched->splits[cur_split].n_inputs; j++) {
-                fprintf(stderr, "[%s (%5.5s)] ", sched->splits[cur_split].inputs[j]->name, fmt_size(ggml_nbytes(sched->splits[cur_split].inputs[j])));
+                fprintf(stderr, "[%s (%5.5s)] ", sched->splits[cur_split].inputs[j]->name,
+                    fmt_size(ggml_nbytes(sched->splits[cur_split].inputs[j])));
             }
             fprintf(stderr, "\n");
             cur_split++;
@@ -552,16 +718,18 @@ static void sched_print_assignments(ggml_backend_sched_t sched, struct ggml_cgra
             continue;
         }
         ggml_tallocr_t node_allocr = node_allocr(node);
-        ggml_backend_t node_backend = node_allocr ? ggml_tallocr_get_buffer(node_allocr)->backend : NULL;
-        fprintf(stderr, "node #%3d (%10.10s): %20.20s (%4.4s) [%4.4s %8.8s]:", i, ggml_op_name(node->op), node->name, fmt_size(ggml_nbytes(node)), node_allocr ? ggml_backend_name(node_backend) : "NULL", causes[hash_id(node)]);
+        ggml_backend_t node_backend = node_allocr ? get_allocr_backend(sched, node_allocr) : NULL; // FIXME:
+        fprintf(stderr, "node #%3d (%10.10s): %20.20s (%4.4s) [%4.4s %8.8s]:", i, ggml_op_name(node->op), node->name,
+            fmt_size(ggml_nbytes(node)), node_allocr ? ggml_backend_name(node_backend) : "NULL", causes[hash_id(node)]);
         for (int j = 0; j < GGML_MAX_SRC; j++) {
             struct ggml_tensor * src = node->src[j];
             if (src == NULL) {
                 break;
             }
             ggml_tallocr_t src_allocr = node_allocr(src);
-            ggml_backend_t src_backend = src_allocr ? ggml_tallocr_get_buffer(src_allocr)->backend : NULL;
-            fprintf(stderr, " %20.20s (%4.4s) [%4.4s %8.8s]", src->name, fmt_size(ggml_nbytes(src)), src_backend ? ggml_backend_name(src_backend) : "NULL", causes[hash_id(src)]);
+            ggml_backend_t src_backend = src_allocr ? get_allocr_backend(sched, src_allocr) : NULL;
+            fprintf(stderr, " %20.20s (%4.4s) [%4.4s %8.8s]", src->name,
+                fmt_size(ggml_nbytes(src)), src_backend ? ggml_backend_name(src_backend) : "NULL", causes[hash_id(src)]);
         }
         fprintf(stderr, "\n");
     }
@@ -587,9 +755,9 @@ static void sched_split_graph(ggml_backend_sched_t sched, struct ggml_cgraph * g
     sched->n_splits = 0;
 
     struct ggml_init_params params = {
-        /*.mem_size =   */ sizeof(sched->context_buffer),
-        /*.mem_buffer = */ sched->context_buffer,
-        /*.no_alloc =   */ true
+        /* .mem_size =   */ sizeof(sched->context_buffer),
+        /* .mem_buffer = */ sched->context_buffer,
+        /* .no_alloc =   */ true
     };
 
     if (sched->ctx != NULL) {
@@ -605,9 +773,9 @@ static void sched_split_graph(ggml_backend_sched_t sched, struct ggml_cgraph * g
             // do not overwrite user assignments
             continue;
         }
-        ggml_backend_t leaf_backend = ggml_get_backend(leaf);
+        ggml_backend_t leaf_backend = get_buffer_backend(sched, leaf->buffer);
         if (leaf_backend == NULL && leaf->view_src != NULL) {
-            leaf_backend = ggml_get_backend(leaf->view_src);
+            leaf_backend = get_buffer_backend(sched, leaf->view_src->buffer);
         }
         if (leaf_backend != NULL) {
             node_allocr(leaf) = ggml_backend_sched_get_tallocr(sched, leaf_backend);
@@ -733,7 +901,7 @@ static void sched_split_graph(ggml_backend_sched_t sched, struct ggml_cgraph * g
                     struct ggml_tensor * tensor_copy = ggml_dup_tensor_layout(sched->ctx, src);
                     sched->node_copies[id][cur_backend_id] = tensor_copy;
                     node_allocr(tensor_copy) = cur_allocr;
-                    ggml_backend_t backend = ggml_tallocr_get_buffer(cur_allocr)->backend;
+                    ggml_backend_t backend = get_allocr_backend(sched, cur_allocr);
                     ggml_format_name(tensor_copy, "%s#%s", ggml_backend_name(backend), src->name);
                 }
                 node->src[j] = sched->node_copies[id][cur_backend_id];
@@ -761,8 +929,8 @@ static void sched_split_graph(ggml_backend_sched_t sched, struct ggml_cgraph * g
             ggml_tallocr_t src_allocr = node_allocr(src);
             if (src_allocr != node_allocr /* && src_backend != NULL */) { // ignore nulls for now
                 fprintf(stderr, "!!!! %s has backend %s, src %d (%s) has backend %s\n",
-                    node->name, node_allocr ? ggml_backend_name(ggml_tallocr_get_buffer(node_allocr)->backend) : "NULL",
-                    j, src->name, src_allocr ? ggml_backend_name(ggml_tallocr_get_buffer(src_allocr)->backend) : "NULL");
+                    node->name, node_allocr ? ggml_backend_name(get_allocr_backend(sched, node_allocr)) : "NULL",
+                    j, src->name, src_allocr ? ggml_backend_name(get_allocr_backend(sched, src_allocr)) : "NULL");
             }
         }
     }
@@ -773,7 +941,7 @@ static void sched_split_graph(ggml_backend_sched_t sched, struct ggml_cgraph * g
     struct ggml_cgraph * graph_copy = ggml_new_graph_custom(sched->ctx, graph->n_nodes + sched->n_splits*GGML_MAX_SPLIT_INPUTS, false);
     for (int i = 0; i < sched->n_splits; i++) {
         struct ggml_backend_sched_split * split = &sched->splits[i];
-        split->graph = ggml_graph_view(sched->ctx, graph, split->i_start, split->i_end);
+        split->graph = ggml_graph_view(graph, split->i_start, split->i_end);
 
         // add inputs to the graph copy so that they are allocated by ggml-alloc at the start of the split
         for (int j = 0; j < split->n_inputs; j++) {
@@ -806,7 +974,7 @@ static void sched_compute_splits(ggml_backend_sched_t sched) {
 
     for (int i = 0; i < sched->n_splits; i++) {
         struct ggml_backend_sched_split * split = &splits[i];
-        ggml_backend_t split_backend = ggml_tallocr_get_buffer(split->tallocr)->backend;
+        ggml_backend_t split_backend = get_allocr_backend(sched, split->tallocr);
         int split_backend_id = sched_backend_prio(sched, split_backend);
 
         // copy the input tensors to the split backend
@@ -822,14 +990,15 @@ static void sched_compute_splits(ggml_backend_sched_t sched) {
                 view->backend = view->view_src->backend;
                 view->buffer  = view->view_src->buffer;
                 view->data    = (char *)view->view_src->data + view->view_offs;
-                ggml_backend_buffer_init_tensor(ggml_backend_sched_get_buffer(sched, view->buffer->backend), view);
+                //ggml_backend_buffer_init_tensor(ggml_backend_sched_get_buffer(sched, view->buffer->backend), view);
+                ggml_backend_buffer_init_tensor(view->buffer, view);
             }
             if (input_cpy->buffer == NULL) {
                 fprintf(stderr, "input_cpy %s has no buffer\n", input_cpy->name);
                 exit(1);
             }
-            GGML_ASSERT(split->inputs[j]->buffer->backend != input_cpy->buffer->backend);
-            GGML_ASSERT(input_cpy->buffer->backend == split_backend);
+            //GGML_ASSERT(split->inputs[j]->buffer->backend != input_cpy->buffer->backend);
+            //GGML_ASSERT(input_cpy->buffer->backend == split_backend);
             ggml_backend_tensor_copy(split->inputs[j], input_cpy);
         }
         // ggml_backend_synchronize(split_backend);
@@ -843,7 +1012,7 @@ static void sched_compute_splits(ggml_backend_sched_t sched) {
 #endif
 
         uint64_t compute_start_us = ggml_time_us();
-        ggml_backend_graph_compute(split_backend, split->graph);
+        ggml_backend_graph_compute(split_backend, &split->graph);
         // ggml_backend_synchronize(split_backend);
         uint64_t compute_end_us = ggml_time_us();
         compute_us[split_backend_id] += compute_end_us - compute_start_us;
@@ -947,4 +1116,154 @@ void ggml_backend_sched_set_node_backend(ggml_backend_sched_t sched, struct ggml
     int backend_index = sched_backend_prio(sched, backend);
     GGML_ASSERT(backend_index >= 0 && backend_index < sched->n_backends);
     node_allocr(node) = sched->tallocs[backend_index];
+}
+
+// utils
+static struct ggml_tensor * graph_dup_tensor(struct ggml_hash_set hash_set, struct ggml_tensor ** node_copies,
+    struct ggml_context * ctx_allocated, struct ggml_context * ctx_unallocated, struct ggml_tensor * src) {
+
+    GGML_ASSERT(src != NULL);
+    GGML_ASSERT(src->data && "graph must be allocated");
+
+    size_t id = ggml_hash_insert(hash_set, src);
+    if (id == GGML_HASHTABLE_ALREADY_EXISTS) {
+        return node_copies[ggml_hash_find(hash_set, src)];
+    }
+
+    struct ggml_tensor * dst = ggml_dup_tensor_layout(src->data && !src->view_src ? ctx_allocated : ctx_unallocated, src);
+    ggml_set_name(dst, src->name);
+    if (src->view_src != NULL) {
+        dst->view_src = graph_dup_tensor(hash_set, node_copies, ctx_allocated, ctx_unallocated, src->view_src);
+        dst->view_offs = src->view_offs;
+    }
+    dst->op = src->op;
+
+    // copy src
+    for (int i = 0; i < GGML_MAX_SRC; i++) {
+        struct ggml_tensor * s = src->src[i];
+        if (s == NULL) {
+            break;
+        }
+        dst->src[i] = graph_dup_tensor(hash_set, node_copies, ctx_allocated, ctx_unallocated, s);
+    }
+
+    node_copies[id] = dst;
+    return dst;
+}
+
+static void graph_init_tensor(struct ggml_hash_set hash_set, struct ggml_tensor ** node_copies, bool * node_init, struct ggml_tensor * src) {
+    size_t id = ggml_hash_find(hash_set, src);
+    if (node_init[id]) {
+        return;
+    }
+    node_init[id] = true;
+
+    struct ggml_tensor * dst = node_copies[id];
+    if (dst->view_src != NULL) {
+        // todo: add ggml_backend_init_view, reuse in ggml-alloc
+        dst->backend = dst->view_src->backend;
+        dst->buffer = dst->view_src->buffer;
+        dst->data = (char *)dst->view_src->data + dst->view_offs;
+    }
+    else {
+        ggml_backend_tensor_copy(src, dst);
+    }
+
+    // init src
+    for (int i = 0; i < GGML_MAX_SRC; i++) {
+        struct ggml_tensor * s = src->src[i];
+        if (s == NULL) {
+            break;
+        }
+        graph_init_tensor(hash_set, node_copies, node_init, s);
+    }
+}
+
+struct ggml_backend_graph_copy ggml_backend_graph_copy(ggml_backend_t backend, struct ggml_cgraph * graph) {
+    struct ggml_hash_set hash_set = {
+        /* .size = */ graph->visited_hash_table.size,
+        /* .keys = */ calloc(sizeof(hash_set.keys[0]) * graph->visited_hash_table.size, 1)
+    };
+    struct ggml_tensor ** node_copies = calloc(sizeof(node_copies[0]) * hash_set.size, 1);
+    bool * node_init = calloc(sizeof(node_init[0]) * hash_set.size, 1);
+
+    struct ggml_init_params params = {
+        /* .mem_size   = */ ggml_tensor_overhead()*hash_set.size + ggml_graph_overhead_custom(graph->size, false),
+        /* .mem_buffer = */ NULL,
+        /* .no_alloc   = */ true
+    };
+
+    struct ggml_context * ctx_allocated = ggml_init(params);
+    struct ggml_context * ctx_unallocated = ggml_init(params);
+
+    // dup nodes
+    for (int i = 0; i < graph->n_nodes; i++) {
+        struct ggml_tensor * node = graph->nodes[i];
+        graph_dup_tensor(hash_set, node_copies, ctx_allocated, ctx_unallocated, node);
+    }
+
+    // allocate nodes
+    ggml_backend_buffer_t buffer = ggml_backend_alloc_ctx_tensors(ctx_allocated, backend);
+
+    //printf("copy buffer size: %zu MB\n", ggml_backend_buffer_get_size(buffer) / 1024 / 1024);
+
+    // copy data and init views
+    for (int i = 0; i < graph->n_nodes; i++) {
+        struct ggml_tensor * node = graph->nodes[i];
+        graph_init_tensor(hash_set, node_copies, node_init, node);
+    }
+
+    // build graph copy
+    struct ggml_cgraph * graph_copy = ggml_new_graph_custom(ctx_allocated, graph->size, false);
+    for (int i = 0; i < graph->n_nodes; i++) {
+        struct ggml_tensor * node = graph->nodes[i];
+        struct ggml_tensor * node_copy = node_copies[ggml_hash_find(hash_set, node)];
+        graph_copy->nodes[i] = node_copy;
+    }
+    graph_copy->n_nodes = graph->n_nodes;
+
+    free(hash_set.keys);
+    free(node_copies);
+
+    return (struct ggml_backend_graph_copy) {
+        /* .buffer           = */ buffer,
+        /* .ctx_allocated    = */ ctx_allocated,
+        /* .ctx_unallocated  = */ ctx_unallocated,
+        /* .graph            = */ graph_copy,
+    };
+}
+
+void ggml_backend_graph_copy_free(struct ggml_backend_graph_copy copy) {
+    ggml_backend_buffer_free(copy.buffer);
+    ggml_free(copy.ctx_allocated);
+    ggml_free(copy.ctx_unallocated);
+}
+
+void ggml_backend_compare_graph_backend(ggml_backend_t backend1, ggml_backend_t backend2, struct ggml_cgraph * graph, ggml_backend_eval_callback callback, void * user_data) {
+    struct ggml_backend_graph_copy copy = ggml_backend_graph_copy(backend2, graph);
+    struct ggml_cgraph * g1 = graph;
+    struct ggml_cgraph * g2 = copy.graph;
+
+    assert(g1->n_nodes == g2->n_nodes);
+
+    for (int i = 0; i < g1->n_nodes; i++) {
+        //printf("eval %d/%d\n", i, g1->n_nodes);
+        struct ggml_tensor * t1 = g1->nodes[i];
+        struct ggml_tensor * t2 = g2->nodes[i];
+
+        assert(t1->op == t2->op && ggml_are_same_layout(t1, t2));
+
+        struct ggml_cgraph g1v = ggml_graph_view(g1, i, i + 1);
+        struct ggml_cgraph g2v = ggml_graph_view(g2, i, i + 1);
+
+        ggml_backend_graph_compute(backend1, &g1v);
+        ggml_backend_graph_compute(backend2, &g2v);
+
+        // compare results, calculate rms etc
+        if (!callback(i, t1, t2, user_data)) {
+            break;
+        }
+    }
+
+    ggml_backend_graph_copy_free(copy);
 }

--- a/src/ggml-backend.c
+++ b/src/ggml-backend.c
@@ -659,7 +659,7 @@ static ggml_backend_t get_allocr_backend(ggml_backend_sched_t sched, ggml_talloc
             return sched->backends[i];
         }
     }
-    assert(false); // should never happen
+    GGML_UNREACHABLE();
 }
 
 // returns the backend that should be used for the node based on the current locations

--- a/src/ggml-backend.c
+++ b/src/ggml-backend.c
@@ -404,7 +404,7 @@ static bool ggml_backend_cpu_buffer_type_supports_backend(ggml_backend_buffer_ty
     GGML_UNUSED(buft);
 }
 
-static struct ggml_backend_buffer_type ggml_backend_buffer_type_cpu_inst = {
+static struct ggml_backend_buffer_type ggml_backend_buffer_type_cpu = {
     /* .iface = */ {
         /* .alloc_buffer     = */ ggml_backend_cpu_buffer_type_alloc_buffer,
         /* .get_alignment    = */ ggml_backend_cpu_buffer_type_get_alignment,
@@ -413,7 +413,9 @@ static struct ggml_backend_buffer_type ggml_backend_buffer_type_cpu_inst = {
     }
 };
 
-ggml_backend_buffer_type_t ggml_backend_buffer_type_cpu = &ggml_backend_buffer_type_cpu_inst;
+ggml_backend_buffer_type_t ggml_backend_cpu_buffer_type(void) {
+    return &ggml_backend_buffer_type_cpu;
+}
 
 struct ggml_backend_cpu_context {
     int n_threads;
@@ -435,7 +437,7 @@ static void ggml_backend_cpu_free(ggml_backend_t backend) {
 }
 
 static ggml_backend_buffer_type_t ggml_backend_cpu_get_default_buffer_type(ggml_backend_t backend) {
-    return ggml_backend_buffer_type_cpu;
+    return ggml_backend_cpu_buffer_type();
 
     GGML_UNUSED(backend);
 }
@@ -544,7 +546,7 @@ void ggml_backend_cpu_set_n_threads(ggml_backend_t backend_cpu, int n_threads) {
 }
 
 ggml_backend_buffer_t ggml_backend_cpu_buffer_from_ptr(void * ptr, size_t size) {
-    return ggml_backend_buffer_init(ggml_backend_buffer_type_cpu, cpu_backend_buffer_i_from_ptr, ptr, size);
+    return ggml_backend_buffer_init(ggml_backend_cpu_buffer_type(), cpu_backend_buffer_i_from_ptr, ptr, size);
 }
 
 static ggml_backend_t ggml_backend_reg_cpu_init(const char * params) {
@@ -553,7 +555,7 @@ static ggml_backend_t ggml_backend_reg_cpu_init(const char * params) {
     GGML_UNUSED(params);
 }
 
-GGML_BACKEND_REGISTER_CONS("CPU", ggml_backend_reg_cpu_init, ggml_backend_buffer_type_cpu)
+GGML_BACKEND_REGISTER("CPU", ggml_backend_reg_cpu_init, ggml_backend_cpu_buffer_type())
 
 // scheduler
 

--- a/src/ggml-backend.c
+++ b/src/ggml-backend.c
@@ -1181,6 +1181,7 @@ static void graph_init_tensor(struct ggml_hash_set hash_set, struct ggml_tensor 
         dst->backend = dst->view_src->backend;
         dst->buffer = dst->view_src->buffer;
         dst->data = (char *)dst->view_src->data + dst->view_offs;
+        ggml_backend_buffer_init_tensor(dst->buffer, dst);
     }
     else {
         ggml_backend_tensor_copy(src, dst);

--- a/src/ggml-cuda.cu
+++ b/src/ggml-cuda.cu
@@ -8509,7 +8509,13 @@ static bool ggml_backend_cuda_supports_op(ggml_backend_t backend, const ggml_ten
                     return true;
                 default:
                     return false;
-            } break;
+            }
+            break;
+        case GGML_OP_NONE:
+        case GGML_OP_RESHAPE:
+        case GGML_OP_VIEW:
+        case GGML_OP_PERMUTE:
+        case GGML_OP_TRANSPOSE:
         case GGML_OP_NORM:
         case GGML_OP_REPEAT:
         case GGML_OP_GET_ROWS:
@@ -8523,10 +8529,6 @@ static bool ggml_backend_cuda_supports_op(ggml_backend_t backend, const ggml_ten
         case GGML_OP_CLAMP:
         case GGML_OP_CPY:
         case GGML_OP_CONT:
-        case GGML_OP_RESHAPE:
-        case GGML_OP_VIEW:
-        case GGML_OP_PERMUTE:
-        case GGML_OP_TRANSPOSE:
         case GGML_OP_DIAG_MASK_INF:
         case GGML_OP_SOFT_MAX:
         case GGML_OP_ROPE:

--- a/src/ggml-cuda.cu
+++ b/src/ggml-cuda.cu
@@ -8500,8 +8500,6 @@ static void ggml_backend_cuda_graph_compute(ggml_backend_t backend, ggml_cgraph 
 }
 
 static bool ggml_backend_cuda_supports_op(ggml_backend_t backend, const ggml_tensor * tensor) {
-
-
     switch (tensor->op) {
         case GGML_OP_UNARY:
             switch (ggml_get_unary_op(tensor)) {

--- a/src/ggml-cuda.cu
+++ b/src/ggml-cuda.cu
@@ -8343,7 +8343,6 @@ static ggml_backend_buffer_t ggml_backend_cuda_host_buffer_type_alloc_buffer(ggm
     return buffer;
 }
 
-
 struct ggml_backend_buffer_type_i cuda_backend_host_buffer_type_interface = {
     /* .alloc_buffer     = */ ggml_backend_cuda_host_buffer_type_alloc_buffer,
     /* .get_alignment    = */ ggml_backend_cpu_buffer_type()->iface.get_alignment,

--- a/src/ggml-cuda.cu
+++ b/src/ggml-cuda.cu
@@ -8592,19 +8592,13 @@ static ggml_backend_t ggml_backend_reg_cuda_init(const char * params, void * use
 }
 
 static int ggml_backend_cuda_reg_devices() {
-    ggml_init_cublas();
-
-    if (g_cublas_loaded) {
-        int device_count = ggml_cuda_get_device_count();
-        for (int i = 0; i < device_count; i++) {
-            char name[128];
-            snprintf(name, sizeof(name), "%s%d", GGML_CUDA_NAME, i);
-            ggml_backend_register(name, ggml_backend_reg_cuda_init, ggml_backend_cuda_buffer_type(i), (void *) (intptr_t) i);
-        }
-        return device_count;
+    int device_count = ggml_cuda_get_device_count();
+    for (int i = 0; i < device_count; i++) {
+        char name[128];
+        snprintf(name, sizeof(name), "%s%d", GGML_CUDA_NAME, i);
+        ggml_backend_register(name, ggml_backend_reg_cuda_init, ggml_backend_cuda_buffer_type(i), (void *) (intptr_t) i);
     }
-
-    return 0;
+    return device_count;
 }
 
 GGML_CONSTRUCTOR(ggml_backend_cuda_reg_devices)

--- a/src/ggml-cuda.cu
+++ b/src/ggml-cuda.cu
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <float.h>
 #include <limits>
 #include <stdint.h>
 #include <stdio.h>
@@ -4684,8 +4685,9 @@ static __global__ void diag_mask_inf_f32(const float * x, float * dst, const int
     }
 
     const int i = row*ncols + col;
-    dst[i] = col > (n_past + row % rows_per_channel) ? -INFINITY : x[i];
+    //dst[i] = col > (n_past + row % rows_per_channel) ? -INFINITY : x[i];
     //dst[i] = x[i] - (col > n_past + row % rows_per_channel) * INT_MAX; // equivalent within rounding error but slightly faster on GPU
+    dst[i] = x[i] - (col > n_past + row % rows_per_channel) * FLT_MAX;
 }
 
 // the CUDA soft max implementation differs from the CPU implementation

--- a/src/ggml-cuda.cu
+++ b/src/ggml-cuda.cu
@@ -189,7 +189,7 @@ static_assert(sizeof(half) == sizeof(ggml_fp16_t), "wrong fp16 size");
             fprintf(stderr, "\nCUDA error %d at %s:%d: %s\n", err_, __FILE__, __LINE__, \
                 cudaGetErrorString(err_));                                              \
             fprintf(stderr, "current device: %d\n", id);                                \
-            exit(1);                                                                    \
+            GGML_ASSERT(!"CUDA error");                                                 \
         }                                                                               \
     } while (0)
 
@@ -203,7 +203,7 @@ static_assert(sizeof(half) == sizeof(ggml_fp16_t), "wrong fp16 size");
             fprintf(stderr, "\ncuBLAS error %d at %s:%d: %s\n",                         \
                     err_, __FILE__, __LINE__, cublasGetStatusString(err_));             \
             fprintf(stderr, "current device: %d\n", id);                                \
-            exit(1);                                                                    \
+            GGML_ASSERT(!"cuBLAS error");                                               \
         }                                                                               \
     } while (0)
 #else
@@ -215,7 +215,7 @@ static_assert(sizeof(half) == sizeof(ggml_fp16_t), "wrong fp16 size");
             cudaGetDevice(&id);                                                         \
             fprintf(stderr, "\ncuBLAS error %d at %s:%d\n", err_, __FILE__, __LINE__);  \
             fprintf(stderr, "current device: %d\n", id);                                \
-            exit(1);                                                                    \
+            GGML_ASSERT(!"cuBLAS error");                                               \
         }                                                                               \
     } while (0)
 #endif // CUDART_VERSION >= 11

--- a/src/ggml-cuda.cu
+++ b/src/ggml-cuda.cu
@@ -8584,10 +8584,10 @@ bool ggml_backend_is_cuda(ggml_backend_t backend) {
     return backend->iface.get_name == ggml_backend_cuda_name;
 }
 
-
 static ggml_backend_t ggml_backend_reg_cuda_init(const char * params, void * user_data) {
     ggml_backend_t cuda_backend = ggml_backend_cuda_init((int) (intptr_t) user_data);
     return cuda_backend;
+
     UNUSED(params);
 }
 
@@ -8597,17 +8597,14 @@ static int ggml_backend_cuda_reg_devices() {
     if (g_cublas_loaded) {
         int device_count = ggml_cuda_get_device_count();
         for (int i = 0; i < device_count; i++) {
-            ggml_backend_t cuda_backend = ggml_backend_cuda_init(i);
             char name[128];
             snprintf(name, sizeof(name), "%s%d", GGML_CUDA_NAME, i);
             ggml_backend_register(name, ggml_backend_reg_cuda_init, ggml_backend_cuda_buffer_type(i), (void *) (intptr_t) i);
         }
         return device_count;
-    } else {
-        return 0;
     }
+
+    return 0;
 }
 
 GGML_CONSTRUCTOR(ggml_backend_cuda_reg_devices)
-// TODO: per device
-// GGML_BACKEND_REGISTER(GGML_CUDA_NAME, ggml_backend_reg_cuda_init, ggml_backend_cuda_buffer_type())

--- a/src/ggml-cuda.h
+++ b/src/ggml-cuda.h
@@ -57,7 +57,7 @@ GGML_API int  ggml_backend_cuda_get_device(ggml_backend_t backend);
 GGML_API ggml_backend_buffer_type_t ggml_backend_cuda_buffer_type(int device);
 
 // pinned host buffer for use with CPU backend for faster copies between CPU and GPU
-GGML_API ggml_backend_buffer_type_t ggml_backend_cuda_host_buffer_type();
+GGML_API ggml_backend_buffer_type_t ggml_backend_cuda_host_buffer_type(void);
 
 #ifdef  __cplusplus
 }

--- a/src/ggml-cuda.h
+++ b/src/ggml-cuda.h
@@ -49,12 +49,12 @@ GGML_API int    ggml_cuda_get_device_count(void);
 GGML_API void   ggml_cuda_get_device_description(int device, char * description, size_t description_size);
 
 // backend API
-GGML_API ggml_backend_t ggml_backend_cuda_init(/*int device*/);
+GGML_API ggml_backend_t ggml_backend_cuda_init(int device);
 
 GGML_API bool ggml_backend_is_cuda(ggml_backend_t backend);
 GGML_API int  ggml_backend_cuda_get_device(ggml_backend_t backend);
 
-GGML_API ggml_backend_buffer_type_t ggml_backend_cuda_buffer_type(/*int device*/);
+GGML_API ggml_backend_buffer_type_t ggml_backend_cuda_buffer_type(int device);
 
 // pinned host buffer for use with CPU backend for faster copies between CPU and GPU
 GGML_API ggml_backend_buffer_type_t ggml_backend_cuda_host_buffer_type();

--- a/src/ggml-cuda.h
+++ b/src/ggml-cuda.h
@@ -51,6 +51,15 @@ GGML_API void   ggml_cuda_get_device_description(int device, char * description,
 // backend API
 GGML_API ggml_backend_t ggml_backend_cuda_init(void); // TODO: take a list of devices to use
 
+GGML_API bool ggml_backend_is_cuda(ggml_backend_t backend);
+
+GGML_API extern ggml_backend_buffer_type_t ggml_backend_buffer_type_cuda;
+
+// allocate a CPU pinned host buffer usable by the CPU backend, that can be used for faster transfer between CPU and CUDA buffers
+ggml_backend_buffer_t ggml_backend_cuda_alloc_host_buffer(size_t size);
+
+GGML_API extern ggml_backend_buffer_type_t ggml_backend_buffer_type_cuda_host; // TODO: is the alloc function really necessary?
+
 #ifdef  __cplusplus
 }
 #endif

--- a/src/ggml-cuda.h
+++ b/src/ggml-cuda.h
@@ -49,16 +49,15 @@ GGML_API int    ggml_cuda_get_device_count(void);
 GGML_API void   ggml_cuda_get_device_description(int device, char * description, size_t description_size);
 
 // backend API
-GGML_API ggml_backend_t ggml_backend_cuda_init(void); // TODO: take a list of devices to use
+GGML_API ggml_backend_t ggml_backend_cuda_init(/*int device*/);
 
 GGML_API bool ggml_backend_is_cuda(ggml_backend_t backend);
+GGML_API int  ggml_backend_cuda_get_device(ggml_backend_t backend);
 
-GGML_API extern ggml_backend_buffer_type_t ggml_backend_buffer_type_cuda;
+GGML_API ggml_backend_buffer_type_t ggml_backend_cuda_buffer_type(/*int device*/);
 
-// allocate a CPU pinned host buffer usable by the CPU backend, that can be used for faster transfer between CPU and CUDA buffers
-ggml_backend_buffer_t ggml_backend_cuda_alloc_host_buffer(size_t size);
-
-GGML_API extern ggml_backend_buffer_type_t ggml_backend_buffer_type_cuda_host; // TODO: is the alloc function really necessary?
+// pinned host buffer for use with CPU backend for faster copies between CPU and GPU
+GGML_API ggml_backend_buffer_type_t ggml_backend_cuda_host_buffer_type();
 
 #ifdef  __cplusplus
 }

--- a/src/ggml-impl.h
+++ b/src/ggml-impl.h
@@ -232,7 +232,7 @@ bool   ggml_hash_contains      (const struct ggml_hash_set hash_set, struct ggml
 // returns GGML_HASHTABLE_FULL if table is full, otherwise the current index of the key or where it should be inserted
 size_t ggml_hash_find          (const struct ggml_hash_set hash_set, struct ggml_tensor * key);
 
-// returns GGML_HAHSHTABLE_ALREADY_EXISTS if key already exists, index otherwise, asserts if table is full
+// returns GGML_HASHTABLE_ALREADY_EXISTS if key already exists, index otherwise, asserts if table is full
 size_t ggml_hash_insert        (      struct ggml_hash_set hash_set, struct ggml_tensor * key);
 
 // return index, asserts if table is full

--- a/src/ggml-metal.h
+++ b/src/ggml-metal.h
@@ -98,7 +98,7 @@ GGML_API ggml_backend_t ggml_backend_metal_init(void);
 
 GGML_API bool ggml_backend_is_metal(ggml_backend_t backend);
 
-GGML_API extern ggml_backend_buffer_type_t ggml_backend_buffer_type_metal;
+GGML_API ggml_backend_buffer_type_t ggml_backend_metal_buffer_type(void);
 
 GGML_API void ggml_backend_metal_set_n_cb(ggml_backend_t backend, int n_cb);
 

--- a/src/ggml-metal.h
+++ b/src/ggml-metal.h
@@ -98,6 +98,8 @@ GGML_API ggml_backend_t ggml_backend_metal_init(void);
 
 GGML_API bool ggml_backend_is_metal(ggml_backend_t backend);
 
+GGML_API extern ggml_backend_buffer_type_t ggml_backend_buffer_type_metal;
+
 GGML_API void ggml_backend_metal_set_n_cb(ggml_backend_t backend, int n_cb);
 
 #ifdef __cplusplus

--- a/src/ggml-metal.m
+++ b/src/ggml-metal.m
@@ -1809,10 +1809,22 @@ static struct ggml_backend_i metal_backend_i = {
     /* .supports_op             = */ ggml_backend_metal_supports_op,
 };
 
-ggml_backend_t ggml_backend_metal_init(void) {
-    struct ggml_metal_context * ctx = malloc(sizeof(struct ggml_metal_context));
+// TODO: make a common log callback for all backends in ggml-backend
+static void ggml_backend_log_callback(enum ggml_log_level level, const char * msg, void * user_data) {
+    fprintf(stderr, "%s", msg);
 
-    ctx = ggml_metal_init(GGML_DEFAULT_N_THREADS);
+    UNUSED(level);
+    UNUSED(user_data);
+}
+
+ggml_backend_t ggml_backend_metal_init(void) {
+    ggml_metal_log_set_callback(ggml_backend_log_callback, NULL);
+
+    struct ggml_metal_context * ctx = ggml_metal_init(GGML_DEFAULT_N_THREADS);
+
+    if (ctx == NULL) {
+        return NULL;
+    }
 
     ggml_backend_t metal_backend = malloc(sizeof(struct ggml_backend));
 

--- a/src/ggml-metal.m
+++ b/src/ggml-metal.m
@@ -1790,10 +1790,45 @@ static void ggml_backend_metal_graph_compute(ggml_backend_t backend, struct ggml
 }
 
 static bool ggml_backend_metal_supports_op(ggml_backend_t backend, const struct ggml_tensor * op) {
-    return true;
+    switch (op->op) {
+        case GGML_OP_UNARY:
+            switch (ggml_get_unary_op(op)) {
+                case GGML_UNARY_OP_SILU:
+                case GGML_UNARY_OP_RELU:
+                case GGML_UNARY_OP_GELU:
+                    return true;
+                default:
+                    return false;
+            }
+            break;
+        case GGML_OP_NONE:
+        case GGML_OP_RESHAPE:
+        case GGML_OP_VIEW:
+        case GGML_OP_TRANSPOSE:
+        case GGML_OP_PERMUTE:
+        case GGML_OP_CONCAT:
+        case GGML_OP_ADD:
+        case GGML_OP_MUL:
+        case GGML_OP_SCALE:
+        case GGML_OP_SQR:
+        case GGML_OP_SOFT_MAX:
+        case GGML_OP_DIAG_MASK_INF:
+        case GGML_OP_MUL_MAT:
+        case GGML_OP_GET_ROWS:
+        case GGML_OP_RMS_NORM:
+        case GGML_OP_NORM:
+        case GGML_OP_ALIBI:
+        case GGML_OP_ROPE:
+        case GGML_OP_IM2COL:
+        case GGML_OP_DUP:
+        case GGML_OP_CPY:
+        case GGML_OP_CONT:
+            return true;
+        default:
+            return false;
+    }
 
     UNUSED(backend);
-    UNUSED(op);
 }
 
 static struct ggml_backend_i metal_backend_i = {

--- a/src/ggml-metal.m
+++ b/src/ggml-metal.m
@@ -245,6 +245,29 @@ struct ggml_metal_context * ggml_metal_init(int n_cb) {
         }
     }
 
+#if TARGET_OS_OSX
+    // print MTL GPU family:
+    GGML_METAL_LOG_INFO("%s: GPU name:   %s\n", __func__, [[ctx->device name] UTF8String]);
+
+    // determine max supported GPU family
+    // https://developer.apple.com/metal/Metal-Shading-Language-Specification.pdf
+    // https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf
+    for (int i = MTLGPUFamilyApple1 + 20; i >= MTLGPUFamilyApple1; --i) {
+        if ([ctx->device supportsFamily:i]) {
+            GGML_METAL_LOG_INFO("%s: GPU family: MTLGPUFamilyApple%d (%d)\n", __func__, i - (int) MTLGPUFamilyApple1 + 1, i);
+            break;
+        }
+    }
+
+    GGML_METAL_LOG_INFO("%s: hasUnifiedMemory              = %s\n",       __func__, ctx->device.hasUnifiedMemory ? "true" : "false");
+    GGML_METAL_LOG_INFO("%s: recommendedMaxWorkingSetSize  = %8.2f MB\n", __func__, ctx->device.recommendedMaxWorkingSetSize / 1e6);
+    if (ctx->device.maxTransferRate != 0) {
+        GGML_METAL_LOG_INFO("%s: maxTransferRate               = %8.2f MB/s\n", __func__, ctx->device.maxTransferRate / 1e6);
+    } else {
+        GGML_METAL_LOG_INFO("%s: maxTransferRate               = built-in GPU\n", __func__);
+    }
+#endif
+
     // load kernels
     {
         NSError * error = nil;
@@ -330,29 +353,6 @@ struct ggml_metal_context * ggml_metal_init(int n_cb) {
 
 #undef GGML_METAL_ADD_KERNEL
     }
-
-#if TARGET_OS_OSX
-    // print MTL GPU family:
-    GGML_METAL_LOG_INFO("%s: GPU name:   %s\n", __func__, [[ctx->device name] UTF8String]);
-
-    // determine max supported GPU family
-    // https://developer.apple.com/metal/Metal-Shading-Language-Specification.pdf
-    // https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf
-    for (int i = MTLGPUFamilyApple1 + 20; i >= MTLGPUFamilyApple1; --i) {
-        if ([ctx->device supportsFamily:i]) {
-            GGML_METAL_LOG_INFO("%s: GPU family: MTLGPUFamilyApple%d (%d)\n", __func__, i - (int) MTLGPUFamilyApple1 + 1, i);
-            break;
-        }
-    }
-
-    GGML_METAL_LOG_INFO("%s: hasUnifiedMemory              = %s\n",       __func__, ctx->device.hasUnifiedMemory ? "true" : "false");
-    GGML_METAL_LOG_INFO("%s: recommendedMaxWorkingSetSize  = %8.2f MB\n", __func__, ctx->device.recommendedMaxWorkingSetSize / 1e6);
-    if (ctx->device.maxTransferRate != 0) {
-        GGML_METAL_LOG_INFO("%s: maxTransferRate               = %8.2f MB/s\n", __func__, ctx->device.maxTransferRate / 1e6);
-    } else {
-        GGML_METAL_LOG_INFO("%s: maxTransferRate               = built-in GPU\n", __func__);
-    }
-#endif
 
     return ctx;
 }

--- a/src/ggml-metal.m
+++ b/src/ggml-metal.m
@@ -1747,7 +1747,7 @@ static bool ggml_backend_metal_buffer_type_supports_backend(ggml_backend_buffer_
     GGML_UNUSED(buft);
 }
 
-static struct ggml_backend_buffer_type ggml_backend_buffer_type_metal_inst = {
+static struct ggml_backend_buffer_type ggml_backend_buffer_type_metal = {
     /* .iface = */ {
         /* .alloc_buffer     = */ ggml_backend_metal_buffer_type_alloc_buffer,
         /* .get_alignment    = */ ggml_backend_metal_buffer_type_get_alignment,
@@ -1756,7 +1756,9 @@ static struct ggml_backend_buffer_type ggml_backend_buffer_type_metal_inst = {
     }
 };
 
-ggml_backend_buffer_type_t ggml_backend_buffer_type_metal = &ggml_backend_buffer_type_metal_inst;
+ggml_backend_buffer_type_t ggml_backend_metal_buffer_type(void) {
+    return &ggml_backend_buffer_type_metal;
+}
 
 static const char * ggml_backend_metal_name(ggml_backend_t backend) {
     return "Metal";
@@ -1854,4 +1856,4 @@ static ggml_backend_t ggml_backend_reg_metal_init(const char * params) {
     GGML_UNUSED(params);
 }
 
-GGML_BACKEND_REGISTER_CONS("Metal", ggml_backend_reg_metal_init, ggml_backend_buffer_type_metal)
+GGML_BACKEND_REGISTER("Metal", ggml_backend_reg_metal_init, ggml_backend_metal_buffer_type())

--- a/src/ggml-metal.m
+++ b/src/ggml-metal.m
@@ -169,7 +169,7 @@ static void ggml_metal_log(enum ggml_log_level level, const char * format, ...){
 struct ggml_metal_context * ggml_metal_init(int n_cb) {
     GGML_METAL_LOG_INFO("%s: allocating\n", __func__);
 
-    id <MTLDevice> device;
+    id<MTLDevice> device;
     NSString * s;
 
 #if TARGET_OS_OSX
@@ -471,6 +471,13 @@ int * ggml_metal_get_concur_list(struct ggml_metal_context * ctx) {
     return ctx->concur_list;
 }
 
+// temporarily defined here for compatibility between ggml-backend and the old API
+struct ggml_backend_metal_buffer_context {
+    void * data;
+
+    id<MTLBuffer> metal;
+};
+
 // finds the Metal buffer that contains the tensor data on the GPU device
 // the assumption is that there is 1-to-1 mapping between the host and device memory buffers, so we can find the
 // Metal buffer based on the host memory pointer
@@ -480,8 +487,17 @@ static id<MTLBuffer> ggml_metal_get_buffer(struct ggml_metal_context * ctx, stru
 
     const int64_t tsize = ggml_nbytes(t);
 
-    if (t->buffer && t->buffer->backend && t->buffer->backend->context) {
-        ctx = t->buffer->backend->context;
+    // compatibility with ggml-backend
+    if (t->buffer && t->buffer->buft == ggml_backend_buffer_type_metal) {
+        struct ggml_backend_metal_buffer_context * buf_ctx = (struct ggml_backend_metal_buffer_context *) t->buffer->context;
+
+        const int64_t ioffs = (int64_t) t->data - (int64_t) buf_ctx->data;
+
+        GGML_ASSERT(ioffs >= 0 && ioffs + tsize <= (int64_t) t->buffer->size);
+
+        *offs = (size_t) ioffs;
+
+        return buf_ctx->metal;
     }
 
     // find the view that contains the tensor fully
@@ -1619,6 +1635,129 @@ void ggml_metal_graph_compute(
 
 // backend interface
 
+static id<MTLDevice> g_backend_device = nil;
+static int g_backend_device_ref_count = 0;
+
+static id<MTLDevice> ggml_backend_metal_get_device(void) {
+    if (g_backend_device == nil) {
+        g_backend_device = MTLCreateSystemDefaultDevice();
+    }
+
+    g_backend_device_ref_count++;
+
+    return g_backend_device;
+}
+
+static void ggml_backend_metal_free_device(void) {
+    assert(g_backend_device_ref_count > 0);
+
+    g_backend_device_ref_count--;
+
+    if (g_backend_device_ref_count == 0) {
+        [g_backend_device release];
+        g_backend_device = nil;
+    }
+}
+
+static void * ggml_backend_metal_buffer_get_base(ggml_backend_buffer_t buffer) {
+    struct ggml_backend_metal_buffer_context * ctx = (struct ggml_backend_metal_buffer_context *)buffer->context;
+
+    return ctx->data;
+}
+
+static void ggml_backend_metal_buffer_free_buffer(ggml_backend_buffer_t buffer) {
+    struct ggml_backend_metal_buffer_context * ctx = (struct ggml_backend_metal_buffer_context *)buffer->context;
+
+    [ctx->metal release];
+    ggml_backend_metal_free_device();
+
+    free(ctx->data);
+    free(ctx);
+
+    UNUSED(buffer);
+}
+
+static void ggml_backend_metal_buffer_set_tensor(ggml_backend_buffer_t buffer, struct ggml_tensor * tensor, const void * data, size_t offset, size_t size) {
+    GGML_ASSERT(offset + size <= ggml_nbytes(tensor) && "tensor write out of bounds");
+    GGML_ASSERT(tensor->data != NULL && "tensor not allocated");
+
+    memcpy((char *)tensor->data + offset, data, size);
+
+    UNUSED(buffer);
+}
+
+static void ggml_backend_metal_buffer_get_tensor(ggml_backend_buffer_t buffer, const struct ggml_tensor * tensor, void * data, size_t offset, size_t size) {
+    GGML_ASSERT(offset + size <= ggml_nbytes(tensor) && "tensor read out of bounds");
+    GGML_ASSERT(tensor->data != NULL && "tensor not allocated");
+
+    memcpy(data, (const char *)tensor->data + offset, size);
+
+    UNUSED(buffer);
+}
+
+static void ggml_backend_metal_buffer_cpy_tensor_from(ggml_backend_buffer_t buffer, struct ggml_tensor * src, struct ggml_tensor * dst) {
+    ggml_backend_tensor_get(src, dst->data, 0, ggml_nbytes(src));
+
+    UNUSED(buffer);
+}
+
+static void ggml_backend_metal_buffer_cpy_tensor_to(ggml_backend_buffer_t buffer, struct ggml_tensor * src, struct ggml_tensor * dst) {
+    ggml_backend_tensor_set(dst, src->data, 0, ggml_nbytes(src));
+
+    UNUSED(buffer);
+}
+
+static struct ggml_backend_buffer_i metal_backend_buffer_i = {
+    /* .free_buffer     = */ ggml_backend_metal_buffer_free_buffer,
+    /* .get_base        = */ ggml_backend_metal_buffer_get_base,
+    /* .init_tensor     = */ NULL,
+    /* .set_tensor      = */ ggml_backend_metal_buffer_set_tensor,
+    /* .get_tensor      = */ ggml_backend_metal_buffer_get_tensor,
+    /* .cpy_tensor_from = */ ggml_backend_metal_buffer_cpy_tensor_from,
+    /* .cpy_tensor_to   = */ ggml_backend_metal_buffer_cpy_tensor_to,
+};
+
+static ggml_backend_buffer_t ggml_backend_metal_buffer_type_alloc_buffer(ggml_backend_buffer_type_t buft, size_t size) {
+    struct ggml_backend_metal_buffer_context * ctx = malloc(sizeof(struct ggml_backend_metal_buffer_context));
+
+    const size_t size_page = sysconf(_SC_PAGESIZE);
+
+    size_t size_aligned = size;
+    if ((size_aligned % size_page) != 0) {
+        size_aligned += (size_page - (size_aligned % size_page));
+    }
+
+    ctx->data  = ggml_metal_host_malloc(size);
+    ctx->metal = [ggml_backend_metal_get_device() newBufferWithBytesNoCopy:ctx->data
+                    length:size_aligned
+                    options:MTLResourceStorageModeShared
+                    deallocator:nil];
+
+    return ggml_backend_buffer_init(buft, metal_backend_buffer_i, ctx, size);
+}
+
+static size_t ggml_backend_metal_buffer_type_get_alignment(ggml_backend_buffer_type_t buft) {
+    return 32;
+    UNUSED(buft);
+}
+
+static bool ggml_backend_metal_buffer_type_supports_backend(ggml_backend_buffer_type_t buft, ggml_backend_t backend) {
+    return ggml_backend_is_metal(backend) || ggml_backend_is_cpu(backend);
+
+    GGML_UNUSED(buft);
+}
+
+static struct ggml_backend_buffer_type ggml_backend_buffer_type_metal_inst = {
+    /* .iface = */ {
+        /* .alloc_buffer     = */ ggml_backend_metal_buffer_type_alloc_buffer,
+        /* .get_alignment    = */ ggml_backend_metal_buffer_type_get_alignment,
+        /* .get_alloc_size   = */ NULL, // defaults to ggml_nbytes
+        /* .supports_backend = */ ggml_backend_metal_buffer_type_supports_backend,
+    }
+};
+
+ggml_backend_buffer_type_t ggml_backend_buffer_type_metal = &ggml_backend_buffer_type_metal_inst;
+
 static const char * ggml_backend_metal_name(ggml_backend_t backend) {
     return "Metal";
 
@@ -1631,69 +1770,12 @@ static void ggml_backend_metal_free(ggml_backend_t backend) {
     free(backend);
 }
 
-static void * ggml_backend_metal_buffer_get_base(ggml_backend_buffer_t buffer) {
-    return (void *)buffer->context;
-}
-
-static void ggml_backend_metal_buffer_free_buffer(ggml_backend_buffer_t buffer) {
-    free(buffer->context);
-    UNUSED(buffer);
-}
-
-static struct ggml_backend_buffer_i metal_backend_buffer_i = {
-    /* .free_buffer    = */ ggml_backend_metal_buffer_free_buffer,
-    /* .get_base       = */ ggml_backend_metal_buffer_get_base,
-    /* .get_alloc_size = */ NULL, // defaults to ggml_nbytes
-    /* .init_tensor    = */ NULL, // no initialization required
-    /* .free_tensor    = */ NULL, // no cleanup required
-};
-
-static ggml_backend_buffer_t ggml_backend_metal_alloc_buffer(ggml_backend_t backend, size_t size) {
-    struct ggml_metal_context * ctx = (struct ggml_metal_context *)backend->context;
-
-    void * data = ggml_metal_host_malloc(size);
-
-    // TODO: set proper name of the buffers
-    ggml_metal_add_buffer(ctx, "backend", data, size, 0);
-
-    return ggml_backend_buffer_init(backend, metal_backend_buffer_i, data, size);
-}
-
-static size_t ggml_backend_metal_get_alignment(ggml_backend_t backend) {
-    return 32;
-    UNUSED(backend);
-}
-
-static void ggml_backend_metal_set_tensor_async(ggml_backend_t backend, struct ggml_tensor * tensor, const void * data, size_t offset, size_t size) {
-    GGML_ASSERT(offset + size <= ggml_nbytes(tensor) && "tensor write out of bounds");
-    GGML_ASSERT(tensor->data != NULL && "tensor not allocated");
-
-    memcpy((char *)tensor->data + offset, data, size);
-
-    UNUSED(backend);
-}
-
-static void ggml_backend_metal_get_tensor_async(ggml_backend_t backend, const struct ggml_tensor * tensor, void * data, size_t offset, size_t size) {
-    GGML_ASSERT(offset + size <= ggml_nbytes(tensor) && "tensor read out of bounds");
-    GGML_ASSERT(tensor->data != NULL && "tensor not allocated");
-
-    memcpy(data, (const char *)tensor->data + offset, size);
-
-    UNUSED(backend);
-}
-
 static void ggml_backend_metal_synchronize(ggml_backend_t backend) {
     UNUSED(backend);
 }
 
-static void ggml_backend_metal_cpy_tensor_from(ggml_backend_t backend, struct ggml_tensor * src, struct ggml_tensor * dst) {
-    ggml_backend_tensor_get(src, dst->data, 0, ggml_nbytes(src));
-
-    UNUSED(backend);
-}
-
-static void ggml_backend_metal_cpy_tensor_to(ggml_backend_t backend, struct ggml_tensor * src, struct ggml_tensor * dst) {
-    ggml_backend_tensor_set_async(dst, src->data, 0, ggml_nbytes(src));
+static ggml_backend_buffer_type_t ggml_backend_metal_get_default_buffer_type(ggml_backend_t backend) {
+    return ggml_backend_buffer_type_metal;
 
     UNUSED(backend);
 }
@@ -1706,25 +1788,25 @@ static void ggml_backend_metal_graph_compute(ggml_backend_t backend, struct ggml
 
 static bool ggml_backend_metal_supports_op(ggml_backend_t backend, const struct ggml_tensor * op) {
     return true;
+
     UNUSED(backend);
     UNUSED(op);
 }
 
 static struct ggml_backend_i metal_backend_i = {
-    /* .get_name            = */ ggml_backend_metal_name,
-    /* .free                = */ ggml_backend_metal_free,
-    /* .alloc_buffer        = */ ggml_backend_metal_alloc_buffer,
-    /* .get_alignment       = */ ggml_backend_metal_get_alignment,
-    /* .set_tensor_async    = */ ggml_backend_metal_set_tensor_async,
-    /* .get_tensor_async    = */ ggml_backend_metal_get_tensor_async,
-    /* .synchronize         = */ ggml_backend_metal_synchronize,
-    /* .cpy_tensor_from     = */ ggml_backend_metal_cpy_tensor_from,
-    /* .cpy_tensor_to       = */ ggml_backend_metal_cpy_tensor_to,
-    /* .graph_plan_create   = */ NULL, // the metal implementation does not require creating graph plans atm
-    /* .graph_plan_free     = */ NULL,
-    /* .graph_plan_compute  = */ NULL,
-    /* .graph_compute       = */ ggml_backend_metal_graph_compute,
-    /* .supports_op         = */ ggml_backend_metal_supports_op,
+    /* .get_name                = */ ggml_backend_metal_name,
+    /* .free                    = */ ggml_backend_metal_free,
+    /* .get_default_buffer_type = */ ggml_backend_metal_get_default_buffer_type,
+    /* .set_tensor_async        = */ NULL,
+    /* .get_tensor_async        = */ NULL,
+    /* .cpy_tensor_from_async   = */ NULL,
+    /* .cpy_tensor_to_async     = */ NULL,
+    /* .synchronize             = */ ggml_backend_metal_synchronize,
+    /* .graph_plan_create       = */ NULL, // the metal implementation does not require creating graph plans atm
+    /* .graph_plan_free         = */ NULL,
+    /* .graph_plan_compute      = */ NULL,
+    /* .graph_compute           = */ ggml_backend_metal_graph_compute,
+    /* .supports_op             = */ ggml_backend_metal_supports_op,
 };
 
 ggml_backend_t ggml_backend_metal_init(void) {
@@ -1747,7 +1829,17 @@ bool ggml_backend_is_metal(ggml_backend_t backend) {
 }
 
 void ggml_backend_metal_set_n_cb(ggml_backend_t backend, int n_cb) {
+    GGML_ASSERT(ggml_backend_is_metal(backend));
+
     struct ggml_metal_context * ctx = (struct ggml_metal_context *)backend->context;
 
     ggml_metal_set_n_cb(ctx, n_cb);
 }
+
+static ggml_backend_t ggml_backend_reg_metal_init(const char * params) {
+    return ggml_backend_metal_init();
+
+    GGML_UNUSED(params);
+}
+
+GGML_BACKEND_REGISTER_CONS("Metal", ggml_backend_reg_metal_init, ggml_backend_buffer_type_metal)

--- a/src/ggml.c
+++ b/src/ggml.c
@@ -8729,7 +8729,6 @@ static void ggml_compute_forward_gelu_f32(
     // row range for this thread
     const int ir0 = dr*ith;
     const int ir1 = MIN(ir0 + dr, nr);
-#if 1
     for (int i1 = ir0; i1 < ir1; i1++) {
         ggml_vec_gelu_f32(nc,
                 (float *) ((char *) dst->data  + i1*( dst->nb[1])),
@@ -8744,15 +8743,6 @@ static void ggml_compute_forward_gelu_f32(
         }
 #endif
     }
-#else
-    for (int i1 = ir0; i1 < ir1; i1++) {
-        const float * src_row = (float *) ((char *) src0->data + i1*(src0->nb[1]));
-        float *       dst_row = (float *) ((char *) dst->data  + i1*( dst->nb[1]));
-        for (int i0 = 0; i0 < nc; i0++) {
-            dst_row[i0] = ggml_gelu_f32(src_row[i0]);
-        }
-    }
-#endif
 }
 
 static void ggml_compute_forward_gelu(

--- a/src/ggml.c
+++ b/src/ggml.c
@@ -1752,6 +1752,24 @@ static_assert(GGML_OP_COUNT == 68, "GGML_OP_COUNT != 68");
 
 static_assert(GGML_OP_POOL_COUNT == 2, "GGML_OP_POOL_COUNT != 2");
 
+
+static const char * GGML_UNARY_OP_NAME[GGML_UNARY_OP_COUNT] = {
+    "ABS",
+    "SGN",
+    "NEG",
+    "STEP",
+    "TANH",
+    "ELU",
+    "RELU",
+    "GELU",
+    "GELU_QUICK",
+    "SILU",
+    "LEAKY",
+};
+
+static_assert(GGML_UNARY_OP_COUNT == 11, "GGML_UNARY_OP_COUNT != 11");
+
+
 static_assert(sizeof(struct ggml_object)%GGML_MEM_ALIGN == 0, "ggml_object size must be a multiple of GGML_MEM_ALIGN");
 static_assert(sizeof(struct ggml_tensor)%GGML_MEM_ALIGN == 0, "ggml_tensor size must be a multiple of GGML_MEM_ALIGN");
 
@@ -2021,6 +2039,20 @@ const char * ggml_op_name(enum ggml_op op) {
 
 const char * ggml_op_symbol(enum ggml_op op) {
     return GGML_OP_SYMBOL[op];
+}
+
+const char * ggml_unary_op_name(enum ggml_unary_op op) {
+    return GGML_UNARY_OP_NAME[op];
+}
+
+const char * ggml_op_desc(const struct ggml_tensor * t) {
+    if (t->op == GGML_OP_UNARY) {
+        enum ggml_unary_op uop = ggml_get_unary_op(t);
+        return ggml_unary_op_name(uop);
+    }
+    else {
+        return ggml_op_name(t->op);
+    }
 }
 
 size_t ggml_element_size(const struct ggml_tensor * tensor) {
@@ -8697,7 +8729,7 @@ static void ggml_compute_forward_gelu_f32(
     // row range for this thread
     const int ir0 = dr*ith;
     const int ir1 = MIN(ir0 + dr, nr);
-
+#if 1
     for (int i1 = ir0; i1 < ir1; i1++) {
         ggml_vec_gelu_f32(nc,
                 (float *) ((char *) dst->data  + i1*( dst->nb[1])),
@@ -8712,6 +8744,15 @@ static void ggml_compute_forward_gelu_f32(
         }
 #endif
     }
+#else
+    for (int i1 = ir0; i1 < ir1; i1++) {
+        const float * src_row = (float *) ((char *) src0->data + i1*(src0->nb[1]));
+        float *       dst_row = (float *) ((char *) dst->data  + i1*( dst->nb[1]));
+        for (int i0 = 0; i0 < nc; i0++) {
+            dst_row[i0] = ggml_gelu_f32(src_row[i0]);
+        }
+    }
+#endif
 }
 
 static void ggml_compute_forward_gelu(
@@ -15204,12 +15245,8 @@ struct ggml_cgraph * ggml_new_graph(struct ggml_context * ctx) {
     return ggml_new_graph_custom(ctx, GGML_DEFAULT_GRAPH_SIZE, false);
 }
 
-struct ggml_cgraph * ggml_graph_view(struct ggml_context * ctx, struct ggml_cgraph * cgraph0, int i0, int i1) {
-    const size_t obj_size = sizeof(struct ggml_cgraph);
-    struct ggml_object * obj = ggml_new_object(ctx, GGML_OBJECT_GRAPH, obj_size);
-    struct ggml_cgraph * cgraph = (struct ggml_cgraph *) ((char *) ctx->mem_buffer + obj->offs);
-
-    *cgraph = (struct ggml_cgraph) {
+struct ggml_cgraph ggml_graph_view(struct ggml_cgraph * cgraph0, int i0, int i1) {
+    struct ggml_cgraph cgraph = {
         /*.size         =*/ 0,
         /*.n_nodes      =*/ i1 - i0,
         /*.n_leafs      =*/ 0,
@@ -15477,6 +15514,8 @@ static int ggml_get_n_tasks(struct ggml_tensor * node, int n_threads) {
                     {
                         n_tasks = n_threads;
                     } break;
+                default:
+                    GGML_ASSERT(false);
             }
             break;
         case GGML_OP_SILU_BACK:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -394,3 +394,13 @@ add_executable(${TEST_TARGET} ${TEST_TARGET}.cpp)
 target_link_libraries(${TEST_TARGET} PRIVATE ggml)
 add_test(NAME ${TEST_TARGET} COMMAND $<TARGET_FILE:${TEST_TARGET}>)
 set_property(TEST ${TEST_TARGET} PROPERTY ENVIRONMENT "LLVM_PROFILE_FILE=${TEST_TARGET}.profraw")
+
+
+#
+# test-backend-ops
+
+set(TEST_TARGET test-backend-ops)
+add_executable(${TEST_TARGET} ${TEST_TARGET}.cpp)
+target_link_libraries(${TEST_TARGET} PRIVATE ggml)
+add_test(NAME ${TEST_TARGET} COMMAND $<TARGET_FILE:${TEST_TARGET}>)
+set_property(TEST ${TEST_TARGET} PROPERTY ENVIRONMENT "LLVM_PROFILE_FILE=${TEST_TARGET}.profraw")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -384,3 +384,13 @@ add_executable(${TEST_TARGET} ${TEST_TARGET}.cpp)
 target_link_libraries(${TEST_TARGET} PRIVATE ggml)
 add_test(NAME ${TEST_TARGET} COMMAND $<TARGET_FILE:${TEST_TARGET}>)
 set_property(TEST ${TEST_TARGET} PROPERTY ENVIRONMENT "LLVM_PROFILE_FILE=${TEST_TARGET}.profraw")
+
+
+#
+# test-backend-buffer
+
+set(TEST_TARGET test-backend-buffer)
+add_executable(${TEST_TARGET} ${TEST_TARGET}.cpp)
+target_link_libraries(${TEST_TARGET} PRIVATE ggml)
+add_test(NAME ${TEST_TARGET} COMMAND $<TARGET_FILE:${TEST_TARGET}>)
+set_property(TEST ${TEST_TARGET} PROPERTY ENVIRONMENT "LLVM_PROFILE_FILE=${TEST_TARGET}.profraw")

--- a/tests/test-backend-buffer.cpp
+++ b/tests/test-backend-buffer.cpp
@@ -54,12 +54,19 @@ void test_buffer(ggml_backend_t backend, ggml_backend_buffer_type_t buft) {
 
 int main() {
     // enumerate backends
+    printf("Testing %zu backends\n\n", ggml_backend_reg_get_count());
+
     for (size_t i = 0; i < ggml_backend_reg_get_count(); i++) {
         printf("Backend %zu/%zu (%s)\n", i + 1, ggml_backend_reg_get_count(), ggml_backend_reg_get_name(i));
+
         ggml_backend_t backend = ggml_backend_reg_init_backend(i, NULL);
+        GGML_ASSERT(backend != NULL);
         printf("  Backend name: %s\n", ggml_backend_name(backend));
+
         test_buffer(backend, ggml_backend_reg_get_default_buffer_type(i));
+
         ggml_backend_free(backend);
+
         printf("  OK\n\n");
     }
 }

--- a/tests/test-backend-buffer.cpp
+++ b/tests/test-backend-buffer.cpp
@@ -49,7 +49,7 @@ static void test_buffer(ggml_backend_t backend, ggml_backend_buffer_type_t buft)
 
     float data[n];
     for (size_t i = 0; i < n; i++) {
-        data[i] = i;
+        data[i] = (float) i;
     }
 
     ggml_backend_tensor_set(tensor, data, 0, sizeof(data));

--- a/tests/test-backend-buffer.cpp
+++ b/tests/test-backend-buffer.cpp
@@ -1,0 +1,65 @@
+#include <ggml.h>
+#include <ggml-alloc.h>
+#include <ggml-backend.h>
+#include <ggml-backend-impl.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+
+bool is_pow2(size_t x) {
+    return (x & (x - 1)) == 0;
+}
+
+void test_buffer(ggml_backend_t backend, ggml_backend_buffer_type_t buft) {
+    GGML_ASSERT(ggml_backend_get_default_buffer_type(backend) == buft);
+
+    //ggml_backend_buffer_t buffer = ggml_backend_alloc_buffer(backend, 1024);
+    ggml_backend_buffer_t buffer = ggml_backend_buft_alloc_buffer(buft, 1024);
+
+    GGML_ASSERT(buffer != NULL);
+
+    GGML_ASSERT(is_pow2(ggml_backend_buffer_get_alignment(buffer)));
+
+    GGML_ASSERT(ggml_backend_buffer_get_base(buffer) != NULL);
+
+    GGML_ASSERT(ggml_backend_buffer_get_size(buffer) >= 1024);
+
+    struct ggml_init_params params = {
+        /* .mem_size = */ 1024,
+        /* .mem_base = */ NULL,
+        /* .no_alloc = */ true,
+    };
+    struct ggml_context * ctx = ggml_init(params);
+
+    struct ggml_tensor * tensor = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, 10);
+
+    GGML_ASSERT(ggml_backend_buffer_get_alloc_size(buffer, tensor) >= 10 * sizeof(float));
+
+    ggml_tallocr_t allocr = ggml_tallocr_new_from_buffer(buffer);
+    ggml_tallocr_alloc(allocr, tensor);
+
+    GGML_ASSERT(tensor->data != NULL);
+
+    GGML_ASSERT(tensor->data >= ggml_backend_buffer_get_base(buffer));
+
+    // TODO:
+    // supports_backend
+    // get/set tensor
+    // cpy tensor from/to
+
+    ggml_tallocr_free(allocr);
+    ggml_backend_buffer_free(buffer);
+    ggml_free(ctx);
+}
+
+int main() {
+    // enumerate backends
+    for (size_t i = 0; i < ggml_backend_reg_get_count(); i++) {
+        printf("Backend %zu/%zu (%s)\n", i + 1, ggml_backend_reg_get_count(), ggml_backend_reg_get_name(i));
+        ggml_backend_t backend = ggml_backend_reg_init_backend(i, NULL);
+        printf("  Backend name: %s\n", ggml_backend_name(backend));
+        test_buffer(backend, ggml_backend_reg_get_default_buffer_type(i));
+        ggml_backend_free(backend);
+        printf("  OK\n\n");
+    }
+}

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -802,9 +802,11 @@ static bool test_backend(ggml_backend_t backend) {
     //test_cases.emplace_back(new test_mul(GGML_TYPE_F32, {16, 10, 10, 10}, {2, 2, 2, 2}));
 
     test_cases.emplace_back(new test_scale());
-    test_cases.emplace_back(new test_norm());
-    test_cases.emplace_back(new test_rms_norm());
 
+    for (float eps : {1e-6f, 1e-5f, 1e-3f, 1e-1f}) {
+        test_cases.emplace_back(new test_norm(GGML_TYPE_F32, {64, 10, 10, 10}, eps));
+        test_cases.emplace_back(new test_rms_norm(GGML_TYPE_F32, {64, 10, 10, 10}, eps));
+    }
 
     for (ggml_type t0 : {GGML_TYPE_F32, GGML_TYPE_F16}) {
         for (ggml_type t1 : {GGML_TYPE_F32 /*, GGML_TYPE_F16 */}) {

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -10,6 +10,7 @@
 #include <random>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string>
 #include <vector>
 
 
@@ -179,16 +180,17 @@ static std::string var_to_str(ggml_type type) {
 }
 
 #define VARS_TO_STR1(a) VAR_TO_STR(a)
-#define VARS_TO_STR2(a, ...) VAR_TO_STR(a) + "," + VARS_TO_STR1(__VA_ARGS__)
-#define VARS_TO_STR3(a, ...) VAR_TO_STR(a) + "," + VARS_TO_STR2(__VA_ARGS__)
-#define VARS_TO_STR4(a, ...) VAR_TO_STR(a) + "," + VARS_TO_STR3(__VA_ARGS__)
-#define VARS_TO_STR5(a, ...) VAR_TO_STR(a) + "," + VARS_TO_STR4(__VA_ARGS__)
-#define VARS_TO_STR6(a, ...) VAR_TO_STR(a) + "," + VARS_TO_STR5(__VA_ARGS__)
-#define VARS_TO_STR7(a, ...) VAR_TO_STR(a) + "," + VARS_TO_STR6(__VA_ARGS__)
-#define VARS_TO_STR8(a, ...) VAR_TO_STR(a) + "," + VARS_TO_STR7(__VA_ARGS__)
-#define VARS_TO_STR9(a, ...) VAR_TO_STR(a) + "," + VARS_TO_STR8(__VA_ARGS__)
-#define VARS_TO_STR10(a,...) VAR_TO_STR(a) + "," + VARS_TO_STR9(__VA_ARGS__)
-#define VARS_TO_STR11(a,...) VAR_TO_STR(a) + "," + VARS_TO_STR10(__VA_ARGS__)
+#define VARS_TO_STR2(a, b) VAR_TO_STR(a) + "," + VAR_TO_STR(b)
+#define VARS_TO_STR3(a, b, c) VAR_TO_STR(a) + "," + VARS_TO_STR2(b, c)
+#define VARS_TO_STR4(a, b, c, d) VAR_TO_STR(a) + "," + VARS_TO_STR3(b, c, d)
+#define VARS_TO_STR5(a, b, c, d, e) VAR_TO_STR(a) + "," + VARS_TO_STR4(b, c, d, e)
+#define VARS_TO_STR6(a, b, c, d, e, f) VAR_TO_STR(a) + "," + VARS_TO_STR5(b, c, d, e, f)
+#define VARS_TO_STR7(a, b, c, d, e, f, g) VAR_TO_STR(a) + "," + VARS_TO_STR6(b, c, d, e, f, g)
+#define VARS_TO_STR8(a, b, c, d, e, f, g, h) VAR_TO_STR(a) + "," + VARS_TO_STR7(b, c, d, e, f, g, h)
+#define VARS_TO_STR9(a, b, c, d, e, f, g, h, i) VAR_TO_STR(a) + "," + VARS_TO_STR8(b, c, d, e, f, g, h, i)
+#define VARS_TO_STR10(a, b, c, d, e, f, g, h, i, j) VAR_TO_STR(a) + "," + VARS_TO_STR9(b, c, d, e, f, g, h, i, j)
+#define VARS_TO_STR11(a, b, c, d, e, f, g, h, i, j, k) VAR_TO_STR(a) + "," + VARS_TO_STR10(b, c, d, e, f, g, h, i, j, k)
+
 
 // accept FLT_MAX as infinity
 static bool isinf_or_max(float f) {

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -27,11 +27,9 @@ static void init_tensor_uniform(ggml_tensor * tensor, float min = -1.0f, float m
     if (tensor->type == GGML_TYPE_F32) {
         ggml_backend_tensor_set(tensor, data.data(), 0, size * sizeof(float));
     } else if (tensor->type == GGML_TYPE_F16) {
-        std::vector<uint16_t> data16(size);
-        for (size_t i = 0; i < size; i++) {
-            data16[i] = ggml_fp32_to_fp16(data[i]);
-        }
-        ggml_backend_tensor_set(tensor, data16.data(), 0, size * sizeof(uint16_t));
+        std::vector<ggml_fp16_t> data16(size);
+        ggml_fp32_to_fp16_row(data.data(), data16.data(), size);
+        ggml_backend_tensor_set(tensor, data16.data(), 0, size * sizeof(ggml_fp16_t));
     } else {
         GGML_ASSERT(false);
     }
@@ -163,7 +161,7 @@ static std::string var_to_str(ggml_type type) {
 }
 
 #define VARS_TO_STR1(a) VAR_TO_STR(a)
-#define VARS_TO_STR2(a, ...) VAR_TO_STR(a) + "," + VAR_TO_STR(__VA_ARGS__)
+#define VARS_TO_STR2(a, ...) VAR_TO_STR(a) + "," + VARS_TO_STR1(__VA_ARGS__)
 #define VARS_TO_STR3(a, ...) VAR_TO_STR(a) + "," + VARS_TO_STR2(__VA_ARGS__)
 #define VARS_TO_STR4(a, ...) VAR_TO_STR(a) + "," + VARS_TO_STR3(__VA_ARGS__)
 #define VARS_TO_STR5(a, ...) VAR_TO_STR(a) + "," + VARS_TO_STR4(__VA_ARGS__)

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -699,35 +699,39 @@ struct test_alibi : public test_case {
 
 // GGML_OP_IM2COL
 struct test_im2col : public test_case {
-    const ggml_type type_a;
-    const ggml_type type_b;
-    const std::array<int64_t, 4> ne_a;
-    const std::array<int64_t, 4> ne_b;
+    const ggml_type type_input;
+    const ggml_type type_kernel;
+    const std::array<int64_t, 4> ne_input;
+    const std::array<int64_t, 4> ne_kernel;
+    // stride
     const int s0;
     const int s1;
+    // padding
     const int p0;
     const int p1;
+    // dilatation
     const int d0;
     const int d1;
+    // mode
     const bool is_2D;
 
     std::string vars() override {
-        return VARS_TO_STR11(type_a, type_b, ne_a, ne_b, s0, s1, p0, p1, d0, d1, is_2D);
+        return VARS_TO_STR11(type_input, type_kernel, ne_input, ne_kernel, s0, s1, p0, p1, d0, d1, is_2D);
     }
 
-    test_im2col(ggml_type type_a = GGML_TYPE_F16, ggml_type type_b = GGML_TYPE_F32,
-            std::array<int64_t, 4> ne_a = {10, 10, 10, 10},
-            std::array<int64_t, 4> ne_b = {10, 10, 10, 10},
+    test_im2col(ggml_type type_input = GGML_TYPE_F32, ggml_type type_kernel = GGML_TYPE_F16,
+            std::array<int64_t, 4> ne_input = {10, 10, 3, 1}, // [input_width, input_height, input_channels, 1]
+            std::array<int64_t, 4> ne_kernel = {3, 3, 3, 1}, // [kernel_width, kernel_height, input_channels, 1]
             int s0 = 1, int s1 = 1,
-            int p0 = 0, int p1 = 0,
+            int p0 = 1, int p1 = 1,
             int d0 = 1, int d1 = 1,
-            bool is_2D = false)
-        : type_a(type_a), type_b(type_b), ne_a(ne_a), ne_b(ne_b), s0(s0), s1(s1), p0(p0), p1(p1), d0(d0), d1(d1), is_2D(is_2D) {}
+            bool is_2D = true)
+        : type_input(type_input), type_kernel(type_kernel), ne_input(ne_input), ne_kernel(ne_kernel), s0(s0), s1(s1), p0(p0), p1(p1), d0(d0), d1(d1), is_2D(is_2D) {}
 
     ggml_tensor * build_graph(ggml_context * ctx) override {
-        ggml_tensor * a = ggml_new_tensor(ctx, type_a, 4, ne_a.data());
-        ggml_tensor * b = ggml_new_tensor(ctx, type_b, 4, ne_b.data());
-        ggml_tensor * out = ggml_im2col(ctx, a, b, s0, s1, p0, p1, d0, d1, is_2D);
+        ggml_tensor * input = ggml_new_tensor(ctx, type_input, 4, ne_input.data());
+        ggml_tensor * kernel = ggml_new_tensor(ctx, type_kernel, 4, ne_kernel.data());
+        ggml_tensor * out = ggml_im2col(ctx, kernel, input, s0, s1, p0, p1, d0, d1, is_2D);
         return out;
     }
 };

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -748,27 +748,27 @@ static bool test_backend(ggml_backend_t backend) {
     test_cases.emplace_back(new test_cpy());
     test_cases.emplace_back(new test_cont());
 
-    test_cases.emplace_back(new test_add(GGML_TYPE_F32, {10, 10, 1, 1}, {1, 1, 1, 1}));
-    test_cases.emplace_back(new test_add(GGML_TYPE_F32, {10, 10, 10, 1}, {1, 1, 1, 1}));
-    test_cases.emplace_back(new test_add(GGML_TYPE_F32, {10, 10, 10, 10}, {1, 1, 1, 1}));
-    //test_cases.emplace_back(new test_add(GGML_TYPE_F32, {10, 10, 10, 10}, {2, 1, 1, 1})); // broadcasting dim 0 is not supported
-    test_cases.emplace_back(new test_add(GGML_TYPE_F32, {10, 10, 10, 10}, {1, 2, 1, 1}));
-    test_cases.emplace_back(new test_add(GGML_TYPE_F32, {10, 10, 10, 10}, {1, 1, 2, 1}));
-    test_cases.emplace_back(new test_add(GGML_TYPE_F32, {10, 10, 10, 10}, {1, 1, 1, 2}));
-    test_cases.emplace_back(new test_add(GGML_TYPE_F32, {10, 10, 10, 10}, {1, 1, 2, 2}));
-    test_cases.emplace_back(new test_add(GGML_TYPE_F32, {10, 10, 10, 10}, {1, 2, 2, 2}));
-    //test_cases.emplace_back(new test_add(GGML_TYPE_F32, {10, 10, 10, 10}, {2, 2, 2, 2}));
+    test_cases.emplace_back(new test_add(GGML_TYPE_F32, {16, 10, 1, 1}, {1, 1, 1, 1}));
+    test_cases.emplace_back(new test_add(GGML_TYPE_F32, {16, 10, 10, 1}, {1, 1, 1, 1}));
+    test_cases.emplace_back(new test_add(GGML_TYPE_F32, {16, 10, 10, 10}, {1, 1, 1, 1}));
+    //test_cases.emplace_back(new test_add(GGML_TYPE_F32, {16, 10, 10, 10}, {2, 1, 1, 1})); // broadcasting dim 0 is not supported
+    test_cases.emplace_back(new test_add(GGML_TYPE_F32, {16, 10, 10, 10}, {1, 2, 1, 1}));
+    test_cases.emplace_back(new test_add(GGML_TYPE_F32, {16, 10, 10, 10}, {1, 1, 2, 1}));
+    test_cases.emplace_back(new test_add(GGML_TYPE_F32, {16, 10, 10, 10}, {1, 1, 1, 2}));
+    test_cases.emplace_back(new test_add(GGML_TYPE_F32, {16, 10, 10, 10}, {1, 1, 2, 2}));
+    test_cases.emplace_back(new test_add(GGML_TYPE_F32, {16, 10, 10, 10}, {1, 2, 2, 2}));
+    //test_cases.emplace_back(new test_add(GGML_TYPE_F32, {16, 10, 10, 10}, {2, 2, 2, 2}));
 
-    test_cases.emplace_back(new test_mul(GGML_TYPE_F32, {10, 10, 1, 1}, {1, 1, 1, 1}));
-    test_cases.emplace_back(new test_mul(GGML_TYPE_F32, {10, 10, 10, 1}, {1, 1, 1, 1}));
-    test_cases.emplace_back(new test_mul(GGML_TYPE_F32, {10, 10, 10, 10}, {1, 1, 1, 1}));
-    //test_cases.emplace_back(new test_mul(GGML_TYPE_F32, {10, 10, 10, 10}, {2, 1, 1, 1})); // broadcasting dim 0 is not supported
-    test_cases.emplace_back(new test_mul(GGML_TYPE_F32, {10, 10, 10, 10}, {1, 2, 1, 1}));
-    test_cases.emplace_back(new test_mul(GGML_TYPE_F32, {10, 10, 10, 10}, {1, 1, 2, 1}));
-    test_cases.emplace_back(new test_mul(GGML_TYPE_F32, {10, 10, 10, 10}, {1, 1, 1, 2}));
-    test_cases.emplace_back(new test_mul(GGML_TYPE_F32, {10, 10, 10, 10}, {1, 1, 2, 2}));
-    test_cases.emplace_back(new test_mul(GGML_TYPE_F32, {10, 10, 10, 10}, {1, 2, 2, 2}));
-    //test_cases.emplace_back(new test_mul(GGML_TYPE_F32, {10, 10, 10, 10}, {2, 2, 2, 2}));
+    test_cases.emplace_back(new test_mul(GGML_TYPE_F32, {16, 10, 1, 1}, {1, 1, 1, 1}));
+    test_cases.emplace_back(new test_mul(GGML_TYPE_F32, {16, 10, 10, 1}, {1, 1, 1, 1}));
+    test_cases.emplace_back(new test_mul(GGML_TYPE_F32, {16, 10, 10, 10}, {1, 1, 1, 1}));
+    //test_cases.emplace_back(new test_mul(GGML_TYPE_F32, {16, 10, 10, 10}, {2, 1, 1, 1})); // broadcasting dim 0 is not supported
+    test_cases.emplace_back(new test_mul(GGML_TYPE_F32, {16, 10, 10, 10}, {1, 2, 1, 1}));
+    test_cases.emplace_back(new test_mul(GGML_TYPE_F32, {16, 10, 10, 10}, {1, 1, 2, 1}));
+    test_cases.emplace_back(new test_mul(GGML_TYPE_F32, {16, 10, 10, 10}, {1, 1, 1, 2}));
+    test_cases.emplace_back(new test_mul(GGML_TYPE_F32, {16, 10, 10, 10}, {1, 1, 2, 2}));
+    test_cases.emplace_back(new test_mul(GGML_TYPE_F32, {16, 10, 10, 10}, {1, 2, 2, 2}));
+    //test_cases.emplace_back(new test_mul(GGML_TYPE_F32, {16, 10, 10, 10}, {2, 2, 2, 2}));
 
     test_cases.emplace_back(new test_scale());
     test_cases.emplace_back(new test_norm());

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -814,6 +814,9 @@ static bool test_backend(ggml_backend_t backend) {
     for (ggml_type t0 : {GGML_TYPE_F32, GGML_TYPE_F16}) {
         for (ggml_type t1 : {GGML_TYPE_F32 /*, GGML_TYPE_F16 */}) {
             // FIXME: CPU crashes on f16xf16
+            test_cases.emplace_back(new test_mul_mat(t0, t1, 32, 32, 32, { 1,  1}, {1, 1}));
+            test_cases.emplace_back(new test_mul_mat(t0, t1, 32, 32, 32, {10,  1}, {1, 1}));
+            test_cases.emplace_back(new test_mul_mat(t0, t1, 32, 32, 32, {10,  1}, {2, 1}));
             test_cases.emplace_back(new test_mul_mat(t0, t1, 32, 32, 32, {10, 10}, {1, 1}));
             test_cases.emplace_back(new test_mul_mat(t0, t1, 32, 32, 32, {10, 10}, {2, 1}));
             test_cases.emplace_back(new test_mul_mat(t0, t1, 32, 32, 32, {10, 10}, {1, 2}));

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -24,7 +24,17 @@ static void init_tensor_uniform(ggml_tensor * tensor, float min = -1.0f, float m
         data[i] = distribution(generator);
     }
 
-    ggml_backend_tensor_set(tensor, data.data(), 0, size * sizeof(float));
+    if (tensor->type == GGML_TYPE_F32) {
+        ggml_backend_tensor_set(tensor, data.data(), 0, size * sizeof(float));
+    } else if (tensor->type == GGML_TYPE_F16) {
+        std::vector<uint16_t> data16(size);
+        for (size_t i = 0; i < size; i++) {
+            data16[i] = ggml_fp32_to_fp16(data[i]);
+        }
+        ggml_backend_tensor_set(tensor, data16.data(), 0, size * sizeof(uint16_t));
+    } else {
+        GGML_ASSERT(false);
+    }
 }
 
 static std::vector<float> tensor_to_float(const ggml_tensor * t) {
@@ -162,6 +172,7 @@ static std::string var_to_str(ggml_type type) {
 #define VARS_TO_STR8(a, ...) VAR_TO_STR(a) + "," + VARS_TO_STR7(__VA_ARGS__)
 #define VARS_TO_STR9(a, ...) VAR_TO_STR(a) + "," + VARS_TO_STR8(__VA_ARGS__)
 #define VARS_TO_STR10(a,...) VAR_TO_STR(a) + "," + VARS_TO_STR9(__VA_ARGS__)
+#define VARS_TO_STR11(a,...) VAR_TO_STR(a) + "," + VARS_TO_STR10(__VA_ARGS__)
 
 
 // normalized mean squared error = mse(a, b) / mse(a, 0)
@@ -690,26 +701,34 @@ struct test_alibi : public test_case {
 
 // GGML_OP_IM2COL
 struct test_im2col : public test_case {
-    const ggml_type type;
-    const int64_t ne_a[4] = {10, 10, 10, 10};
-    const int64_t ne_b[4] = {10, 10, 10, 10};
-    int s0;
-    int s1;
-    int p0;
-    int p1;
-    int d0;
-    int d1;
-    bool is_2D;
+    const ggml_type type_a;
+    const ggml_type type_b;
+    const std::array<int64_t, 4> ne_a;
+    const std::array<int64_t, 4> ne_b;
+    const int s0;
+    const int s1;
+    const int p0;
+    const int p1;
+    const int d0;
+    const int d1;
+    const bool is_2D;
 
     std::string vars() override {
-        return VARS_TO_STR10(type, ne_a, ne_b, s0, s1, p0, p1, d0, d1, is_2D);
+        return VARS_TO_STR11(type_a, type_b, ne_a, ne_b, s0, s1, p0, p1, d0, d1, is_2D);
     }
 
-    test_im2col(ggml_type type = GGML_TYPE_F32) : type(type) {}
+    test_im2col(ggml_type type_a = GGML_TYPE_F16, ggml_type type_b = GGML_TYPE_F32,
+            std::array<int64_t, 4> ne_a = {10, 10, 10, 10},
+            std::array<int64_t, 4> ne_b = {10, 10, 10, 10},
+            int s0 = 1, int s1 = 1,
+            int p0 = 0, int p1 = 0,
+            int d0 = 1, int d1 = 1,
+            bool is_2D = false)
+        : type_a(type_a), type_b(type_b), ne_a(ne_a), ne_b(ne_b), s0(s0), s1(s1), p0(p0), p1(p1), d0(d0), d1(d1), is_2D(is_2D) {}
 
     ggml_tensor * build_graph(ggml_context * ctx) override {
-        ggml_tensor * a = ggml_new_tensor(ctx, type, 4, ne_a);
-        ggml_tensor * b = ggml_new_tensor(ctx, type, 4, ne_b);
+        ggml_tensor * a = ggml_new_tensor(ctx, type_a, 4, ne_a.data());
+        ggml_tensor * b = ggml_new_tensor(ctx, type_b, 4, ne_b.data());
         ggml_tensor * out = ggml_im2col(ctx, a, b, s0, s1, p0, p1, d0, d1, is_2D);
         return out;
     }
@@ -763,7 +782,7 @@ static bool test_backend(ggml_backend_t backend) {
     test_cases.emplace_back(new test_soft_max());
     test_cases.emplace_back(new test_rope());
     test_cases.emplace_back(new test_alibi());
-    //test_cases.emplace_back(new test_im2col());
+    test_cases.emplace_back(new test_im2col());
 
     size_t n_ok = 0;
     for (auto & test : test_cases) {

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -769,7 +769,11 @@ static bool test_backend(ggml_backend_t backend) {
         test_cases.emplace_back(new test_unary((ggml_unary_op) op));
     }
 
-    test_cases.emplace_back(new test_get_rows());
+    for (ggml_type type : {GGML_TYPE_F32, GGML_TYPE_F16}) {
+        test_cases.emplace_back(new test_get_rows(type, 10, 5, 3));
+        test_cases.emplace_back(new test_get_rows(type, 16, 5, 3));
+    }
+
     test_cases.emplace_back(new test_repeat());
     test_cases.emplace_back(new test_dup());
     test_cases.emplace_back(new test_cpy());

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -800,21 +800,34 @@ static bool test_backend(ggml_backend_t backend) {
     test_cases.emplace_back(new test_scale());
     test_cases.emplace_back(new test_norm());
     test_cases.emplace_back(new test_rms_norm());
-    test_cases.emplace_back(new test_mul_mat());
+
+
+    for (ggml_type t0 : {GGML_TYPE_F32, GGML_TYPE_F16}) {
+        for (ggml_type t1 : {GGML_TYPE_F32 /*, GGML_TYPE_F16 */}) {
+            // FIXME: CPU crashes on f16xf16
+            test_cases.emplace_back(new test_mul_mat(t0, t1, 32, 32, 32, {10, 10}, {1, 1}));
+            test_cases.emplace_back(new test_mul_mat(t0, t1, 32, 32, 32, {10, 10}, {2, 1}));
+            test_cases.emplace_back(new test_mul_mat(t0, t1, 32, 32, 32, {10, 10}, {1, 2}));
+            test_cases.emplace_back(new test_mul_mat(t0, t1, 32, 32, 32, {10, 10}, {2, 2}));
+        }
+    }
+
     test_cases.emplace_back(new test_sqr());
     test_cases.emplace_back(new test_clamp());
     test_cases.emplace_back(new test_diag_mask_inf());
     test_cases.emplace_back(new test_soft_max());
 
-    test_cases.emplace_back(new test_rope(GGML_TYPE_F32, {128,  32, 10, 1}, 128, 0, 512)); // llama 7B
-    test_cases.emplace_back(new test_rope(GGML_TYPE_F32, {128,  40, 10, 1}, 128, 0, 512)); // llama 13B
-    test_cases.emplace_back(new test_rope(GGML_TYPE_F32, {128,  52, 10, 1}, 128, 0, 512)); // llama 30B
-    test_cases.emplace_back(new test_rope(GGML_TYPE_F32, {128,  64, 10, 1}, 128, 0, 512)); // llama 65B
-    test_cases.emplace_back(new test_rope(GGML_TYPE_F32, { 64,   1, 10, 1},  64, 2, 512)); // neox (falcon 7B)
-    test_cases.emplace_back(new test_rope(GGML_TYPE_F32, { 64,  71, 10, 1},  64, 2, 512)); // neox (falcon 7B)
-    test_cases.emplace_back(new test_rope(GGML_TYPE_F32, { 64,   8, 10, 1},  64, 2, 512)); // neox (falcon 40B)
-    test_cases.emplace_back(new test_rope(GGML_TYPE_F32, { 64, 128, 10, 1},  64, 2, 512)); // neox (falcon 40B)
-    //test_cases.emplace_back(new test_rope(GGML_TYPE_F32, {80, 32, 10, 1}, 20, 2, 512)); // neox rope (stablelm) (TODO: enable after llama.cpp sync)
+    for (ggml_type type : {GGML_TYPE_F32, GGML_TYPE_F16}) {
+        test_cases.emplace_back(new test_rope(type, {128,  32, 10, 1}, 128, 0, 512)); // llama 7B
+        test_cases.emplace_back(new test_rope(type, {128,  40, 10, 1}, 128, 0, 512)); // llama 13B
+        test_cases.emplace_back(new test_rope(type, {128,  52, 10, 1}, 128, 0, 512)); // llama 30B
+        test_cases.emplace_back(new test_rope(type, {128,  64, 10, 1}, 128, 0, 512)); // llama 65B
+        test_cases.emplace_back(new test_rope(type, { 64,   1, 10, 1},  64, 2, 512)); // neox (falcon 7B)
+        test_cases.emplace_back(new test_rope(type, { 64,  71, 10, 1},  64, 2, 512)); // neox (falcon 7B)
+        test_cases.emplace_back(new test_rope(type, { 64,   8, 10, 1},  64, 2, 512)); // neox (falcon 40B)
+        test_cases.emplace_back(new test_rope(type, { 64, 128, 10, 1},  64, 2, 512)); // neox (falcon 40B)
+        //test_cases.emplace_back(new test_rope(type, {80, 32, 10, 1}, 20, 2, 512)); // neox rope (stablelm) (TODO: enable after llama.cpp sync)
+    }
 
     test_cases.emplace_back(new test_alibi());
     test_cases.emplace_back(new test_im2col());

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -144,7 +144,7 @@ struct test_case {
         // check if backends support op
         for (ggml_backend_t backend : {backend1, backend2}) {
             if (!ggml_backend_supports_op(backend, out)) {
-                //printf("Backend [%s] does not support op %s, skipping\n", ggml_backend_name(backend), ggml_op_desc(out));
+                printf("  %s: not supported\n", ggml_op_desc(out));
                 ggml_free(ctx);
                 return true;
             }
@@ -161,26 +161,28 @@ struct test_case {
         initialize_tensors(ctx);
 
         // compare
+        bool ok = true;
+
         auto callback = [](int index, ggml_tensor * t1, ggml_tensor * t2, void * user_data) -> bool {
             std::vector<float> f1 = tensor_to_float(t1);
             std::vector<float> f2 = tensor_to_float(t2);
             double err = nmse(f1.data(), f2.data(), f1.size());
             if (err > 1e-6) {
-                printf("Error: %s: %f\n", ggml_op_desc(t1), err);
-                return false;
+                printf("Error: %s: NMSE = %f\n", ggml_op_desc(t1), err);
+                *(bool *) user_data = false;
             }
             return true;
         };
 
-        ggml_backend_compare_graph_backend(backend1, backend2, gf, callback, nullptr);
+        ggml_backend_compare_graph_backend(backend1, backend2, gf, callback, &ok);
 
-        printf("  %s: OK\n", ggml_op_desc(out));
+        printf("  %s: %s\n", ggml_op_desc(out), ok ? "OK" : "FAIL");
 
         ggml_backend_buffer_free(buf);
 
         ggml_free(ctx);
 
-        return true; // or false if failed
+        return ok;
     }
 };
 
@@ -188,16 +190,17 @@ struct test_case {
 struct test_unary : public test_case {
     const ggml_unary_op op;
     const ggml_type type;
+    const int64_t ne[4];
 
-    test_unary(ggml_unary_op op, ggml_type type = GGML_TYPE_F32) : op(op), type(type) {}
+    test_unary(ggml_unary_op op,
+                ggml_type type = GGML_TYPE_F32,
+                int64_t ne0 = 128, int64_t ne1 = 10, int64_t ne2 = 10, int64_t ne3 = 10)
+        : op(op), type(type), ne {ne0, ne1, ne2, ne3} {
+    }
 
     ggml_tensor * build_graph(ggml_context * ctx) override {
-        static const int n = 10;
-
-        ggml_tensor * in = ggml_new_tensor_1d(ctx, type, n);
-
+        ggml_tensor * in = ggml_new_tensor(ctx, type, 4, ne);
         ggml_tensor * out = ggml_unary(ctx, in, op);
-
         return out;
     }
 };
@@ -212,11 +215,8 @@ struct test_get_rows : public test_case {
     test_get_rows(ggml_type type = GGML_TYPE_F32) : type(type) {}
 
     ggml_tensor * build_graph(ggml_context * ctx) override {
-
-        ggml_tensor * rows = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, r);
-
         ggml_tensor * in = ggml_new_tensor_2d(ctx, type, n, m);
-
+        ggml_tensor * rows = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, r);
         ggml_tensor * out = ggml_get_rows(ctx, in, rows);
 
         return out;
@@ -238,26 +238,409 @@ struct test_get_rows : public test_case {
     }
 };
 
+// GGML_OP_REPEAT
+struct test_repeat : public test_case {
+    const ggml_type type;
+    const int64_t ne[4] = { 10, 10, 10, 10 };
+    const int64_t nr[4] = { 2, 2, 2, 2 };
+
+    test_repeat(ggml_type type = GGML_TYPE_F32) : type(type) {}
+
+    ggml_tensor * build_graph(ggml_context * ctx) override {
+        ggml_tensor * target = ggml_new_tensor_4d(ctx, type, ne[0]*nr[0], ne[1]*nr[1], ne[2]*nr[2], ne[3]*nr[3]);
+        ggml_tensor * src = ggml_new_tensor(ctx, type, 4, ne);
+        ggml_tensor * out = ggml_repeat(ctx, src, target);
+        return out;
+    }
+};
+
+// GGML_OP_DUP
+struct test_dup : public test_case {
+    const ggml_type type;
+    const int64_t ne[4] = { 10, 10, 10, 1 }; // TODO: cuda backend doesn't support 4D tensors
+
+    test_dup(ggml_type type = GGML_TYPE_F32) : type(type) {}
+
+    ggml_tensor * build_graph(ggml_context * ctx) override {
+        ggml_tensor * src = ggml_new_tensor(ctx, type, 4, ne);
+        ggml_tensor * out = ggml_dup(ctx, src);
+        return out;
+    }
+};
+
+// GGML_OP_CPY
+struct test_cpy : public test_case {
+    const ggml_type type_src;
+    const ggml_type type_dst;
+    const int64_t ne[4] = { 10, 10, 10, 1 }; // TODO: cuda backend doesn't support 4D tensors
+
+    test_cpy(ggml_type type_src = GGML_TYPE_F32, ggml_type type_dst = GGML_TYPE_F32)
+        : type_src(type_src), type_dst(type_dst) {}
+
+    ggml_tensor * build_graph(ggml_context * ctx) override {
+        ggml_tensor * src = ggml_new_tensor(ctx, type_src, 4, ne);
+        ggml_tensor * dst = ggml_new_tensor(ctx, type_dst, 4, ne);
+        ggml_tensor * out = ggml_cpy(ctx, src, dst);
+        return out;
+    }
+};
+
+// GGML_OP_CONT
+struct test_cont : public test_case {
+    const ggml_type type;
+    const int64_t ne[4] = { 10, 10, 10, 1 }; // TODO: cuda backend doesn't support 4D tensors
+
+    test_cont(ggml_type type = GGML_TYPE_F32) : type(type) {}
+
+    ggml_tensor * build_graph(ggml_context * ctx) override {
+        ggml_tensor * src = ggml_new_tensor(ctx, type, 4, ne);
+        src = ggml_transpose(ctx, src);
+        ggml_tensor * out = ggml_cont(ctx, src);
+
+        return out;
+    }
+};
+
+// GGML_OP_ADD
+struct test_add : public test_case {
+    const ggml_type type;
+    const int64_t ne[4] = { 10, 10, 10, 10 };
+    // TODO: broadcasting
+
+    test_add(ggml_type type = GGML_TYPE_F32) : type(type) {}
+
+    ggml_tensor * build_graph(ggml_context * ctx) override {
+        ggml_tensor * a = ggml_new_tensor(ctx, type, 4, ne);
+        ggml_tensor * b = ggml_new_tensor(ctx, type, 4, ne);
+        ggml_tensor * out = ggml_add(ctx, a, b);
+        return out;
+    }
+};
+
+// GGML_OP_MUL
+struct test_mul : public test_case {
+    const ggml_type type;
+    const int64_t ne[4] = { 10, 10, 10, 10 };
+    // TODO: broadcasting
+
+    test_mul(ggml_type type = GGML_TYPE_F32) : type(type) {}
+
+    ggml_tensor * build_graph(ggml_context * ctx) override {
+        ggml_tensor * a = ggml_new_tensor(ctx, type, 4, ne);
+        ggml_tensor * b = ggml_new_tensor(ctx, type, 4, ne);
+        ggml_tensor * out = ggml_mul(ctx, a, b);
+        return out;
+    }
+};
+
+// GGML_OP_SCALE
+struct test_scale : public test_case {
+    const ggml_type type;
+    const int64_t ne[4] = { 10, 10, 10, 10 };
+
+    test_scale(ggml_type type = GGML_TYPE_F32) : type(type) {}
+
+    ggml_tensor * build_graph(ggml_context * ctx) override {
+        ggml_tensor * a = ggml_new_tensor(ctx, type, 4, ne);
+        ggml_tensor * scale = ggml_new_tensor_1d(ctx, type, 1);
+        ggml_tensor * out = ggml_scale(ctx, a, scale);
+        return out;
+    }
+};
+
+// GGML_OP_NORM
+struct test_norm : public test_case {
+    const ggml_type type;
+    const int64_t ne[4] = { 64, 10, 10, 10 };
+    float eps = 1e-6f;
+
+    test_norm(ggml_type type = GGML_TYPE_F32) : type(type) {}
+
+    ggml_tensor * build_graph(ggml_context * ctx) override {
+        ggml_tensor * a = ggml_new_tensor(ctx, type, 4, ne);
+        ggml_tensor * out = ggml_norm(ctx, a, eps);
+        return out;
+    }
+};
+
+// GGML_OP_RMS_NORM
+struct test_rms_norm : public test_case {
+    const ggml_type type;
+    const int64_t ne[4] = { 64, 10, 10, 10 };
+    float eps = 1e-6f;
+
+    test_rms_norm(ggml_type type = GGML_TYPE_F32) : type(type) {}
+
+    ggml_tensor * build_graph(ggml_context * ctx) override {
+        ggml_tensor * a = ggml_new_tensor(ctx, type, 4, ne);
+        ggml_tensor * out = ggml_rms_norm(ctx, a, eps);
+        return out;
+    }
+};
+
+// GGML_OP_MUL_MAT
+struct test_mul_mat : public test_case {
+    const ggml_type type;
+    const int64_t m = 10;
+    const int64_t n = 10;
+    const int64_t k = 10;
+    const int64_t bs[2] = {10, 10}; // dims 3 and 4
+    const int64_t nr[2] = {10, 10};  // broadcast in dims 3 and 4
+
+    test_mul_mat(ggml_type type = GGML_TYPE_F32) : type(type) {}
+
+    ggml_tensor * build_graph(ggml_context * ctx) override {
+        // C^T = A * B^T: (k, m) * (k, n) => (m, n)
+        ggml_tensor * a = ggml_new_tensor_4d(ctx, type, k, m, bs[0]*nr[0], bs[1]*nr[1]);
+        ggml_tensor * b = ggml_new_tensor_4d(ctx, type, k, n, bs[0]*nr[0], bs[1]*nr[1]);
+        ggml_tensor * out = ggml_mul_mat(ctx, a, b);
+        return out;
+    }
+};
+
+// GGML_OP_SQR
+struct test_sqr : public test_case {
+    const ggml_type type;
+    const int64_t ne[4] = { 10, 10, 10, 10 };
+
+    test_sqr(ggml_type type = GGML_TYPE_F32) : type(type) {}
+
+    ggml_tensor * build_graph(ggml_context * ctx) override {
+        ggml_tensor * a = ggml_new_tensor(ctx, type, 4, ne);
+        ggml_tensor * out = ggml_sqr(ctx, a);
+        return out;
+    }
+};
+
+// GGML_OP_CLAMP
+struct test_clamp : public test_case {
+    const ggml_type type;
+    const int64_t ne[4] = { 10, 10, 10, 10 };
+    float min = -0.5f;
+    float max = 0.5f;
+
+    test_clamp(ggml_type type = GGML_TYPE_F32) : type(type) {}
+
+    ggml_tensor * build_graph(ggml_context * ctx) override {
+        ggml_tensor * a = ggml_new_tensor(ctx, type, 4, ne);
+        ggml_tensor * out = ggml_clamp(ctx, a, min, max);
+        return out;
+    }
+};
+
+// GGML_OP_DIAG_MASK_INF
+struct test_diag_mask_inf : public test_case {
+    const ggml_type type;
+    const int64_t ne[4] = { 10, 10, 10, 10 };
+    const int n_past = 5;
+
+    test_diag_mask_inf(ggml_type type = GGML_TYPE_F32) : type(type) {}
+
+    ggml_tensor * build_graph(ggml_context * ctx) override {
+        ggml_tensor * a = ggml_new_tensor(ctx, type, 4, ne);
+        ggml_tensor * out = ggml_diag_mask_inf(ctx, a, n_past);
+        return out;
+    }
+};
+
+// GGML_OP_SOFT_MAX
+struct test_soft_max : public test_case {
+    const ggml_type type;
+    const int64_t ne[4] = { 10, 10, 10, 10 };
+
+    test_soft_max(ggml_type type = GGML_TYPE_F32) : type(type) {}
+
+    ggml_tensor * build_graph(ggml_context * ctx) override {
+        ggml_tensor * a = ggml_new_tensor(ctx, type, 4, ne);
+        ggml_tensor * out = ggml_soft_max(ctx, a);
+        return out;
+    }
+};
+
+// GGML_OP_ROPE
+struct test_rope : public test_case {
+    const ggml_type type;
+    const int64_t ne[4] = { 10, 10, 10, 10 };
+    int n_dims = 10;
+    int mode = 0;
+    int n_ctx = 512;
+
+    test_rope(ggml_type type = GGML_TYPE_F32) : type(type) {}
+
+    ggml_tensor * build_graph(ggml_context * ctx) override {
+        ggml_tensor * a = ggml_new_tensor(ctx, type, 4, ne);
+        ggml_tensor * pos = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, ne[2]);
+        ggml_tensor * out = ggml_rope(ctx, a, pos, n_dims, mode, n_ctx);
+        return out;
+    }
+
+    void initialize_tensors(ggml_context * ctx) override {
+        for (ggml_tensor * t = ggml_get_first_tensor(ctx); t != NULL; t = ggml_get_next_tensor(ctx, t)) {
+            if (t->type == GGML_TYPE_I32) {
+                // pos
+                std::vector<int> data(ne[2]);
+                for (int i = 0; i < ne[2]; i++) {
+                    data[i] = rand() % n_ctx;
+                }
+                ggml_backend_tensor_set(t, data.data(), 0, ne[2] * sizeof(int));
+            } else {
+                init_tensor_uniform(t);
+            }
+        }
+    }
+};
+
+// GGML_OP_ALIBI
+struct test_alibi : public test_case {
+    const ggml_type type;
+    const int64_t ne[4] = { 10, 10, 10, 10 };
+    int n_past = 512;
+    int n_head = 10;
+    float bias_max = 0.5f;
+
+    test_alibi(ggml_type type = GGML_TYPE_F32) : type(type) {}
+
+    ggml_tensor * build_graph(ggml_context * ctx) override {
+        ggml_tensor * a = ggml_new_tensor(ctx, type, 4, ne);
+        ggml_tensor * out = ggml_alibi(ctx, a, n_past, n_head, bias_max);
+        return out;
+    }
+};
+
+// GGML_OP_IM2COL
+struct test_im2col : public test_case {
+    const ggml_type type;
+    const int64_t ne[4] = { 10, 10, 10, 10 };
+    int s0;
+    int s1;
+    int p0;
+    int p1;
+    int d0;
+    int d1;
+    bool is_2D;
+
+    test_im2col(ggml_type type = GGML_TYPE_F32) : type(type) {}
+
+    ggml_tensor * build_graph(ggml_context * ctx) override {
+        // TODO
+    }
+};
+
+
 void test_backend(ggml_backend_t backend) {
     ggml_backend_t backend_cpu = ggml_backend_cpu_init();
 
-    // test unary ops
+    // unary ops
     for (int op = 0; op < GGML_UNARY_OP_COUNT; op++) {
         test_unary test((ggml_unary_op) op);
         test.eval(backend_cpu, backend);
     }
 
-    // test get_rows
+    // get_rows
     {
         test_get_rows test;
         test.eval(backend_cpu, backend);
     }
 
-    // TODO:
-    // ggml_repeat, ggml_dup, ggml_add, ggml_mul,
-    // ggml_norm, ggml_rms_norm, ggml_mul_mat, ggml_scale,
-    // ggml_sqr, ggml_clamp, ggml_cpy, ggml_cont,
-    // ggml_diag_mask_inf, ggml_soft_max, ggml_rope, ggml_alibi, ggml_im2col
+    // ggml_repeat
+    {
+        test_repeat test;
+        test.eval(backend_cpu, backend);
+    }
+
+    // ggml_dup
+    {
+        test_dup test;
+        test.eval(backend_cpu, backend);
+    }
+
+    // ggml_cpy
+    {
+        test_cpy test;
+        test.eval(backend_cpu, backend);
+    }
+
+    // ggml_cont
+    {
+        test_cont test;
+        test.eval(backend_cpu, backend);
+    }
+
+    // ggml_add
+    {
+        test_add test;
+        test.eval(backend_cpu, backend);
+    }
+
+    // ggml_mul
+    {
+        test_mul test;
+        test.eval(backend_cpu, backend);
+    }
+
+    // ggml_scale
+    {
+        test_scale test;
+        test.eval(backend_cpu, backend);
+    }
+
+    // ggml_norm
+    {
+        test_norm test;
+        test.eval(backend_cpu, backend);
+    }
+
+    // ggml_rms_norm
+    {
+        test_rms_norm test;
+        test.eval(backend_cpu, backend);
+    }
+
+    // ggml_mul_mat
+    {
+        test_mul_mat test;
+        test.eval(backend_cpu, backend);
+    }
+
+    // ggml_sqr
+    {
+        test_sqr test;
+        test.eval(backend_cpu, backend);
+    }
+
+    // ggml_clamp,
+    {
+        test_clamp test;
+        test.eval(backend_cpu, backend);
+    }
+
+    // ggml_diag_mask_inf
+    {
+        test_diag_mask_inf test;
+        test.eval(backend_cpu, backend);
+    }
+
+    // ggml_soft_max
+    {
+        test_soft_max test;
+        test.eval(backend_cpu, backend);
+    }
+
+    // ggml_rope
+    {
+        test_rope test;
+        test.eval(backend_cpu, backend);
+    }
+
+    // ggml_alibi
+    {
+        test_alibi test;
+        test.eval(backend_cpu, backend);
+    }
+
+    // ggml_im2col
+
+    ggml_backend_free(backend_cpu);
 }
 
 int main() {

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -1,0 +1,280 @@
+#include <cstring>
+#include <functional>
+#include <ggml.h>
+#include <ggml-alloc.h>
+#include <ggml-backend.h>
+#include <ggml-backend-impl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <vector>
+#include <random>
+
+
+static void init_tensor_uniform(ggml_tensor * tensor, float min = -1.0f, float max = 1.0f) {
+    size_t size = ggml_nelements(tensor);
+    std::vector<float> data(size);
+
+    std::random_device rd;
+    std::default_random_engine generator(rd());
+    std::uniform_real_distribution<float> distribution(min, max);
+
+    for (size_t i = 0; i < size; i++) {
+        data[i] = distribution(generator);
+    }
+
+    ggml_backend_tensor_set(tensor, data.data(), 0, size * sizeof(float));
+}
+
+static std::vector<float> tensor_to_float(const struct ggml_tensor * t) {
+    std::vector<float> tv;
+    tv.reserve(ggml_nelements(t));
+
+    std::vector<uint8_t> buf(ggml_nbytes(t));
+    ggml_backend_tensor_get(t, buf.data(), 0, ggml_nbytes(t));
+
+    for (int64_t i3 = 0; i3 < t->ne[3]; i3++) {
+        for (int64_t i2 = 0; i2 < t->ne[2]; i2++) {
+            for (int64_t i1 = 0; i1 < t->ne[1]; i1++) {
+                for (int64_t i0 = 0; i0 < t->ne[0]; i0++) {
+                    size_t i = i3*t->nb[3] + i2*t->nb[2] + i1*t->nb[1] + i0*t->nb[0];
+                    float v;
+                    if (t->type == GGML_TYPE_F16) {
+                        v = (float) ggml_fp16_to_fp32(*(ggml_fp16_t*)&buf[i]);
+                    } else if (t->type == GGML_TYPE_F32) {
+                        v = *(float *) &buf[i];
+                    } else {
+                        GGML_ASSERT(false);
+                    }
+                    tv.push_back(v);
+                }
+            }
+        }
+    }
+
+    return tv;
+}
+
+static double cosine_similarity(const float * v1, const float * v2, size_t n) {
+    double dot = 0.0;
+    double mag1 = 0.0;
+    double mag2 = 0.0;
+
+    for (size_t i = 0; i < n; i++) {
+        if (std::isnan(v1[i]) || std::isnan(v2[i])) {
+            return -1.0f;
+        }
+        if (std::isinf(v1[i]) && std::isinf(v2[i])) {
+            continue;
+        }
+        dot  += v1[i]*v2[i];
+        mag1 += v1[i]*v1[i];
+        mag2 += v2[i]*v2[i];
+    }
+
+    return dot/sqrt(mag1*mag2);
+}
+
+static float distance(const float * v1, const float * v2, size_t n) {
+    double d = 0.0;
+
+    for (size_t i = 0; i < n; i++) {
+        if (std::isnan(v1[i]) || std::isnan(v2[i])) {
+            return INFINITY;
+        }
+        if (std::isinf(v1[i]) && std::isinf(v2[i])) {
+            continue;
+        }
+        d += (v1[i] - v2[i])*(v1[i] - v2[i]);
+    }
+
+    return sqrt(d);
+}
+
+static float vec_len(const float * v, size_t n) {
+    double d = 0.0;
+
+    for (size_t i = 0; i < n; i++) {
+        if (std::isnan(v[i])) {
+            return INFINITY;
+        }
+        if (std::isinf(v[i])) {
+            continue;
+        }
+        d += v[i]*v[i];
+    }
+
+    return sqrt(d);
+}
+
+// normalized mean squared error = mse(a, b) / mse(a, 0)
+static double nmse(const float * a, const float * b, size_t n) {
+    double mse_a_b = 0.0;
+    double mse_a_0 = 0.0;
+
+    for (size_t i = 0; i < n; i++) {
+        float a_i = a[i];
+        float b_i = b[i];
+
+        mse_a_b += (a_i - b_i) * (a_i - b_i);
+        mse_a_0 += a_i * a_i;
+    }
+
+    return mse_a_b / mse_a_0;
+}
+
+struct test_case {
+    virtual ggml_tensor * build_graph(ggml_context * ctx) = 0;
+
+    virtual void initialize_tensors(ggml_context * ctx) {
+        for (ggml_tensor * t = ggml_get_first_tensor(ctx); t != nullptr; t = ggml_get_next_tensor(ctx, t)) {
+            init_tensor_uniform(t);
+        }
+    }
+
+    bool eval(ggml_backend_t backend1, ggml_backend_t backend2) {
+        ggml_init_params params = {
+            /* .mem_size = */ ggml_tensor_overhead()*128 + ggml_graph_overhead(),
+            /* .mem_base = */ NULL,
+            /* .no_alloc = */ true,
+        };
+        ggml_context * ctx = ggml_init(params);
+
+        ggml_tensor * out = build_graph(ctx);
+
+        // check if backends support op
+        for (ggml_backend_t backend : {backend1, backend2}) {
+            if (!ggml_backend_supports_op(backend, out)) {
+                //printf("Backend [%s] does not support op %s, skipping\n", ggml_backend_name(backend), ggml_op_desc(out));
+                ggml_free(ctx);
+                return true;
+            }
+        }
+
+        // allocate
+        ggml_backend_buffer_t buf = ggml_backend_alloc_ctx_tensors(ctx, backend1);
+
+        // build graph
+        ggml_cgraph * gf = ggml_new_graph(ctx);
+        ggml_build_forward_expand(gf, out);
+
+        // randomize tensors
+        initialize_tensors(ctx);
+
+        // compare
+        auto callback = [](int index, ggml_tensor * t1, ggml_tensor * t2, void * user_data) -> bool {
+            std::vector<float> f1 = tensor_to_float(t1);
+            std::vector<float> f2 = tensor_to_float(t2);
+            double err = nmse(f1.data(), f2.data(), f1.size());
+            if (err > 1e-6) {
+                printf("Error: %s: %f\n", ggml_op_desc(t1), err);
+                return false;
+            }
+            return true;
+        };
+
+        ggml_backend_compare_graph_backend(backend1, backend2, gf, callback, nullptr);
+
+        printf("  %s: OK\n", ggml_op_desc(out));
+
+        ggml_backend_buffer_free(buf);
+
+        ggml_free(ctx);
+
+        return true; // or false if failed
+    }
+};
+
+// GGML_OP_UNARY
+struct test_unary : public test_case {
+    const ggml_unary_op op;
+    const ggml_type type;
+
+    test_unary(ggml_unary_op op, ggml_type type = GGML_TYPE_F32) : op(op), type(type) {}
+
+    ggml_tensor * build_graph(ggml_context * ctx) override {
+        static const int n = 10;
+
+        ggml_tensor * in = ggml_new_tensor_1d(ctx, type, n);
+
+        ggml_tensor * out = ggml_unary(ctx, in, op);
+
+        return out;
+    }
+};
+
+// GGML_OP_GET_ROWS
+struct test_get_rows : public test_case {
+    const ggml_type type;
+    const int n = 10; // cols
+    const int m = 5;  // rows
+    const int r = 3;  // rows to get
+
+    test_get_rows(ggml_type type = GGML_TYPE_F32) : type(type) {}
+
+    ggml_tensor * build_graph(ggml_context * ctx) override {
+
+        ggml_tensor * rows = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, r);
+
+        ggml_tensor * in = ggml_new_tensor_2d(ctx, type, n, m);
+
+        ggml_tensor * out = ggml_get_rows(ctx, in, rows);
+
+        return out;
+    }
+
+    void initialize_tensors(ggml_context * ctx) override {
+        for (ggml_tensor * t = ggml_get_first_tensor(ctx); t != NULL; t = ggml_get_next_tensor(ctx, t)) {
+            if (t->type == GGML_TYPE_I32) {
+                // rows
+                std::vector<int> data(r);
+                for (int i = 0; i < r; i++) {
+                    data[i] = rand() % m;
+                }
+                ggml_backend_tensor_set(t, data.data(), 0, r * sizeof(int));
+            } else {
+                init_tensor_uniform(t);
+            }
+        }
+    }
+};
+
+void test_backend(ggml_backend_t backend) {
+    ggml_backend_t backend_cpu = ggml_backend_cpu_init();
+
+    // test unary ops
+    for (int op = 0; op < GGML_UNARY_OP_COUNT; op++) {
+        test_unary test((ggml_unary_op) op);
+        test.eval(backend_cpu, backend);
+    }
+
+    // test get_rows
+    {
+        test_get_rows test;
+        test.eval(backend_cpu, backend);
+    }
+
+    // TODO:
+    // ggml_repeat, ggml_dup, ggml_add, ggml_mul,
+    // ggml_norm, ggml_rms_norm, ggml_mul_mat, ggml_scale,
+    // ggml_sqr, ggml_clamp, ggml_cpy, ggml_cont,
+    // ggml_diag_mask_inf, ggml_soft_max, ggml_rope, ggml_alibi, ggml_im2col
+}
+
+int main() {
+    // enumerate backends
+    printf("Testing %zu backends\n\n", ggml_backend_reg_get_count());
+
+    for (size_t i = 0; i < ggml_backend_reg_get_count(); i++) {
+        printf("Backend %zu/%zu (%s)\n", i + 1, ggml_backend_reg_get_count(), ggml_backend_reg_get_name(i));
+
+        ggml_backend_t backend = ggml_backend_reg_init_backend(i, NULL);
+        GGML_ASSERT(backend != NULL);
+        printf("  Backend name: %s\n", ggml_backend_name(backend));
+
+        test_backend(backend);
+
+        ggml_backend_free(backend);
+
+        printf("  OK\n\n");
+    }
+}

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -856,7 +856,11 @@ static bool test_backend(ggml_backend_t backend) {
 
     test_cases.emplace_back(new test_sqr());
     test_cases.emplace_back(new test_clamp());
-    test_cases.emplace_back(new test_diag_mask_inf());
+
+    test_cases.emplace_back(new test_diag_mask_inf(GGML_TYPE_F32, {10, 10,  1,  1}, 5));
+    test_cases.emplace_back(new test_diag_mask_inf(GGML_TYPE_F32, {10, 10, 10,  1}, 5));
+    test_cases.emplace_back(new test_diag_mask_inf(GGML_TYPE_F32, {10, 10, 10, 10}, 5));
+
     test_cases.emplace_back(new test_soft_max());
 
     for (ggml_type type : {GGML_TYPE_F32, GGML_TYPE_F16}) {

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -732,6 +732,29 @@ struct test_im2col : public test_case {
     }
 };
 
+// GGML_OP_CONCAT
+struct test_concat : public test_case {
+    const ggml_type type;
+    const std::array<int64_t, 4> ne;
+    const int64_t b_ne2;
+
+    std::string vars() override {
+        return VARS_TO_STR3(type, ne, b_ne2);
+    }
+
+    test_concat(ggml_type type = GGML_TYPE_F32,
+            std::array<int64_t, 4> ne = {10, 10, 10, 10},
+            int64_t b_ne2 = 10)
+        : type(type), ne(ne), b_ne2(b_ne2) {}
+
+    ggml_tensor * build_graph(ggml_context * ctx) override {
+        ggml_tensor * a = ggml_new_tensor(ctx, type, 4, ne.data());
+        ggml_tensor * b = ggml_new_tensor_4d(ctx, type, ne[0], ne[1], b_ne2, ne[3]);
+        ggml_tensor * out = ggml_concat(ctx, a, b);
+        return out;
+    }
+};
+
 static bool test_backend(ggml_backend_t backend) {
     ggml_backend_t backend_cpu = ggml_backend_cpu_init();
 
@@ -781,6 +804,7 @@ static bool test_backend(ggml_backend_t backend) {
     test_cases.emplace_back(new test_rope());
     test_cases.emplace_back(new test_alibi());
     test_cases.emplace_back(new test_im2col());
+    test_cases.emplace_back(new test_concat());
 
     size_t n_ok = 0;
     for (auto & test : test_cases) {

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -119,6 +119,23 @@ static float vec_len(const float * v, size_t n) {
 }
 */
 
+// normalized mean squared error = mse(a, b) / mse(a, 0)
+static double nmse(const float * a, const float * b, size_t n) {
+    double mse_a_b = 0.0;
+    double mse_a_0 = 0.0;
+
+    for (size_t i = 0; i < n; i++) {
+        float a_i = a[i];
+        float b_i = b[i];
+
+        mse_a_b += (a_i - b_i) * (a_i - b_i);
+        mse_a_0 += a_i * a_i;
+    }
+
+    return mse_a_b / mse_a_0;
+}
+
+// utils for printing the variables of the test cases
 #define VAR_TO_STR(x) (#x "=" + var_to_str(x))
 
 template<typename T>
@@ -172,22 +189,6 @@ static std::string var_to_str(ggml_type type) {
 #define VARS_TO_STR10(a,...) VAR_TO_STR(a) + "," + VARS_TO_STR9(__VA_ARGS__)
 #define VARS_TO_STR11(a,...) VAR_TO_STR(a) + "," + VARS_TO_STR10(__VA_ARGS__)
 
-
-// normalized mean squared error = mse(a, b) / mse(a, 0)
-static double nmse(const float * a, const float * b, size_t n) {
-    double mse_a_b = 0.0;
-    double mse_a_0 = 0.0;
-
-    for (size_t i = 0; i < n; i++) {
-        float a_i = a[i];
-        float b_i = b[i];
-
-        mse_a_b += (a_i - b_i) * (a_i - b_i);
-        mse_a_0 += a_i * a_i;
-    }
-
-    return mse_a_b / mse_a_0;
-}
 
 struct test_case {
     virtual ~test_case() {}

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -805,7 +805,17 @@ static bool test_backend(ggml_backend_t backend) {
     test_cases.emplace_back(new test_clamp());
     test_cases.emplace_back(new test_diag_mask_inf());
     test_cases.emplace_back(new test_soft_max());
-    test_cases.emplace_back(new test_rope());
+
+    test_cases.emplace_back(new test_rope(GGML_TYPE_F32, {128,  32, 10, 1}, 128, 0, 512)); // llama 7B
+    test_cases.emplace_back(new test_rope(GGML_TYPE_F32, {128,  40, 10, 1}, 128, 0, 512)); // llama 13B
+    test_cases.emplace_back(new test_rope(GGML_TYPE_F32, {128,  52, 10, 1}, 128, 0, 512)); // llama 30B
+    test_cases.emplace_back(new test_rope(GGML_TYPE_F32, {128,  64, 10, 1}, 128, 0, 512)); // llama 65B
+    test_cases.emplace_back(new test_rope(GGML_TYPE_F32, { 64,   1, 10, 1},  64, 2, 512)); // neox (falcon 7B)
+    test_cases.emplace_back(new test_rope(GGML_TYPE_F32, { 64,  71, 10, 1},  64, 2, 512)); // neox (falcon 7B)
+    test_cases.emplace_back(new test_rope(GGML_TYPE_F32, { 64,   8, 10, 1},  64, 2, 512)); // neox (falcon 40B)
+    test_cases.emplace_back(new test_rope(GGML_TYPE_F32, { 64, 128, 10, 1},  64, 2, 512)); // neox (falcon 40B)
+    //test_cases.emplace_back(new test_rope(GGML_TYPE_F32, {80, 32, 10, 1}, 20, 2, 512)); // neox rope (stablelm) (TODO: enable after llama.cpp sync)
+
     test_cases.emplace_back(new test_alibi());
     test_cases.emplace_back(new test_im2col());
     test_cases.emplace_back(new test_concat());

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -190,6 +190,8 @@ static double nmse(const float * a, const float * b, size_t n) {
 }
 
 struct test_case {
+    virtual ~test_case() {}
+
     virtual std::string vars() {
         return "";
     }

--- a/tests/test-conv1d.cpp
+++ b/tests/test-conv1d.cpp
@@ -71,7 +71,7 @@ void load_model(test_model & model, bool use_gpu = false) {
 #ifdef GGML_USE_CUBLAS
     if (use_gpu) {
         fprintf(stderr, "%s: using CUDA backend\n", __func__);
-        model.backend = ggml_backend_cuda_init();
+        model.backend = ggml_backend_cuda_init(0);
         if (!model.backend) {
             fprintf(stderr, "%s: ggml_backend_cuda_init() failed\n", __func__);
         }

--- a/tests/test-conv2d.cpp
+++ b/tests/test-conv2d.cpp
@@ -71,7 +71,7 @@ void load_model(test_model & model, bool use_gpu = false) {
 #ifdef GGML_USE_CUBLAS
     if (use_gpu) {
         fprintf(stderr, "%s: using CUDA backend\n", __func__);
-        model.backend = ggml_backend_cuda_init();
+        model.backend = ggml_backend_cuda_init(0);
         if (!model.backend) {
             fprintf(stderr, "%s: ggml_backend_cuda_init() failed\n", __func__);
         }

--- a/tests/test-mul-mat.cpp
+++ b/tests/test-mul-mat.cpp
@@ -51,7 +51,7 @@ void load_model(test_model & model, float* a, float* b, int M, int N, int K, boo
 #ifdef GGML_USE_CUBLAS
     if (use_gpu) {
         fprintf(stderr, "%s: using CUDA backend\n", __func__);
-        model.backend = ggml_backend_cuda_init();
+        model.backend = ggml_backend_cuda_init(0);
         if (!model.backend) {
             fprintf(stderr, "%s: ggml_backend_cuda_init() failed\n", __func__);
         }


### PR DESCRIPTION
- [x] Buffer types
- [x] Backend registry
- [x] Graph copy & compare between backends
- [x] `ggml_backend_alloc_ctx_tensors`
- [x] `ggml_unary_op_name` and `ggml_op_desc`
- [x] Backend buffer tests
- [x] Backend op tests
- [x] Update Metal backend
- [x] CUDA multiple device support

## Buffer types
- Buffers are no longer tied to a backend instance
- A buffer may be used in multiple backends. In systems with unified memory or integrated GPUs, this can allow fallback to CPU without copies
- Backends may add different types of buffers, even for different backends. For example, ggml-cuda adds a host pinned buffer that can be used with the CPU backend for faster transfer of inputs and outputs between system and device memory.


## Backend registry

Allows enumerating and initializing the available backends.
```C
// enumerate backends
for (size_t i = 0; i < ggml_backend_reg_get_count(); i++) {
    printf("Backend %zu/%zu (%s)\n", i + 1, ggml_backend_reg_get_count(), ggml_backend_reg_get_name(i));
    ggml_backend_buffer_t buf = ggml_backend_buft_alloc_buffer(ggml_backend_reg_get_default_buffer_type(i), size);
    ggml_backend_t backend = ggml_backend_reg_init_backend(i, NULL);
    // ...
}

// initialize a backend by name
ggml_backend_t backend = ggml_backend_reg_init_backend_from_str("CUDA0"); // cuda device 0
```

## Graph copy & compare between backends

Copy a graph to a different backend and evaluate it on both one op at a time. A callback can be used to compare the results of each operation.

```C++
// graph is allocated on the CUDA backend: copy and compare with CPU backend
auto eval_callback = [](int index, struct ggml_tensor * t1, struct ggml_tensor * t2, void * user_data) {
    if (t1->type == GGML_TYPE_F32) {
        std::vector<float> v1(GGML_PAD(ggml_nbytes(t1), sizeof(float)) / sizeof(float));
        std::vector<float> v2(GGML_PAD(ggml_nbytes(t2), sizeof(float)) / sizeof(float));

        ggml_backend_tensor_get(t1, v1.data(), 0, ggml_nbytes(t1));
        ggml_backend_tensor_get(t2, v2.data(), 0, ggml_nbytes(t2));

        for (size_t i = 0; i < v1.size(); ++i) {
            if (fabsf(v1[i] - v2[i]) > 1e0) {
                printf("[%d] %s [%s]: mismatch at index %zu: %f != %f\n", index, t1->name, ggml_op_desc(t1), i, v1[i], v2[i]);
                return false; // stop graph eval on first error
            }
        }
    }
    return true;
};

ggml_backend_compare_graph_backend(model.backend, backend_cpu, gf, eval_callback, nullptr);
```


## `ggml_backend_alloc_ctx_tensors`

Allocate all the tensors in a context and a backend buffer in one step. Ref: #578 

```C++
model.ln_f_g = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, n_embd);
model.ln_f_b = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, n_embd);

model.wte     = ggml_new_tensor_2d(ctx, wtype,         n_embd, n_vocab);
model.wpe     = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, n_embd, n_ctx);
model.lm_head = ggml_new_tensor_2d(ctx, wtype,         n_embd, n_vocab);
// etc

// allocate the model tensors in a backend buffer
model.buffer_w = ggml_backend_alloc_ctx_tensors(ctx, model.backend);
```

## `ggml_unary_op_name` and `ggml_op_desc`

`ggml_op_desc` can be used as a replacement of `ggml_op_name` that also returns the name of the unary op when the op is `GGML_OP_UNARY`.

## CUDA multiple device support

`ggml_backend_cuda_init` takes a `int device` parameter that specifies the CUDA device to use. To use the default device, pass `0`. Each device is registered as a different backend in the backend registry, with names `CUDA0` for device 0, `CUDA1` for device 1 and so on.


## Backend op tests

Each op implemented in the backends is tested against the CPU backend. Tensors are initialized with random data, and the result of the op is compared using a normalized MSE. New ops implemented in the backends should add a test in `test-backend-ops.cpp`. Only F16/F32 tests for now, quantized types are not yet supported in the test.