### PR TITLE
gguf : use Qn_K for k-quants instead of KQn

### DIFF
--- a/docs/gguf.md
+++ b/docs/gguf.md
@@ -48,12 +48,12 @@ To correctly parse a well formed naming convention based gguf filename, it is re
 
 For example:
 
-  * `Mixtral-v0.1-8x7B-KQ2.gguf`:
+  * `Mixtral-v0.1-8x7B-Q2_K.gguf`:
     - Model Name: Mixtral
     - Version Number: v0.1
     - Expert Count: 8
     - Parameter Count: 7B
-    - Weight Encoding Scheme: KQ2
+    - Weight Encoding Scheme: Q2_K
     - Shard: N/A
 
   * `Hermes-2-Pro-Llama-3-8B-F16.gguf`:
@@ -89,7 +89,7 @@ function parseGGUFFilename(filename) {
 }
 
 const testCases = [
-  {filename: 'Mixtral-v0.1-8x7B-KQ2.gguf',              expected: { modelName: 'Mixtral',              version: 'v0.1',   expertsCount: 8,    parameters: '7B',   encodingScheme: 'KQ2',  shard: null,    shardTotal: null }},
+  {filename: 'Mixtral-v0.1-8x7B-Q2_K.gguf',              expected: { modelName: 'Mixtral',              version: 'v0.1',   expertsCount: 8,    parameters: '7B',   encodingScheme: 'Q2_K',  shard: null,    shardTotal: null }},
   {filename: 'Grok-v1.0-100B-Q4_0-00003-of-00009.gguf', expected: { modelName: 'Grok',                 version: 'v1.0',   expertsCount: null, parameters: '100B', encodingScheme: 'Q4_0', shard: 3,       shardTotal: 9    }},
   {filename: 'Hermes-2-Pro-Llama-3-8B-F16.gguf',        expected: { modelName: 'Hermes 2 Pro Llama 3', version: 'v0.0',   expertsCount: null, parameters: '8B',   encodingScheme: 'F16',  shard: null,    shardTotal: null }},
   {filename: 'Hermes-2-Pro-Llama-3-v32.33-8Q-F16.gguf', expected: { modelName: 'Hermes 2 Pro Llama 3', version: 'v32.33', expertsCount: null, parameters: '8Q',   encodingScheme: 'F16',  shard: null,    shardTotal: null }},


### PR DESCRIPTION
#822 (by @mofosyne) has introduced a naming convention for GGUF model files, but the way it names k-quants doesn't follow the established practice (all other places where k-quants are named use `Qn_K` where `n` is the number of bits per weight excluding the scales).

`rg -i 'KQ\d'` doesn't return anything related to quants except for this recently-added section, while
`rg -i 'Q\d_K'` returns a lot of things related to k-quants when run in `ggml` and `llama.cpp` repos

So this renames `KQ2` to `Q2_K`, for consistency. This should avoid unnecessary confusion.

(note that the recently-added [wiki page about "tensor encoding schemes"](https://github.com/ggerganov/llama.cpp/wiki/Tensor-Encoding-Schemes) will need to be updated too, since it is the only other place I found to also use this `KQ<X>` naming scheme)