### PR TITLE
Change installation path of static libraries to standard directory

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -399,6 +399,5 @@ set_target_properties(${TARGET} PROPERTIES
 
 install(TARGETS ${TARGET}
     LIBRARY DESTINATION lib
-    ARCHIVE DESTINATION lib/static
     PUBLIC_HEADER DESTINATION include/ggml
     )


### PR DESCRIPTION
Currently, the static libraries are configured to be installed in the `lib/static` directory. While this setup is functional, it is somewhat unconventional. I believe this modification will enhance compatibility and adhere to common practices in C++ project configurations.