### PR TITLE
Fix examples/simple/simple-ctx

### DIFF
--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -2,6 +2,19 @@
 
 This example simply performs a matrix multiplication, solely for the purpose of demonstrating a basic usage of ggml and backend handling. The code is commented to help understand what each part does.
 
+Normally in matrix multiplication...
+
+$$
+A * B = C
+$$
+
+In `ggml` the weight matrix is already transposed.
+
+So your inputs are: $$A \text{ and } B^T$$  
+And the output is: $$C^T$$
+
+Let's look at a traditional matrix multiplication:
+
 $$
 \begin{bmatrix}
 2 & 8 \\
@@ -16,9 +29,21 @@ $$
 \end{bmatrix}
 \=
 \begin{bmatrix}
-60 & 110 & 54 & 29 \\
-55 & 90 & 126 & 28 \\
-50 & 54 & 42 & 64 \\
+60 & 90 & 42 \\
+55 & 54 & 29 \\
+50 &  54 & 28 \\
+110 & 126 & 64 \\
+\end{bmatrix}
+$$
+
+In `ggml` the second matrix above will be stored transposed in memory, and the output will also be transposed in memory.  
+So `ggml` will yield:
+
+$$
+\begin{bmatrix}
+60 & 55 & 50 & 110 \\
+90 & 54 & 54 & 126 \\
+42 & 29 & 28 & 64 \\
 \end{bmatrix}
 $$
 

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -2,18 +2,11 @@
 
 This example simply performs a matrix multiplication, solely for the purpose of demonstrating a basic usage of ggml and backend handling. The code is commented to help understand what each part does.
 
-Normally in matrix multiplication...
+Traditional matrix multiplication goes like this (multiply row-by-column):
 
 $$
-A * B = C
+A \times B = C
 $$
-
-In `ggml` the weight matrix is already transposed.
-
-So your inputs are: $$A \text{ and } B^T$$  
-And the output is: $$C^T$$
-
-Let's look at a traditional matrix multiplication:
 
 $$
 \begin{bmatrix}
@@ -36,10 +29,28 @@ $$
 \end{bmatrix}
 $$
 
-In `ggml` the second matrix above will be stored transposed in memory, and the output will also be transposed in memory.  
-So `ggml` will yield:
+In `ggml`, we pass the matrix $B$ in transposed form and multiply row-by-row. The result $C$ is also transposed:
 
 $$
+ggml\\_mul\\_mat(A, B^T) = C^T
+$$
+
+$$
+ggml\\_mul\\_mat(
+\begin{bmatrix}
+2 & 8 \\
+5 & 1 \\
+4 & 2 \\
+8 & 6 \\
+\end{bmatrix}
+,
+\begin{bmatrix}
+10 & 5 \\
+9 & 9 \\
+5 & 4 \\
+\end{bmatrix}
+)
+\=
 \begin{bmatrix}
 60 & 55 & 50 & 110 \\
 90 & 54 & 54 & 126 \\

--- a/examples/simple/simple-ctx.cpp
+++ b/examples/simple/simple-ctx.cpp
@@ -104,9 +104,9 @@ int main(void) {
     memcpy(out_data.data(), result->data, ggml_nbytes(result));
 
     // expected result:
-    // [ 60.00 110.00 54.00 29.00
-    //  55.00 90.00 126.00 28.00
-    //  50.00 54.00 42.00 64.00 ]
+    // [ 60.00 55.00 50.00 110.00
+    //   90.00 54.00 54.00 126.00
+    //   42.00 29.00 28.00 64.00 ]
 
     printf("mul mat (%d x %d) (transposed result):\n[", (int) result->ne[0], (int) result->ne[1]);
     for (int j = 0; j < result->ne[1] /* rows */; j++) {
@@ -115,7 +115,7 @@ int main(void) {
         }
 
         for (int i = 0; i < result->ne[0] /* cols */; i++) {
-            printf(" %.2f", out_data[i * result->ne[1] + j]);
+            printf(" %.2f", out_data[j * result->ne[0] + i]);
         }
     }
     printf(" ]\n");


### PR DESCRIPTION
There was an error in how the result tensor was being accessed.

This error led to the example creator defining incorrect expected result.

Please double check my assumption that the output of ggml_mul_mat is the transposed result of A*B.