### PR TITLE
metal : wrap each operation in debug group

### DIFF
--- a/src/ggml-metal.m
+++ b/src/ggml-metal.m
@@ -1067,6 +1067,8 @@ bool ggml_metal_graph_compute(
                     GGML_ASSERT(!"unsupported op");
                 }
 
+                [encoder pushDebugGroup:[NSString stringWithCString:ggml_op_desc(dst)]];
+
                 const int64_t  ne00 = src0 ? src0->ne[0] : 0;
                 const int64_t  ne01 = src0 ? src0->ne[1] : 0;
                 const int64_t  ne02 = src0 ? src0->ne[2] : 0;
@@ -2423,6 +2425,8 @@ bool ggml_metal_graph_compute(
                             GGML_ASSERT(false);
                         }
                 }
+
+                [encoder popDebugGroup];
             }
 
             if (encoder != nil) {


### PR DESCRIPTION
The screenshot below shows a Metal debug capture of `gpt-2-backend` with the addition of debug groups.

<img width="387" alt="ggml-metal-debug-group" src="https://github.com/ggerganov/ggml/assets/7120397/133565a9-0e6b-49ef-8640-d287689818bc">
