### PR TITLE
sycl : add build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,18 @@ cmake -DGGML_CUBLAS=ON -DCMAKE_CUDA_COMPILER=/usr/local/cuda-12.1/bin/nvcc ..
 cmake -DCMAKE_C_COMPILER="$(hipconfig -l)/clang" -DCMAKE_CXX_COMPILER="$(hipconfig -l)/clang++" -DGGML_HIPBLAS=ON
 ```
 
+## Using SYCL
+
+```bash
+# linux
+source /opt/intel/oneapi/setvars.sh
+cmake -G "Ninja" -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx -DGGML_SYCL=ON ..
+
+# windows
+"C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
+cmake -G "Ninja" -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=icx -DGGML_SYCL=ON ..
+```
+
 ## Compiling for Android
 
 Download and unzip the NDK from this download [page](https://developer.android.com/ndk/downloads). Set the NDK_ROOT_PATH environment variable or provide the absolute path to the CMAKE_ANDROID_NDK in the command below.


### PR DESCRIPTION
Tested with oneAPI 2024.2, building is okay on windows.

## Compiler Version

```
icx --version                 
Intel(R) oneAPI DPC++/C++ Compiler for applications running on Intel(R) 64, Version 2024.2.0 Build 20240602
Copyright (C) 1985-2024 Intel Corporation. All rights reserved.

Intel(R) oneAPI DPC++/C++ Compiler 2024.2.0 (2024.2.0.20240602)
Target: x86_64-pc-windows-msvc
Thread model: posix
InstalledDir: C:\Program Files (x86)\Intel\oneAPI\compiler\2024.2\bin\compiler
Configuration file: C:\Program Files (x86)\Intel\oneAPI\compiler\2024.2\bin\compiler\..\icx.cfg
```

## Devices

```
# I've installed multiple oneAPI variants -- some devices were duplicated...
sycl-ls
[opencl:cpu][opencl:0] Intel(R) OpenCL, 13th Gen Intel(R) Core(TM) i9-13900 OpenCL 3.0 (Build 0) [2024.18.6.0.02_160000]
[opencl:gpu][opencl:1] Intel(R) OpenCL Graphics, Intel(R) Arc(TM) A770 Graphics OpenCL 3.0 NEO  [31.0.101.5522]
[opencl:gpu][opencl:2] Intel(R) OpenCL Graphics, Intel(R) Arc(TM) A750 Graphics OpenCL 3.0 NEO  [31.0.101.5522]
[opencl:cpu][opencl:3] Intel(R) OpenCL, 13th Gen Intel(R) Core(TM) i9-13900 OpenCL 3.0 (Build 0) [2023.16.12.0.12_195853.xmain-hotfix]
[opencl:fpga][opencl:4] Intel(R) FPGA Emulation Platform for OpenCL(TM), Intel(R) FPGA Emulation Device OpenCL 1.2  [2023.16.12.0.12_195853.xmain-hotfix]
[opencl:cpu][opencl:5] Intel(R) OpenCL, 13th Gen Intel(R) Core(TM) i9-13900 OpenCL 3.0 (Build 0) [2024.17.3.0.08_160000]
[opencl:fpga][opencl:6] Intel(R) FPGA Emulation Platform for OpenCL(TM), Intel(R) FPGA Emulation Device OpenCL 1.2  [2024.17.3.0.08_160000]
[level_zero:gpu][level_zero:0] Intel(R) Level-Zero, Intel(R) Arc(TM) A770 Graphics 1.3 [1.3.29283]
[level_zero:gpu][level_zero:1] Intel(R) Level-Zero, Intel(R) Arc(TM) A750 Graphics 1.3 [1.3.29283]
```

## Running test-backend-ops

### Using i9-13900 CPU as a SYCL device

```
set ONEAPI_DEVICE_SELECTOR=opencl:0
.\bin\test-backend-ops.exe
```

[sycl-cpu-test.txt](https://github.com/user-attachments/files/16033278/sycl-cpu-test.txt)


134 MUL_MAT failures and 1 assertion in ROPE (blocking remaining tests).

### Using Intel Arc A770 GPU as a SYCL device

```
set ONEAPI_DEVICE_SELECTOR=level_zero:0
.\bin\test-backend-ops.exe
```

[sycl-gpu-test.txt](https://github.com/user-attachments/files/16033279/sycl-gpu-test.txt)


223 failures (4 NORM, 4 RMS_NORM, 164 MUL_MAT, 51 SOFT_MAX) and 1 assertion in ROPE (blocking remaining tests).
