### PR TITLE
ggml-backend : remove backend self-registration

### DIFF
--- a/src/ggml-backend-impl.h
+++ b/src/ggml-backend-impl.h
@@ -105,36 +105,7 @@ extern "C" {
 
     typedef ggml_backend_t (*ggml_backend_init_fn)(const char * params, void * user_data);
 
-    size_t ggml_backend_register(const char * name, ggml_backend_init_fn init_fn, ggml_backend_buffer_type_t default_buffer_type, void * user_data);
-
-
-    // Register a int function to be called at program startup
-    #if defined(__GNUC__) || defined(__clang__)
-        #define GGML_CONSTRUCTOR(init_fn) \
-            static void __attribute__((constructor)) init_fn ## _ggml_constructor(void) { \
-                init_fn(); \
-            }
-    #elif defined(_MSC_VER)
-        #ifdef __cplusplus
-            #define GGML_CONSTRUCTOR(init_fn) \
-                static int init_fn ## _ggml_constructor_dummy = init_fn();
-        #else
-            #define GGML_CONSTRUCTOR(init_fn) \
-                __pragma(section(".CRT$XCV", read)) \
-                __declspec(allocate(".CRT$XCV")) int (*init_fn ## _ggml_constructor)(void) = init_fn; \
-                __pragma(comment(linker, "/include:" #init_fn "_ggml_constructor"))
-        #endif
-    #else
-        #error "GGML_CONSTRUCTOR not implemented for this compiler"
-    #endif
-
-
-    // Register a backend
-    #define GGML_BACKEND_REGISTER(name, init_fn, buft, user_data) \
-        static void init_fn ## _backend_register(void) { \
-            ggml_backend_register(name, init_fn, buft, user_data); \
-        } \
-        GGML_CONSTRUCTOR(init_fn ## _backend_register)
+    void ggml_backend_register(const char * name, ggml_backend_init_fn init_fn, ggml_backend_buffer_type_t default_buffer_type, void * user_data);
 
 #ifdef  __cplusplus
 }

--- a/src/ggml-cuda.cu
+++ b/src/ggml-cuda.cu
@@ -9034,7 +9034,7 @@ static ggml_backend_t ggml_backend_reg_cuda_init(const char * params, void * use
     UNUSED(params);
 }
 
-static int ggml_backend_cuda_reg_devices() {
+extern "C" int ggml_backend_cuda_reg_devices() {
     int device_count = ggml_cuda_get_device_count();
     //int device_count = 1; // DEBUG: some tools require delaying CUDA initialization
     for (int i = 0; i < device_count; i++) {
@@ -9044,5 +9044,3 @@ static int ggml_backend_cuda_reg_devices() {
     }
     return device_count;
 }
-
-GGML_CONSTRUCTOR(ggml_backend_cuda_reg_devices)

--- a/src/ggml-metal.m
+++ b/src/ggml-metal.m
@@ -2057,11 +2057,11 @@ void ggml_backend_metal_set_n_cb(ggml_backend_t backend, int n_cb) {
     ggml_metal_set_n_cb(ctx, n_cb);
 }
 
-static ggml_backend_t ggml_backend_reg_metal_init(const char * params, void * user_data) {
+ggml_backend_t ggml_backend_reg_metal_init(const char * params, void * user_data); // silence warning
+
+ggml_backend_t ggml_backend_reg_metal_init(const char * params, void * user_data) {
     return ggml_backend_metal_init();
 
     GGML_UNUSED(params);
     GGML_UNUSED(user_data);
 }
-
-GGML_BACKEND_REGISTER("Metal", ggml_backend_reg_metal_init, ggml_backend_metal_buffer_type(), NULL)


### PR DESCRIPTION
Register backends manually instead to fix compilation issues.