### PR TITLE
metal : add debug capture backend function

### DIFF
--- a/src/ggml-metal.h
+++ b/src/ggml-metal.h
@@ -109,6 +109,9 @@ GGML_API ggml_backend_buffer_type_t ggml_backend_metal_buffer_type(void);
 // ref: https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf
 GGML_API bool ggml_backend_metal_supports_family(ggml_backend_t backend, int family);
 
+// capture all command buffers committed the next time `ggml_backend_graph_compute` is called
+GGML_API void ggml_backend_metal_capture_next_compute(ggml_backend_t backend);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
`ggml_backend_metal_capture_next_compute` will capture all command buffers the next time `ggml_backend_graph_compute` is called, simplifying the Metal debugger workflow.

```c
// Example usage
if (ggml_backend_is_metal(model.backend)) {
    ggml_backend_metal_capture_next_compute(model.backend);
}
```