### PR TITLE
fix ROCm on Windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -343,11 +343,7 @@ target_include_directories(${TARGET} PUBLIC
     ${GGML_EXTRA_INCS}
     )
 
-if (WIN32)
-    target_link_libraries(${TARGET} PUBLIC ${GGML_EXTRA_LIBS} ${CMAKE_THREAD_LIBS_INIT})
-else()
-    target_link_libraries(${TARGET} PUBLIC m ${GGML_EXTRA_LIBS} ${CMAKE_THREAD_LIBS_INIT})
-endif()
+target_link_libraries(${TARGET} PUBLIC ${GGML_EXTRA_LIBS} ${CMAKE_THREAD_LIBS_INIT})
 
 if (BUILD_SHARED_LIBS)
     set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -343,6 +343,11 @@ target_include_directories(${TARGET} PUBLIC
     ${GGML_EXTRA_INCS}
     )
 
+find_library(MATH_LIBRARY m)
+if (MATH_LIBRARY)
+    target_link_libraries(${TARGET} PUBLIC ${MATH_LIBRARY})
+endif()
+
 target_link_libraries(${TARGET} PUBLIC ${GGML_EXTRA_LIBS} ${CMAKE_THREAD_LIBS_INIT})
 
 if (BUILD_SHARED_LIBS)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -343,14 +343,10 @@ target_include_directories(${TARGET} PUBLIC
     ${GGML_EXTRA_INCS}
     )
 
-if (MSVC)
+if (WIN32)
     target_link_libraries(${TARGET} PUBLIC ${GGML_EXTRA_LIBS} ${CMAKE_THREAD_LIBS_INIT})
 else()
-    if (WIN32 AND GGML_HIPBLAS)
-        target_link_libraries(${TARGET} PUBLIC ${GGML_EXTRA_LIBS} ${CMAKE_THREAD_LIBS_INIT})
-    else()
-        target_link_libraries(${TARGET} PUBLIC m ${GGML_EXTRA_LIBS} ${CMAKE_THREAD_LIBS_INIT})
-    endif()
+    target_link_libraries(${TARGET} PUBLIC m ${GGML_EXTRA_LIBS} ${CMAKE_THREAD_LIBS_INIT})
 endif()
 
 if (BUILD_SHARED_LIBS)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -263,7 +263,7 @@ if (GGML_HIPBLAS)
     if (${hipblas_FOUND} AND ${hip_FOUND})
         message(STATUS "HIP and hipBLAS found")
 
-        set(GGML_EXTRA_FLAGS ${GGML_EXTRA_FLAGS} -DGGML_USE_CUBLAS)
+        add_compile_definitions(GGML_USE_HIPBLAS GGML_USE_CUBLAS)
 
         add_library(ggml-rocm OBJECT ggml-cuda.cu ggml-cuda.h)
         if (BUILD_SHARED_LIBS)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -346,7 +346,11 @@ target_include_directories(${TARGET} PUBLIC
 if (MSVC)
     target_link_libraries(${TARGET} PUBLIC ${GGML_EXTRA_LIBS} ${CMAKE_THREAD_LIBS_INIT})
 else()
-    target_link_libraries(${TARGET} PUBLIC m ${GGML_EXTRA_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+    if (WIN32 AND GGML_HIPBLAS)
+        target_link_libraries(${TARGET} PUBLIC ${GGML_EXTRA_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+    else()
+        target_link_libraries(${TARGET} PUBLIC m ${GGML_EXTRA_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+    endif()
 endif()
 
 if (BUILD_SHARED_LIBS)


### PR DESCRIPTION
There is no need for the m link library in the Windows environment. If we try to link, an error will occur.
I can make sure it's correct because at [rwkv](https://github.com/saharNooby/rwkv.cpp/blob/d37568443493b540204bc93008d7820b1eefb74a/CMakeLists.txt#L422), that's what I do. We can also check in the rwkv release that the built library is correct.