### PR TITLE
Feature: Circular Padding

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -17,7 +17,7 @@ const builtin = @import("builtin");
 //     zig build run_test-mul-mat2
 //     zig build run_test-opt
 //     zig build run_test-vec1
-//     zig build run_test-circularpadding
+//     zig build run_test-pad-circular
 //     zig build run_test0
 //     zig build run_test1
 //     zig build run_test2
@@ -96,7 +96,7 @@ pub fn build(b: *std.build.Builder) void {
         "test1",
         "test2",
         "test3",
-        "test-circularpadding",
+        "test-pad-circular",
     } else .{
         // "test-blas0",
         // "test-grad0",
@@ -112,7 +112,7 @@ pub fn build(b: *std.build.Builder) void {
         "test1",
         "test2",
         "test3",
-        "test-circularpadding",
+        "test-pad-circular",
     };
     inline for (tests) |name| {
         const exe = b.addExecutable(.{

--- a/include/ggml/ggml.h
+++ b/include/ggml/ggml.h
@@ -450,7 +450,7 @@ extern "C" {
         GGML_OP_CROSS_ENTROPY_LOSS,
         GGML_OP_CROSS_ENTROPY_LOSS_BACK,
 
-        GGML_OP_CIRCULAR_PADDING,
+        GGML_OP_PAD_CIRCULAR,
 
         GGML_OP_COUNT,
     };
@@ -1782,7 +1782,7 @@ extern "C" {
 
     // Circular Padding
 
-    GGML_API struct ggml_tensor * ggml_circular_padding(
+    GGML_API struct ggml_tensor * ggml_pad_circular(
             struct ggml_context * ctx,
             struct ggml_tensor  * a,
             int                   padding);

--- a/src/ggml.c
+++ b/src/ggml.c
@@ -1649,7 +1649,7 @@ static const char * GGML_OP_NAME[GGML_OP_COUNT] = {
     "CROSS_ENTROPY_LOSS",
     "CROSS_ENTROPY_LOSS_BACK",
 
-    "CIRCULAR_PADDING"
+    "PAD_CIRCULAR"
 };
 
 static_assert(GGML_OP_COUNT == 71, "GGML_OP_COUNT != 71");
@@ -1735,7 +1735,7 @@ static const char * GGML_OP_SYMBOL[GGML_OP_COUNT] = {
     "cross_entropy_loss(x,y)",
     "cross_entropy_loss_back(x,y)",
 
-    "circular_pad(x)"
+    "pad_circular(x)"
 };
 
 static_assert(GGML_OP_COUNT == 71, "GGML_OP_COUNT != 71");
@@ -6307,9 +6307,9 @@ struct ggml_tensor * ggml_cross_entropy_loss_back(
     return result;
 }
 
-//GGML_CIRCULAR_PADDING
+//GGML_PAD_CIRCULAR
 
-static struct ggml_tensor * ggml_circular_padding_impl(
+static struct ggml_tensor * ggml_pad_circular_impl(
     struct ggml_context * ctx,
     struct ggml_tensor * a,
     int padding) {
@@ -6328,7 +6328,7 @@ static struct ggml_tensor * ggml_circular_padding_impl(
             new_width,
             a->ne[2], a->ne[3]);
 
-    result->op = GGML_OP_CIRCULAR_PADDING;
+    result->op = GGML_OP_PAD_CIRCULAR;
     result->op_params[0] = padding;
     result->grad = is_node ? ggml_dup_tensor(ctx, result) : NULL;
     result->src[0] = a;
@@ -6337,11 +6337,11 @@ static struct ggml_tensor * ggml_circular_padding_impl(
     return result;
 }
 
-struct ggml_tensor * ggml_circular_padding(
+struct ggml_tensor * ggml_pad_circular(
     struct ggml_context * ctx,
     struct ggml_tensor * a,
     int padding) {
-    return ggml_circular_padding_impl(ctx, a, padding);
+    return ggml_pad_circular_impl(ctx, a, padding);
 }
 
 
@@ -13876,9 +13876,9 @@ static void ggml_compute_forward_cross_entropy_loss_back(
     }
 }
 
-// ggml_compute_cicular_padding
+// ggml_compute_pad_circular
 
-static void ggml_compute_forward_circular_padding_f16(
+static void ggml_compute_forward_pad_circular_f16(
         const struct ggml_compute_params * params,
         const struct ggml_tensor * src,
         struct ggml_tensor * dst) {
@@ -13913,7 +13913,7 @@ static void ggml_compute_forward_circular_padding_f16(
     }
 }
 
-static void ggml_compute_forward_circular_padding_f32(
+static void ggml_compute_forward_pad_circular_f32(
         const struct ggml_compute_params * params,
         const struct ggml_tensor * src,
         struct ggml_tensor * dst) {
@@ -13950,7 +13950,7 @@ static void ggml_compute_forward_circular_padding_f32(
 }
 
 // TODO: Make sure this works i am not familiar with quantization.
-static void ggml_compute_forward_circular_padding_q_f32(
+static void ggml_compute_forward_pad_circular_q_f32(
         const struct ggml_compute_params * params,
         const struct ggml_tensor * src,
         struct ggml_tensor * dst) {
@@ -13987,7 +13987,7 @@ static void ggml_compute_forward_circular_padding_q_f32(
 
 }
 
-static void ggml_compute_forward_circular_padding(
+static void ggml_compute_forward_pad_circular(
         const struct ggml_compute_params * params,
         const struct ggml_tensor * src,
         struct ggml_tensor * dst) {
@@ -13996,10 +13996,10 @@ static void ggml_compute_forward_circular_padding(
 
     switch (src->type) {
         case GGML_TYPE_F32:
-            ggml_compute_forward_circular_padding_f32(params, src, dst);
+            ggml_compute_forward_pad_circular_f32(params, src, dst);
             break;
         case GGML_TYPE_F16:
-            ggml_compute_forward_circular_padding_f16(params, src, dst);
+            ggml_compute_forward_pad_circular_f16(params, src, dst);
             break;
         case GGML_TYPE_Q4_0:
         case GGML_TYPE_Q4_1:
@@ -14012,7 +14012,7 @@ static void ggml_compute_forward_circular_padding(
         case GGML_TYPE_Q5_K:
         case GGML_TYPE_Q6_K:
             {
-                ggml_compute_forward_circular_padding_q_f32(params, src,dst);
+                ggml_compute_forward_pad_circular_q_f32(params, src,dst);
             } break;
         default:
             {
@@ -14343,9 +14343,9 @@ static void ggml_compute_forward(struct ggml_compute_params * params, struct ggm
                 ggml_compute_forward_cross_entropy_loss_back(params, tensor->src[0], tensor->src[1], tensor->src[2], tensor);
             }
             break;
-        case GGML_OP_CIRCULAR_PADDING:
+        case GGML_OP_PAD_CIRCULAR:
             {
-                ggml_compute_forward_circular_padding(params, tensor->src[0], tensor);
+                ggml_compute_forward_pad_circular(params, tensor->src[0], tensor);
             }
             break;
         case GGML_OP_NONE:
@@ -15413,7 +15413,7 @@ static void ggml_compute_backward(struct ggml_context * ctx, struct ggml_tensor 
             {
                 GGML_ASSERT(false); // not supported
             } break;
-        case GGML_OP_CIRCULAR_PADDING:
+        case GGML_OP_PAD_CIRCULAR:
             {
                 GGML_ASSERT(false); // TODO: not implemented
             } break;
@@ -16045,7 +16045,7 @@ static int ggml_get_n_tasks(struct ggml_tensor * node, int n_threads) {
             {
                 n_tasks = n_threads;
             } break;
-        case GGML_OP_CIRCULAR_PADDING:
+        case GGML_OP_PAD_CIRCULAR:
             {
                 n_tasks=n_threads;
             };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -406,9 +406,9 @@ add_test(NAME ${TEST_TARGET} COMMAND $<TARGET_FILE:${TEST_TARGET}>)
 set_property(TEST ${TEST_TARGET} PROPERTY ENVIRONMENT "LLVM_PROFILE_FILE=${TEST_TARGET}.profraw")
 
 #
-# test-circularpadding
+# test-pad-circular
 
-set(TEST_TARGET test-circularpadding)
+set(TEST_TARGET test-pad-circular)
 add_executable(${TEST_TARGET} ${TEST_TARGET}.cpp)
 target_link_libraries(${TEST_TARGET} PRIVATE ggml)
 add_test(NAME ${TEST_TARGET} COMMAND $<TARGET_FILE:${TEST_TARGET}>)

--- a/tests/test-pad-circular.cpp
+++ b/tests/test-pad-circular.cpp
@@ -21,49 +21,64 @@ struct ggml_context* make_ctx(void) {
 }
 int main(void) {
     bool debug = false;
-
+    const int pad_amount=2;
+    const int base_tensor_size=3;
     struct ggml_context * ctx = make_ctx();
     struct ggml_tensor * a = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, 3, 3);
-    float test_data[3][3] = {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
-    for (int i = 0; i < 3; ++i) {
-        for (int j = 0; j < 3; ++j) {
-            ggml_set_f32_1d(a, i * 3 + j, test_data[i][j]);
+    //Base tensor values is hardcoded
+    float test_data[base_tensor_size][base_tensor_size] = {
+        {1, 2, 3},
+        {4, 5, 6},
+        {7, 8, 9}
+        };
+    for (int i = 0; i < base_tensor_size; ++i) {
+        for (int j = 0; j < base_tensor_size; ++j) {
+            ggml_set_f32_1d(a, i * base_tensor_size + j, test_data[i][j]);
         }
     }
     if (debug) {
         printf("Base Tensor Data:\n");
-        for (int i = 0; i < 3; ++i) {
-            for (int j = 0; j < 3; ++j) {
-                float val = ggml_get_f32_1d(a, i * 3 + j);
+        for (int i = 0; i < base_tensor_size; ++i) {
+            for (int j = 0; j < base_tensor_size; ++j) {
+                float val = ggml_get_f32_1d(a, i * base_tensor_size + j);
                 printf("%4.1f ", val);
             }
             printf("\n");
         }
     }
-    struct ggml_tensor * padded_a = ggml_circular_padding(ctx, a, 1);
+    struct ggml_tensor * padded_a = ggml_pad_circular(ctx, a, pad_amount);
     struct ggml_cgraph * gf = ggml_new_graph(ctx);
     ggml_build_forward_expand(gf, padded_a);
     ggml_graph_compute_with_ctx(ctx, gf, 1);
-    float expected[5][5] = {
+    //Expected Result is also hardcoded
+    float expected_pad1[base_tensor_size+pad_amount*2][base_tensor_size+pad_amount*2] = {
         {9, 7, 8, 9, 7},
         {3, 1, 2, 3, 1},
         {6, 4, 5, 6, 4},
         {9, 7, 8, 9, 7},
         {3, 1, 2, 3, 1}
     };
-
+    float expected_pad2[base_tensor_size+pad_amount*2][base_tensor_size+pad_amount*2] = {
+        {5, 6, 4, 5, 6, 4, 5},
+        {8, 9, 7, 8, 9, 7, 8},
+        {2, 3, 1, 2, 3, 1, 2},
+        {5, 6, 4, 5, 6, 4, 5},
+        {8, 9, 7, 8, 9, 7, 8},
+        {2, 3, 1, 2, 3, 1, 2},
+        {5, 6, 4, 5, 6, 4, 5}
+    };
     bool passed = true;
     if(debug){
         printf("\nResult:\n");
     }
-    for (int i = 0; i < 5; ++i) {
-        for (int j = 0; j < 5; ++j) {
-            float val = ggml_get_f32_1d(padded_a, i * 5 + j);
+    for (int i = 0; i < base_tensor_size+pad_amount*2; ++i) {
+        for (int j = 0; j < base_tensor_size+pad_amount*2; ++j) {
+            float val = ggml_get_f32_1d(padded_a, i * (base_tensor_size+pad_amount*2) + j);
 
             if(debug){
                 printf("%4.1f ", val);
             }
-            if (val != expected[i][j]) {
+            if (val != expected_pad2[i][j]) {
                 passed = false;
             }
         }
@@ -71,9 +86,9 @@ int main(void) {
     }
     if (debug && !passed) {
         printf("Expected Result:\n");
-        for (int i = 0; i < 5; ++i) {
-            for (int j = 0; j < 5; ++j) {
-                printf("%4.1f ", expected[i][j]);
+        for (int i = 0; i < base_tensor_size+pad_amount*2; ++i) {
+            for (int j = 0; j < base_tensor_size+pad_amount*2; ++j) {
+                printf("%4.1f ", expected_pad2[i][j]);
             }
             printf("\n");
         }


### PR DESCRIPTION
This pull request introduces the circular padding feature into the ggml library. 

`struct ggml_tensor * paddedoutput= ggml_circular_padding(ctx, tensorInput, paddingAmount);`

I believe i wrote the code be effecient and able to parallelized, i'm not entirely familiar with c, so if anyone can review and make sure it's not going to interfere or grind anything to a halt = )

Example input and output with padding 1
![image](https://github.com/ggerganov/ggml/assets/3459724/d6784526-9511-4443-813b-80ad92855b91)
