### PR TITLE
gguf : add input validation, prevent integer overflows

### DIFF
--- a/src/ggml.c
+++ b/src/ggml.c
@@ -19363,9 +19363,9 @@ struct gguf_context * gguf_init_from_file(const char * fname, struct gguf_init_p
 
         // sanity-checks to prevent from integer/buffer overflows
 
-        ok = ok && (ctx->header.n_tensors < SIZE_MAX/sizeof(struct gguf_tensor_info));
-        ok = ok && (ctx->header.n_tensors < SIZE_MAX/ggml_tensor_overhead());
-        ok = ok && (ctx->header.n_kv      < SIZE_MAX/sizeof(struct gguf_kv));
+        ok = ok && (ctx->header.n_tensors < (SIZE_MAX/2)/sizeof(struct gguf_tensor_info));
+        ok = ok && (ctx->header.n_tensors < (SIZE_MAX/2)/ggml_tensor_overhead());
+        ok = ok && (ctx->header.n_kv      < (SIZE_MAX/2)/sizeof(struct gguf_kv));
 
         if (!ok) {
             fprintf(stderr, "%s: failed to read header\n", __func__);

--- a/src/ggml.c
+++ b/src/ggml.c
@@ -19348,10 +19348,9 @@ struct gguf_context * gguf_init_from_file(const char * fname, struct gguf_init_p
         }
 
         // sanity-checks to prevent from integer/buffer overflows
-        // - sizeof(struct gguf_tensor_info)*n_tensors < SIZE_MAX
-        // - sizeof(struct gguf_kv)*n_kv               < SIZE_MAX
 
         ok = ok && (ctx->header.n_tensors < SIZE_MAX/sizeof(struct gguf_tensor_info));
+        ok = ok && (ctx->header.n_tensors < SIZE_MAX/ggml_tensor_overhead());
         ok = ok && (ctx->header.n_kv      < SIZE_MAX/sizeof(struct gguf_kv));
 
         if (!ok) {

--- a/src/ggml.c
+++ b/src/ggml.c
@@ -19430,11 +19430,17 @@ struct gguf_context * gguf_init_from_file(const char * fname, struct gguf_init_p
 
             ok = ok && gguf_fread_str(file, &info->name,                          &offset);
             ok = ok && gguf_fread_el (file, &info->n_dims, sizeof(info->n_dims),  &offset);
+
+            ok = ok && (info->n_dims <= GGML_MAX_DIMS);
+
             for (uint32_t j = 0; j < info->n_dims; ++j) {
                 ok = ok && gguf_fread_el(file, &info->ne[j], sizeof(info->ne[j]), &offset);
             }
+
             ok = ok && gguf_fread_el (file, &info->type,   sizeof(info->type),    &offset);
             ok = ok && gguf_fread_el (file, &info->offset, sizeof(info->offset),  &offset);
+
+            ok = ok && (info->type < GGML_TYPE_COUNT);
 
             if (!ok) {
                 fprintf(stderr, "%s: failed to read tensor info\n", __func__);

--- a/src/ggml.c
+++ b/src/ggml.c
@@ -19398,10 +19398,10 @@ struct gguf_context * gguf_init_from_file(const char * fname, struct gguf_init_p
                                     }
                                 } break;
                             case GGUF_TYPE_ARRAY:
-                            case GGUF_TYPE_COUNT: GGML_ASSERT(false && "invalid type"); break;
+                            default: GGML_ASSERT(false && "invalid type"); break;
                         }
                     } break;
-                case GGUF_TYPE_COUNT: GGML_ASSERT(false && "invalid type");
+                default: GGML_ASSERT(false && "invalid type");
             }
 
             if (!ok) {
@@ -19975,7 +19975,7 @@ void gguf_set_kv(struct gguf_context * ctx, struct gguf_context * src) {
                         gguf_set_arr_data(ctx, src->kv[i].key.data, src->kv[i].value.arr.type, src->kv[i].value.arr.data, src->kv[i].value.arr.n);
                     }
                 } break;
-            case GGUF_TYPE_COUNT:  GGML_ASSERT(false && "invalid type"); break;
+            default: GGML_ASSERT(false && "invalid type"); break;
         }
     }
 }
@@ -20151,10 +20151,10 @@ static void gguf_write_to_buf(const struct gguf_context * ctx, struct gguf_buf *
                                 }
                             } break;
                         case GGUF_TYPE_ARRAY:
-                        case GGUF_TYPE_COUNT: GGML_ASSERT(false && "invalid type"); break;
+                        default: GGML_ASSERT(false && "invalid type"); break;
                     }
                 } break;
-            case GGUF_TYPE_COUNT: GGML_ASSERT(false && "invalid type");
+            default: GGML_ASSERT(false && "invalid type");
         }
     }
 


### PR DESCRIPTION
Input validation when reading GGUF files

Without these checks it is possible for crafted GGUF files to cause integer overflows, followed by heap overflows.

Thanks to Databricks team for responsibly reporting these