### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ make -j4 gpt-2-backend gpt-j
 
 # Run the GPT-2 small 117M model
 ../examples/gpt-2/download-ggml-model.sh 117M
-./bin/gpt-2 -m models/gpt-2-117M/ggml-model.bin -p "This is an example"
+./bin/gpt-2-backend -m models/gpt-2-117M/ggml-model.bin -p "This is an example"
 
 # Run the GPT-J 6B model (requires 12GB disk space and 16GB CPU RAM)
 ../examples/gpt-j/download-ggml-model.sh 6B


### PR DESCRIPTION
Fix #666 

Using `gpt-2-backend` instead of `gpt-2` to update the README.md