### PR TITLE
feat : add `col2im` kernels

### DIFF
--- a/include/ggml/ggml.h
+++ b/include/ggml/ggml.h
@@ -464,6 +464,7 @@ extern "C" {
         GGML_OP_CLAMP,
         GGML_OP_CONV_TRANSPOSE_1D,
         GGML_OP_IM2COL,
+        GGML_OP_COL2IM,
         GGML_OP_CONV_TRANSPOSE_2D,
         GGML_OP_POOL_1D,
         GGML_OP_POOL_2D,
@@ -1548,6 +1549,19 @@ extern "C" {
             float                 max);
 
     GGML_API struct ggml_tensor * ggml_im2col(
+            struct ggml_context * ctx,
+            struct ggml_tensor  * a,
+            struct ggml_tensor  * b,
+            int                  s0,
+            int                  s1,
+            int                  p0,
+            int                  p1,
+            int                  d0,
+            int                  d1,
+            bool                 is_2D,
+            enum ggml_type       dst_type);
+
+    GGML_API struct ggml_tensor * ggml_col2im(
             struct ggml_context * ctx,
             struct ggml_tensor  * a,
             struct ggml_tensor  * b,

--- a/src/ggml-metal.m
+++ b/src/ggml-metal.m
@@ -166,6 +166,8 @@ enum ggml_metal_kernel_type {
     GGML_METAL_KERNEL_TYPE_ALIBI_F32,
     GGML_METAL_KERNEL_TYPE_IM2COL_F16,
     GGML_METAL_KERNEL_TYPE_IM2COL_F32,
+    GGML_METAL_KERNEL_TYPE_COL2IM_F16,
+    GGML_METAL_KERNEL_TYPE_COL2IM_F32,
     GGML_METAL_KERNEL_TYPE_UPSCALE_F32,
     GGML_METAL_KERNEL_TYPE_PAD_F32,
     GGML_METAL_KERNEL_TYPE_ARANGE_F32,
@@ -597,6 +599,8 @@ static struct ggml_metal_context * ggml_metal_init(int n_cb) {
         GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_ALIBI_F32,                 alibi_f32,              true);
         GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_IM2COL_F16,                im2col_f16,             true);
         GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_IM2COL_F32,                im2col_f32,             true);
+        GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_COL2IM_F16,                col2im_f16,  true);
+        GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_COL2IM_F32,                col2im_f32,  true);
         GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_UPSCALE_F32,               upscale_f32,            true);
         GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_PAD_F32,                   pad_f32,                true);
         GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_TIMESTEP_EMBEDDING_F32,    timestep_embedding_f32, true);
@@ -724,6 +728,7 @@ static bool ggml_metal_supports_op(const struct ggml_metal_context * ctx, const 
         case GGML_OP_ALIBI:
         case GGML_OP_ROPE:
         case GGML_OP_IM2COL:
+        case GGML_OP_COL2IM:
             return true;
         case GGML_OP_POOL_1D:
         case GGML_OP_POOL_2D:

--- a/src/ggml-metal.m
+++ b/src/ggml-metal.m
@@ -599,8 +599,8 @@ static struct ggml_metal_context * ggml_metal_init(int n_cb) {
         GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_ALIBI_F32,                 alibi_f32,              true);
         GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_IM2COL_F16,                im2col_f16,             true);
         GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_IM2COL_F32,                im2col_f32,             true);
-        GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_COL2IM_F16,                col2im_f16,  true);
-        GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_COL2IM_F32,                col2im_f32,  true);
+        GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_COL2IM_F16,                col2im_f16,             true);
+        GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_COL2IM_F32,                col2im_f32,             true);
         GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_UPSCALE_F32,               upscale_f32,            true);
         GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_PAD_F32,                   pad_f32,                true);
         GGML_METAL_ADD_KERNEL(GGML_METAL_KERNEL_TYPE_TIMESTEP_EMBEDDING_F32,    timestep_embedding_f32, true);

