### PR TITLE
ggml : remove unnecessary UNUSED macro call

### DIFF
--- a/src/ggml.c
+++ b/src/ggml.c
@@ -17955,7 +17955,6 @@ static void ggml_build_forward_impl(struct ggml_cgraph * cgraph, struct ggml_ten
     }
 
     const int n0 = cgraph->n_nodes;
-    UNUSED(n0);
 
     ggml_visit_parents(cgraph, tensor);
 


### PR DESCRIPTION
This commit removes an UNUSED macro call that is not needed as the variable n0 is used in the code and will not produce a warning.