### PR TITLE
cuda : ggml_mul_mat assert for padded src1

### DIFF
--- a/src/ggml-cuda.cu
+++ b/src/ggml-cuda.cu
@@ -8529,6 +8529,7 @@ static void ggml_cuda_mul_mat_mat_batched_cublas(const ggml_tensor * src0, const
     if (src1->type != GGML_TYPE_F16) {
         const to_fp16_cuda_t to_fp16_cuda = ggml_get_to_fp16_cuda(src1->type);
         const int64_t ne_src1 = ggml_nelements(src1);
+        GGML_ASSERT(ne_src1 == ggml_nbytes(src1)/ggml_type_size(src1->type));
         src1_f16_alloc.alloc(ne_src1);
         GGML_ASSERT(to_fp16_cuda != nullptr);
         to_fp16_cuda(src1_ddf, src1_f16_alloc.get(), ne_src1, main_stream);


### PR DESCRIPTION
Currently, the padded matrix multiplications in `whisper.cpp` are silently failing with CUDA:

https://github.com/ggerganov/ggml/blob/dbd02958fa4f46898f68ca29c27ddcdc58a06f98/examples/whisper/whisper.cpp#L224-L230

The reason is that the `to_fp16_cuda` and `to_fp32_cuda` calls assume no padding of the data. We can either assert that the data is not padded, or over-allocate a buffer accounting for the padding. The latter produces correct results, but is sub-optimal.

Drafting this PR to brainstorm some potential solutions