### PR TITLE
change GGML_MAX_NAME to 128

### DIFF
--- a/include/ggml/ggml.h
+++ b/include/ggml/ggml.h
@@ -218,7 +218,7 @@
 #define GGML_MAX_PARAMS         2048
 #define GGML_MAX_CONTEXTS       64
 #define GGML_MAX_SRC            10
-#define GGML_MAX_NAME           64
+#define GGML_MAX_NAME           128
 #define GGML_MAX_OP_PARAMS      64
 #define GGML_DEFAULT_N_THREADS  4
 #define GGML_DEFAULT_GRAPH_SIZE 2048

--- a/include/ggml/ggml.h
+++ b/include/ggml/ggml.h
@@ -218,7 +218,9 @@
 #define GGML_MAX_PARAMS         2048
 #define GGML_MAX_CONTEXTS       64
 #define GGML_MAX_SRC            10
-#define GGML_MAX_NAME           128
+#ifndef GGML_MAX_NAME
+#define GGML_MAX_NAME           64
+#endif
 #define GGML_MAX_OP_PARAMS      64
 #define GGML_DEFAULT_N_THREADS  4
 #define GGML_DEFAULT_GRAPH_SIZE 2048


### PR DESCRIPTION
Names of certain tensors, like those in stable-diffusion, exceed a length of 64 characters. I hope the upstream ggml can merge this pr, so I don't have to maintain a separate fork.