### PR TITLE
fix the conv_2d batch mode

### DIFF
--- a/src/ggml.c
+++ b/src/ggml.c
@@ -5556,7 +5556,9 @@ struct ggml_tensor * ggml_conv_2d(
                 ggml_reshape_2d(ctx, im2col, im2col->ne[0],  im2col->ne[3] * im2col->ne[2] * im2col->ne[1]), // [N, OH, OW, IC * KH * KW] => [N*OH*OW, IC * KH * KW]
                 ggml_reshape_2d(ctx, a, (a->ne[0] * a->ne[1] * a->ne[2]),  a->ne[3]));                       // [OC，IC, KH, KW] => [OC, IC * KH * KW]
 
-    result = ggml_reshape_4d(ctx, result, im2col->ne[1], im2col->ne[2], a->ne[3], im2col->ne[3]); // [N, OC, OH, OW]
+    result = ggml_reshape_4d(ctx, result, im2col->ne[1], im2col->ne[2], im2col->ne[3], a->ne[3]); // [OC, N, OH, OW]
+    result = ggml_cont(ctx, ggml_permute(ctx, result, 0, 1, 3, 2)); // [N, OC, OH, OW]
+
 
     return result;
 }


### PR DESCRIPTION
I think there is a bug in ```ggml_conv_2d``` which mixed up convolution results from different images when run in batch mode.
Specifically, this line
```
result = ggml_reshape_4d(ctx, result, im2col->ne[1], im2col->ne[2], a->ne[3], im2col->ne[3]); // [N, OC, OH, OW]
```
is supposed to reshape result to [N, OC, OH, OW]. However, values for a particular ```i``` of dimension N (batch size) are mixed from  
```j's```. 

This can be checked by making a stack of 2 input images each with identical but different values and observe the convolution mixed from both images.    

The proper way to do this step is
```
result = ggml_reshape_4d(ctx, result, im2col->ne[1], im2col->ne[2], im2col->ne[3], a->ne[3]); // [ OC, N, OH, OW]    
result = ggml_cont(ctx, ggml_permute(ctx, result, 0, 1, 3, 2)); // [N, OC, OH, OW]
```