### PR TITLE
Modify ggml_backend_is_cpu to use ggml_backend_i::get_name callback

### DIFF
--- a/src/ggml-backend.c
+++ b/src/ggml-backend.c
@@ -807,7 +807,7 @@ ggml_backend_t ggml_backend_cpu_init(void) {
 }
 
 GGML_CALL bool ggml_backend_is_cpu(ggml_backend_t backend) {
-    if (!backend) {
+    if (!backend || !backend->iface.get_name) {
         return false;
     }
 

--- a/src/ggml-backend.c
+++ b/src/ggml-backend.c
@@ -807,7 +807,12 @@ ggml_backend_t ggml_backend_cpu_init(void) {
 }
 
 GGML_CALL bool ggml_backend_is_cpu(ggml_backend_t backend) {
-    return backend && backend->iface.get_name == ggml_backend_cpu_name;
+    if (!backend) {
+        return false;
+    }
+
+    char * backend_name = backend->iface.get_name(backend);
+    return strcmp(backend_name, "CPU") == 0;
 }
 
 void ggml_backend_cpu_set_n_threads(ggml_backend_t backend_cpu, int n_threads) {


### PR DESCRIPTION
This function was not actually calling the callback.

Instead, it was comparing the callback function to the static CPU name function. This does not work for sharing backends between modules in multi module programs.