### PR TITLE
Fix bug: missiong pthread link.

### DIFF
--- a/src/ggml-cuda.cu
+++ b/src/ggml-cuda.cu
@@ -2390,6 +2390,7 @@ GGML_CALL static void ggml_backend_cuda_synchronize(ggml_backend_t backend) {
     GGML_UNUSED(backend);
 }
 
+#ifdef USE_CUDA_GRAPH
 static void set_ggml_graph_node_properties(ggml_tensor * node, ggml_graph_node_properties * graph_node_properties) {
     graph_node_properties->node_address = node->data;
     graph_node_properties->node_op = node->op;
@@ -2401,7 +2402,9 @@ static void set_ggml_graph_node_properties(ggml_tensor * node, ggml_graph_node_p
         graph_node_properties->src_address[i] = node->src[i] ? node->src[i]->data : nullptr;
     }
 }
+#endif
 
+#ifdef USE_CUDA_GRAPH
 static bool ggml_graph_node_has_matching_properties(ggml_tensor * node, ggml_graph_node_properties * graph_node_properties) {
     if (node->data != graph_node_properties->node_address &&
           node->op != GGML_OP_CPY &&
@@ -2433,6 +2436,7 @@ static bool ggml_graph_node_has_matching_properties(ggml_tensor * node, ggml_gra
     }
     return true;
 }
+#endif
 
 GGML_CALL static enum ggml_status ggml_backend_cuda_graph_compute(ggml_backend_t backend, ggml_cgraph * cgraph) {
     ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *)backend->context;
@@ -3007,6 +3011,8 @@ GGML_CALL bool ggml_backend_cuda_register_host_buffer(void * buffer, size_t size
     }
     return true;
 #else
+    GGML_UNUSED(buffer);
+    GGML_UNUSED(size);
     return false;
 #endif
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -426,6 +426,6 @@ set_property(TEST ${TEST_TARGET} PROPERTY ENVIRONMENT "LLVM_PROFILE_FILE=${TEST_
 
 set(TEST_TARGET test-backend-ops)
 add_executable(${TEST_TARGET} ${TEST_TARGET}.cpp)
-target_link_libraries(${TEST_TARGET} PRIVATE ggml)
+target_link_libraries(${TEST_TARGET} PRIVATE ggml pthread)
 add_test(NAME ${TEST_TARGET} COMMAND $<TARGET_FILE:${TEST_TARGET}>)
 set_property(TEST ${TEST_TARGET} PROPERTY ENVIRONMENT "LLVM_PROFILE_FILE=${TEST_TARGET}.profraw")

--- a/tests/test-conv2d.cpp
+++ b/tests/test-conv2d.cpp
@@ -21,12 +21,14 @@
 #include <string>
 #include <vector>
 
+#ifdef GGML_USE_METAL
 static void ggml_log_callback_default(ggml_log_level level, const char * text, void * user_data) {
     (void) level;
     (void) user_data;
     fputs(text, stderr);
     fflush(stderr);
 }
+#endif
 
 struct test_model {
     struct ggml_tensor * a;


### PR DESCRIPTION
Test steps
1) mkdir build
2) cd build
3) cmake -DGGML_CUDA=ON -DBUILD_SHARED_LIBS_DEFAULT=OFF -DCMAKE_CUDA_COMPILER=/usr/local/cuda-11.7/bin/nvcc ..
4) make -j 12
/usr/bin/ld: CMakeFiles/test-backend-ops.dir/test-backend-ops.cpp.o: undefined reference to symbol 'pthread_create@@GLIBC_2.2.5'
/usr/bin/ld: /lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