--- a/src/ggml.c
+++ b/src/ggml.c
@@ -13628,7 +13628,7 @@ static void ggml_compute_forward_col2im_f32(
     const int nth = params->nth;
 
     const int64_t N  = is_2D ? ne13 : ne12;
-    const int64_t IC = is_2D ? ne03 : ne02;
+    const int64_t C  = is_2D ? ne03 : ne02;
     const int64_t IH = is_2D ? ne12 : 1;
     const int64_t IW = ne11;
 
@@ -13649,19 +13649,19 @@ static void ggml_compute_forward_col2im_f32(
         return;
     }
 
-    // col2im: [N, IH, IW, IC*KH*KW] => [N, IC, OH, OW]
+    // col2im: [N, IH, IW, C*KH*KW] => [N, C, OH, OW]
     {
         float * const wdata = (float *) dst->data;
 
-        memset(wdata, 0, sizeof(float) * N * IC * OH * OW);
+        memset(wdata, 0, sizeof(float) * N * C * OH * OW);
 
         for (int64_t in = 0; in < N; in++) {
             for (int64_t iih = 0; iih < IH; iih++) {  // 1
                 for (int64_t iiw = 0; iiw < IW; iiw++) {
-                    for (int64_t iic = ith; iic < IC; iic += nth) {
+                    for (int64_t iic = ith; iic < C; iic += nth) {
 
-                        const float * src_data = (float *)((char *) src1->data + (in*IH*IW + iih*IW + iiw) * (IC*KH*KW));  // [IC*KH*KW]
-                        float * dst_data = wdata + (in*IC*OH + iic*OH) * OW;  // [OH, OW]
+                        const float * src_data = (float *)((char *) src1->data + (in*IH*IW + iih*IW + iiw) * (C*KH*KW));  // [C*KH*KW]
+                        float * dst_data = wdata + (in*C*OH + iic*OH) * OW;  // [OH, OW]
 
                         for (int64_t ikh = 0; ikh < KH; ikh++) {  // 1
                             for (int64_t ikw = 0; ikw < KW; ikw++) {

--- a/src/ggml.c
+++ b/src/ggml.c
@@ -13642,7 +13642,7 @@ static void ggml_compute_forward_col2im_f32(
     const int64_t OH = is_2D ? ne1 : 1;
     const int64_t OW = ne0;
 
-    GGML_ASSERT(nb00 == sizeof(float));
+    GGML_ASSERT(nb00 == sizeof(ggml_fp16_t));
     GGML_ASSERT(nb10 == sizeof(float));
 
     if (params->type == GGML_TASK_TYPE_INIT) {

--- a/src/ggml.c
+++ b/src/ggml.c
@@ -2034,7 +2034,7 @@ static const char * GGML_OP_NAME[GGML_OP_COUNT] = {
     "CROSS_ENTROPY_LOSS_BACK",
 };
 
-static_assert(GGML_OP_COUNT == 76, "GGML_OP_COUNT != 76");
+static_assert(GGML_OP_COUNT == 77, "GGML_OP_COUNT != 77");
 
 static const char * GGML_OP_SYMBOL[GGML_OP_COUNT] = {
     "none",
@@ -2125,7 +2125,7 @@ static const char * GGML_OP_SYMBOL[GGML_OP_COUNT] = {
     "cross_entropy_loss_back(x,y)",
 };
 
-static_assert(GGML_OP_COUNT == 76, "GGML_OP_COUNT != 76");
+static_assert(GGML_OP_COUNT == 77, "GGML_OP_COUNT != 77");
 
 static_assert(GGML_OP_POOL_COUNT == 2, "GGML_OP_POOL_COUNT != 2");
 
@@ -5762,7 +5762,7 @@ struct ggml_tensor* ggml_conv_1d_ph(
 
 // ggml_conv_transpose_1d
 
-static int64_t ggml_calc_conv_transpose_1d_output_size(int64_t ins, int64_t ks, int s, int p, int d) {
+static int64_t ggml_calc_conv_transpose_output_size(int64_t ins, int64_t ks, int s, int p, int d) {
     return (ins - 1) * s - 2 * p + d * (ks - 1) + 1;
 }
 
@@ -5788,7 +5788,7 @@ GGML_API struct ggml_tensor * ggml_conv_transpose_1d(
     }
 
     const int64_t ne[4] = {
-        ggml_calc_conv_transpose_1d_output_size(b->ne[0], a->ne[0], s0, 0 /*p0*/, 1 /*d0*/),
+        ggml_calc_conv_transpose_output_size(b->ne[0], a->ne[0], s0, 0 /*p0*/, 1 /*d0*/),
         a->ne[1], b->ne[2], 1,
     };
     struct ggml_tensor * result = ggml_new_tensor(ctx, GGML_TYPE_F32, 4, ne);
@@ -5908,8 +5908,8 @@ struct ggml_tensor * ggml_col2im(
         is_node = true;
     }
 
-    const int64_t OH = is_2D ? ggml_calc_conv_transpose_output_size(b->ne[2], a->ne[1], s1, p1) : 0;
-    const int64_t OW =         ggml_calc_conv_transpose_output_size(b->ne[1], a->ne[0], s0, p0);
+    const int64_t OH = is_2D ? ggml_calc_conv_transpose_output_size(b->ne[2], a->ne[1], s1, p1, 1 /*d0*/) : 0;
+    const int64_t OW =         ggml_calc_conv_transpose_output_size(b->ne[1], a->ne[0], s0, p0, 1 /*d1*/);
 
     const int64_t ne[4] = {
         OW,
@@ -5976,10 +5976,6 @@ struct ggml_tensor * ggml_conv_2d_s1_ph(
 
 // ggml_conv_transpose_2d_p0
 
-static int64_t ggml_calc_conv_transpose_output_size(int64_t ins, int64_t ks, int s, int p) {
-    return (ins - 1) * s - 2 * p + ks;
-}
-
 struct ggml_tensor * ggml_conv_transpose_2d_p0(
         struct ggml_context * ctx,
         struct ggml_tensor  * a,
@@ -5995,8 +5991,8 @@ struct ggml_tensor * ggml_conv_transpose_2d_p0(
     }
 
     const int64_t ne[4] = {
-        ggml_calc_conv_transpose_output_size(b->ne[0], a->ne[0], stride, 0 /*p0*/),
-        ggml_calc_conv_transpose_output_size(b->ne[1], a->ne[1], stride, 0 /*p1*/),
+        ggml_calc_conv_transpose_output_size(b->ne[0], a->ne[0], stride, 0 /*p0*/, 1 /*d1*/),
+        ggml_calc_conv_transpose_output_size(b->ne[1], a->ne[1], stride, 0 /*p1*/, 1 /*d1*/),
         a->ne[2], b->ne[3],
     };
 


### PR DESCRIPTION
This PR implements the `col2im` kernel to support `ggml_conv_transpose_1d` on Metal. It proceeds as follows:
- [x] Write a C kernel for `col2im`
- [ ] Write a Metal kernel for `col2im`
- [ ] Remove the old implementation of `ggml_conv_transpose_1d`
- [ ] Implement the one using `ggml_col2im`