### PR TITLE
fix : cuda order of synchronization when setting a buffer

### DIFF
--- a/src/ggml-cuda.cu
+++ b/src/ggml-cuda.cu
@@ -9687,10 +9687,10 @@ static void ggml_backend_cuda_buffer_set_tensor(ggml_backend_buffer_t buffer, gg
 
     ggml_backend_buffer_context_cuda * ctx = (ggml_backend_buffer_context_cuda *)buffer->context;
 
+    CUDA_CHECK(cudaMemcpy((char *)tensor->data + offset, data, size, cudaMemcpyHostToDevice));
+
     ggml_cuda_set_device(ctx->device);
     CUDA_CHECK(cudaDeviceSynchronize());
-
-    CUDA_CHECK(cudaMemcpy((char *)tensor->data + offset, data, size, cudaMemcpyHostToDevice));
 }
 
 static void ggml_backend_cuda_buffer_get_tensor(ggml_backend_buffer_t buffer, const ggml_tensor * tensor, void * data, size_t offset, size_t size) {

--- a/src/ggml-cuda.cu
+++ b/src/ggml-cuda.cu
@@ -9687,9 +9687,9 @@ static void ggml_backend_cuda_buffer_set_tensor(ggml_backend_buffer_t buffer, gg
 
     ggml_backend_buffer_context_cuda * ctx = (ggml_backend_buffer_context_cuda *)buffer->context;
 
-    CUDA_CHECK(cudaMemcpy((char *)tensor->data + offset, data, size, cudaMemcpyHostToDevice));
-
     ggml_cuda_set_device(ctx->device);
+    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaMemcpy((char *)tensor->data + offset, data, size, cudaMemcpyHostToDevice));
     CUDA_CHECK(cudaDeviceSynchronize());
 }
 


### PR DESCRIPTION
we need to wait **after** the set to wait for all data to arrive.

see here https://github.com/leejet/stable-diffusion.cpp/pull/129#issuecomment-1873844723
and here https://github.com/leejet/stable-diffusion.cpp/pull/129#issuecomment-1873978488