### PR TITLE
ggml: add type_size to data view offset calc

### DIFF
--- a/src/ggml.c
+++ b/src/ggml.c
@@ -2942,7 +2942,8 @@ static struct ggml_tensor * ggml_new_tensor_impl(
 
     void * data = view_src != NULL ? view_src->data : NULL;
     if (data != NULL) {
-        data = (char *) data + view_offs;
+        size_t type_size = ggml_type_size(type);
+        data = (char *) data + (view_offs * type_size);
     }
 
     size_t obj_alloc_size = 0;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -432,3 +432,11 @@ add_executable(${TEST_TARGET} ${TEST_TARGET}.cpp)
 target_link_libraries(${TEST_TARGET} PRIVATE ggml)
 add_test(NAME ${TEST_TARGET} COMMAND $<TARGET_FILE:${TEST_TARGET}>)
 set_property(TEST ${TEST_TARGET} PROPERTY ENVIRONMENT "LLVM_PROFILE_FILE=${TEST_TARGET}.profraw")
+
+#
+# test-view
+
+set(TEST_TARGET test-view)
+add_executable(${TEST_TARGET} ${TEST_TARGET}.c)
+target_link_libraries(${TEST_TARGET} PRIVATE ggml)
+add_test(NAME ${TEST_TARGET} COMMAND $<TARGET_FILE:${TEST_TARGET}>)

--- a/tests/test-view.c
+++ b/tests/test-view.c
@@ -1,0 +1,37 @@
+#include "ggml/ggml.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, const char ** argv) {
+    struct ggml_init_params params = {
+      .mem_size   = 16*1024*1024,
+      .mem_buffer = NULL,
+      .no_alloc   = false,
+    };
+    struct ggml_context* ctx = ggml_init(params);
+
+    int len = 10;
+    struct ggml_tensor* x = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, len);
+    for (int i = 0; i < len; i++) {
+        ggml_set_f32_1d(x, i, i);
+    }
+
+    struct ggml_tensor* view = ggml_view_1d(ctx, x, 5, 0);
+    GGML_ASSERT(ggml_get_f32_1d(view, 0) == 0);
+    GGML_ASSERT(ggml_get_f32_1d(view, 1) == 1);
+    GGML_ASSERT(ggml_get_f32_1d(view, 2) == 2);
+    GGML_ASSERT(ggml_get_f32_1d(view, 3) == 3);
+    GGML_ASSERT(ggml_get_f32_1d(view, 4) == 4);
+
+    view = ggml_view_1d(ctx, x, 5, 5);
+    GGML_ASSERT(ggml_get_f32_1d(view, 0) == 5);
+    GGML_ASSERT(ggml_get_f32_1d(view, 1) == 6);
+    GGML_ASSERT(ggml_get_f32_1d(view, 2) == 7);
+    GGML_ASSERT(ggml_get_f32_1d(view, 3) == 8);
+    GGML_ASSERT(ggml_get_f32_1d(view, 4) == 9);
+
+    ggml_free(ctx);
+
+    return 0;
+}


### PR DESCRIPTION
This commit suggests adding the type_size to the calculation of the offset when creating a view of a tensor.

The motivation for this change is that when I tried calling `ggml_view_1d` using an offset like this:
```c
    struct ggml_tensor * view = ggml_view_1d(ctx, x, 5, 0);
```
Where the `x` tensor has 10 elments with values ranging from 0 to 9, and requesting a view with 5 elements, starting at offset zero this works as expected.

But if I try using an offset of 5, with the expectation (which may be incorrect) that this would produce a view with the last 5 elements of the tensor `x`:
```c
    struct ggml_tensor * view = ggml_view_1d(ctx, x, 5, 5);
```
This does not work as I had expected. This commit contains a test with the above use case, which hopefully clarifies that I'm trying to do and perhaps someone can point out what I'm doing wrong, or confirm that this may be an issue with the current implementation.