### PR TITLE
Create CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,8 @@
+cff-version: 1.2.0
+message: If you use this software, please cite it using these metadata.
+title: GGML - Tensor library for machine learning
+authors:
+  - family-names: Gerganov
+    given-names: Georgi
+license: MIT
+repository-code: "https://github.com/ggerganov/ggml"


### PR DESCRIPTION
Related issue: #642 

To automatically generate APA & Bibtex citations. As mentioned in #642 registering the software to zenodo and fix the version is preferable. Thus, optionally this PR can be closed after zenodo register and extending the citation information (e.g. adding DOI). @ggerganov 

NOTE: Also, a version tag coıuld be created from latest commits as to specify version in a better way (to appear nicely on citations).

I have created a zenodo entry which would generate the following bibtex, I just created a preview (not published) an entry on behalf of @ggerganov. I can publish it for the version I specified, but I think it'd be better if you publish that as a creator and the owner.

```bibtex
@software{georgi_2023_XXXXXXXX,
  author       = {Georgi, Gerganov},
  title        = {GGML - Tensor library for machine learning},
  month        = dec,
  year         = 2023,
  publisher    = {Github},
  version      = {c80e07e9d4724392aaf02cdf32d1a1fb7228bea9},
  doi          = {10.5281/zenodo.XXXXXXXX},
  url          = {https://github.com/ggerganov/ggml}
}
``` 