### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.3)
+cmake_minimum_required (VERSION 3.12)
 project(ggml VERSION 0.1.0)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS "on")


### PR DESCRIPTION
This CMakeLists.txt file uses Cmake command `add_compile_definitions()`.

That command did not exist until CMake 3.12.

Reference documentation:
https://cmake.org/cmake/help/latest/command/add_compile_definitions.html

I see a failure in CMake 3.10 with existing CMakeLists.txt