### PR TITLE
Fix compiler warning: this use of defined may not be portable

### DIFF
--- a/src/ggml-cuda/common.cuh
+++ b/src/ggml-cuda/common.cuh
@@ -317,9 +317,17 @@ static __device__ __forceinline__ int __dp4a(const int a, const int b, int c) {
 }
 #endif // defined(GGML_USE_HIPBLAS)
 
-#define FP16_AVAILABLE (defined(GGML_USE_HIPBLAS) && defined(__HIP_PLATFORM_AMD__)) || __CUDA_ARCH__ >= CC_PASCAL
+#if (defined(GGML_USE_HIPBLAS) && defined(__HIP_PLATFORM_AMD__)) || __CUDA_ARCH__ >= CC_PASCAL
+#define FP16_AVAILABLE 1
+#else
+#define FP16_AVAILABLE 0
+#endif
 
-#define FP16_MMA_AVAILABLE !(defined(GGML_USE_HIPBLAS) && defined(__HIP_PLATFORM_AMD__)) && __CUDA_ARCH__ >= CC_VOLTA
+#if !(defined(GGML_USE_HIPBLAS) && defined(__HIP_PLATFORM_AMD__)) && __CUDA_ARCH__ >= CC_VOLTA
+#define FP16_MMA_AVAILABLE 1
+#else
+#define FP16_MMA_AVAILABLE 0
+#endif
 
 static bool fast_fp16_available(const int cc) {
     return cc >= CC_PASCAL && cc != 610;


### PR DESCRIPTION
I compile GGML library with `-Wpedantic` flag and get this warning (https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wexpansion-to-defined):
```
warning: this use of "defined" may not be portable [-Wexpansion-to-defined]
  373 | #if FP16_AVAILABLE
      |     ^~~~~~~~~~~~~~
```

Fixed in this PR.