### PR TITLE
Adds Swift Package declaration for GGML

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,49 @@
+// swift-tools-version: 5.9
+
+import PackageDescription
+
+let package = Package(
+    name: "ggml",
+    platforms: [
+        .macOS(.v12),
+        .iOS(.v14),
+        .watchOS(.v4),
+        .tvOS(.v14)
+    ],
+    products: [
+        .library(name: "ggml", targets: ["ggml"]),
+    ],
+    targets: [
+        .target(
+            name: "ggml",
+            path: ".",
+            exclude: [],
+            sources: [
+                "ggml.c",
+                "ggml-alloc.c",
+                "ggml-backend.c",
+                "ggml-quants.c",
+                "ggml-metal.m",
+            ],
+            resources: [
+                .process("ggml-metal.metal")
+            ],
+            publicHeadersPath: "spm-headers",
+            cSettings: [
+                .unsafeFlags(["-Wno-shorten-64-to-32", "-O3", "-DNDEBUG"]),
+                .define("GGML_USE_ACCELERATE"),
+                .unsafeFlags(["-fno-objc-arc"]),
+                .define("GGML_USE_METAL"),
+                // NOTE: NEW_LAPACK will required iOS version 16.4+
+                // We should consider add this in the future when we drop support for iOS 14
+                // (ref: ref: https://developer.apple.com/documentation/accelerate/1513264-cblas_sgemm?language=objc)
+                // .define("ACCELERATE_NEW_LAPACK"),
+                // .define("ACCELERATE_LAPACK_ILP64")
+            ],
+            linkerSettings: [
+                .linkedFramework("Accelerate")
+            ]
+        )
+    ],
+    cxxLanguageStandard: .cxx11
+)

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 5.5
 
 import PackageDescription
 
@@ -19,16 +19,16 @@ let package = Package(
             path: ".",
             exclude: [],
             sources: [
-                "ggml.c",
-                "ggml-alloc.c",
-                "ggml-backend.c",
-                "ggml-quants.c",
-                "ggml-metal.m",
+                "src/ggml.c",
+                "src/ggml-alloc.c",
+                "src/ggml-backend.c",
+                "src/ggml-quants.c",
+                "src/ggml-metal.m",
             ],
             resources: [
-                .process("ggml-metal.metal")
+                .process("src/ggml-metal.metal")
             ],
-            publicHeadersPath: "spm-headers",
+            publicHeadersPath: "include/ggml",
             cSettings: [
                 .unsafeFlags(["-Wno-shorten-64-to-32", "-O3", "-DNDEBUG"]),
                 .define("GGML_USE_ACCELERATE"),


### PR DESCRIPTION
When adding both whisper.cpp and llama.cpp as package dependency in Xcode - we run into "duplicate declarations of symbols" issue as both of these package uses the same source files for ggml.

Adding this swift package to ggml and importing it as a dependency to both whisper.cpp and llama.cpp solves the issue.

Once this pull request is merged, merge the pull requests to both whisper.cpp and llama.cpp that use ggml as dependency.