### PR TITLE
Vulkan: Initialize vk_buffer_struct handle members to VK_NULL_HANDLE

### DIFF
--- a/src/ggml-vulkan.cpp
+++ b/src/ggml-vulkan.cpp
@@ -238,8 +238,8 @@ struct vk_device_struct {
 };
 
 struct vk_buffer_struct {
-    vk::Buffer buffer;
-    vk::DeviceMemory device_memory;
+    vk::Buffer buffer = VK_NULL_HANDLE;
+    vk::DeviceMemory device_memory = VK_NULL_HANDLE;
     vk::MemoryPropertyFlags memory_property_flags;
     void * ptr;
     size_t size = 0;


### PR DESCRIPTION
This prevents invalid frees when destroying a partially initialized vk_buffer_struct. For example, this could happen in `ggml_vk_create_buffer` when running out of device memory.