### PR TITLE
add t5 layer norm support

### DIFF
--- a/include/ggml.h
+++ b/include/ggml.h
@@ -1117,6 +1117,18 @@ extern "C" {
             struct ggml_tensor  * a);
 
     // normalize along rows
+    GGML_API struct ggml_tensor * ggml_norm_ext(
+            struct ggml_context * ctx,
+            struct ggml_tensor  * a,
+            float                 eps,
+            bool                  sub_mean);
+    
+    GGML_API struct ggml_tensor * ggml_norm_ext_inplace(
+            struct ggml_context * ctx,
+            struct ggml_tensor  * a,
+            float                 eps,
+            bool                  sub_mean);
+
     GGML_API struct ggml_tensor * ggml_norm(
             struct ggml_context * ctx,
             struct ggml_tensor  * a,

--- a/src/ggml-kompute.cpp
+++ b/src/ggml-kompute.cpp
@@ -835,8 +835,9 @@ static void ggml_vk_norm_(
     const std::shared_ptr<kp::Tensor>& out,
     uint32_t inOff, uint32_t outOff,
     int32_t ne00, int32_t nb01,
-    int32_t nrows, float epsilon
+    int32_t nrows, float epsilon, bool sub_mean
 ) {
+    // TODO: handle sub_mean
     GGML_ASSERT(nb01%sizeof(float) == 0);
     GGML_ASSERT(ne00%sizeof(float) == 0);
 
@@ -1592,8 +1593,10 @@ static void ggml_vk_graph_compute(struct ggml_kompute_context * ctx, struct ggml
                 case GGML_OP_NORM:
                     {
                         float eps;
+                        bool sub_mean;
                         memcpy(&eps, dst->op_params, sizeof(float));
-                        ggml_vk_norm(seq, id_src0, id_dst, off_src0, off_dst, ne00, nb01, ggml_nrows(src0), eps);
+                        memcpy(&sub_mean, (char*)dst->op_params + sizeof(float), sizeof(bool));
+                        ggml_vk_norm(seq, id_src0, id_dst, off_src0, off_dst, ne00, nb01, ggml_nrows(src0), eps, sub_mean);
                     } break;
                 case GGML_OP_RMS_NORM:
                     {
@@ -1601,7 +1604,7 @@ static void ggml_vk_graph_compute(struct ggml_kompute_context * ctx, struct ggml
 
                         float eps;
                         memcpy(&eps, dst->op_params, sizeof(float));
-                        ggml_vk_rms_norm(seq, id_src0, id_dst, off_src0, off_dst, ne00, nb01, ggml_nrows(src0), eps);
+                        ggml_vk_rms_norm(seq, id_src0, id_dst, off_src0, off_dst, ne00, nb01, ggml_nrows(src0), eps, true);
                     } break;
                 case GGML_OP_MUL_MAT:
                     {

--- a/src/ggml-metal.m
+++ b/src/ggml-metal.m
@@ -2264,7 +2264,9 @@ static enum ggml_status ggml_metal_graph_compute(
                         GGML_ASSERT(ggml_is_contiguous_1(src0));
 
                         float eps;
+                        bool sub_mean;
                         memcpy(&eps, dst->op_params, sizeof(float));
+                        memcpy(&sub_mean, (char*)dst->op_params + sizeof(float), sizeof(bool));
 
                         const int nth = MIN(256, ne00);
 
@@ -2276,6 +2278,7 @@ static enum ggml_status ggml_metal_graph_compute(
                         [encoder setBytes:&ne00    length:sizeof( int64_t) atIndex:2];
                         [encoder setBytes:&nb01    length:sizeof(uint64_t) atIndex:3];
                         [encoder setBytes:&eps     length:sizeof(   float) atIndex:4];
+                        [encoder setBytes:&sub_mean length:sizeof(   bool) atIndex:5];
                         [encoder setThreadgroupMemoryLength:GGML_PAD(nth*sizeof(float), 16) atIndex:0];
 
                         const int64_t nrows = ggml_nrows(src0);

--- a/src/ggml-vulkan.cpp
+++ b/src/ggml-vulkan.cpp
@@ -4408,7 +4408,7 @@ static void ggml_vk_cpy(ggml_backend_vk_context * ctx, vk_context * subctx, cons
 
 static void ggml_vk_norm(ggml_backend_vk_context * ctx, vk_context * subctx, const ggml_tensor * src0, ggml_tensor * dst) {
     float * op_params = (float *)dst->op_params;
-
+    // TODO: handle sub_mean
     ggml_vk_op_f32<vk_op_push_constants>(ctx, subctx, src0, nullptr, nullptr, dst, GGML_OP_NORM, { (uint32_t)src0->ne[0], (uint32_t)src0->ne[1], op_params[0], 0.0f });
 }
 


### PR DESCRIPTION
The t5 layer norm does not subtract the mean during calculation, so I made a simple modification to ggml_norm to adapt it. This is a straightforward change and has already been validated in the sd.cpp project (since sd3 uses t5). However, due to limitations in my development environment, I have not been able to validate all the modifications. So far, I have only tested the changes for CUDA and CPU. Additionally, I am not very familiar with some environments, such as Kompute, so I have not developed corresponding support. I hope developers familiar with these environments can help improve it.

Ref: https://github.com/huggingface/transformers/blob/main/src/transformers/models/t5/modeling_t5.py#L230