### PR TITLE
mnist: fix the emcc command to compile correctly

### DIFF
--- a/examples/mnist/README.md
+++ b/examples/mnist/README.md
@@ -127,7 +127,7 @@ The example can be compiled with Emscripten like this:
 
 ```bash
 cd examples/mnist
-emcc -I../../include -I../../include/ggml -I../../examples ../../src/ggml.c main.cpp -o web/mnist.js -s EXPORTED_FUNCTIONS='["_wasm_eval","_wasm_random_digit","_malloc","_free"]' -s EXPORTED_RUNTIME_METHODS='["ccall"]' -s ALLOW_MEMORY_GROWTH=1 --preload-file models/mnist
+emcc -I../../include -I../../include/ggml -I../../examples ../../src/ggml.c ../../src/ggml-quants.c main.cpp -o web/mnist.js -s EXPORTED_FUNCTIONS='["_wasm_eval","_wasm_random_digit","_malloc","_free"]' -s EXPORTED_RUNTIME_METHODS='["ccall"]' -s ALLOW_MEMORY_GROWTH=1 --preload-file models/mnist
 ```
 
 Online demo: https://mnist.ggerganov.com


### PR DESCRIPTION
Otherwise we get linking errors:
```
wasm-ld: error: /var/folders/8w/5mqfkhqn1nj0tw97g3hl1nyh0000gn/T/emscripten_temp_hj657tq4/ggml_0.o: undefined symbol: dequantize_row_q4_0 
wasm-ld: error: /var/folders/8w/5mqfkhqn1nj0tw97g3hl1nyh0000gn/T/emscripten_temp_hj657tq4/ggml_0.o: undefined symbol: quantize_row_q4_0 ...
```