### PR TITLE
Perf optimization for generic ggml_vec_dot_q5

### DIFF
--- a/src/ggml-quants.c
+++ b/src/ggml-quants.c
@@ -4832,15 +4832,25 @@ void ggml_vec_dot_q5_0_q8_0(int n, float * restrict s, size_t bs, const void * r
         int sumi0 = 0;
         int sumi1 = 0;
 
-        for (int j = 0; j < qk/2; ++j) {
-            const uint8_t xh_0 = ((qh & (1u << (j + 0 ))) >> (j + 0 )) << 4;
-            const uint8_t xh_1 = ((qh & (1u << (j + 16))) >> (j + 12));
+        if (qh) {
+            for (int j = 0; j < qk/2; ++j) {
+                const uint8_t xh_0 = ((qh & (1u << (j + 0 ))) >> (j + 0 )) << 4;
+                const uint8_t xh_1 = ((qh & (1u << (j + 16))) >> (j + 12));
 
-            const int32_t x0 = (int8_t)(((x[ib].qs[j] & 0x0F) | xh_0) - 16);
-            const int32_t x1 = (int8_t)(((x[ib].qs[j] >>   4) | xh_1) - 16);
+                const int32_t x0 = (int8_t)(((x[ib].qs[j] & 0x0F) | xh_0) - 16);
+                const int32_t x1 = (int8_t)(((x[ib].qs[j] >>   4) | xh_1) - 16);
 
-            sumi0 += (x0 * y[ib].qs[j]);
-            sumi1 += (x1 * y[ib].qs[j + qk/2]);
+                sumi0 += (x0 * y[ib].qs[j]);
+                sumi1 += (x1 * y[ib].qs[j + qk/2]);
+            }
+        } else {
+            for (int j = 0; j < qk/2; ++j) {
+                const int32_t x0 = (int8_t)((x[ib].qs[j] & 0x0F) - 16);
+                const int32_t x1 = (int8_t)((x[ib].qs[j] >>   4) - 16);
+
+                sumi0 += (x0 * y[ib].qs[j]);
+                sumi1 += (x1 * y[ib].qs[j + qk/2]);
+            }
         }
 
         int sumi = sumi0 + sumi1;
@@ -5206,15 +5216,25 @@ void ggml_vec_dot_q5_1_q8_1(int n, float * restrict s, size_t bs, const void * r
         int sumi0 = 0;
         int sumi1 = 0;
 
-        for (int j = 0; j < qk/2; ++j) {
-            const uint8_t xh_0 = ((qh >> (j +  0)) << 4) & 0x10;
-            const uint8_t xh_1 = ((qh >> (j + 12))     ) & 0x10;
+        if (qh) {
+            for (int j = 0; j < qk/2; ++j) {
+                const uint8_t xh_0 = ((qh >> (j +  0)) << 4) & 0x10;
+                const uint8_t xh_1 = ((qh >> (j + 12))     ) & 0x10;
 
-            const int32_t x0 = (x[ib].qs[j] & 0xF) | xh_0;
-            const int32_t x1 = (x[ib].qs[j] >>  4) | xh_1;
+                const int32_t x0 = (x[ib].qs[j] & 0xF) | xh_0;
+                const int32_t x1 = (x[ib].qs[j] >>  4) | xh_1;
 
-            sumi0 += (x0 * y[ib].qs[j]);
-            sumi1 += (x1 * y[ib].qs[j + qk/2]);
+                sumi0 += (x0 * y[ib].qs[j]);
+                sumi1 += (x1 * y[ib].qs[j + qk/2]);
+            }
+        } else {
+            for (int j = 0; j < qk/2; ++j) {
+                const int32_t x0 = (x[ib].qs[j] & 0xF);
+                const int32_t x1 = (x[ib].qs[j] >>  4);
+
+                sumi0 += (x0 * y[ib].qs[j]);
+                sumi1 += (x1 * y[ib].qs[j + qk/2]);
+            }
         }
 
         int sumi = sumi0 + sumi1;


### PR DESCRIPTION
More optimizations related to #898. That one showed {20%, 4%} for whisper and llama, and this one is an additional {10%, 2%} on top of that, as measured on an Ampere Altra. We discovered that we can reduce the amount of computations when `qh` is zero inside the loop. So the perf improvement depends on the model and the query, etc.

For those watching, the scalar path is important for benchmarking in SPEC CPUv8, as it allows a complete apples-to-apples comparison of any system, past or future. For example, SPEC CPU 2000 is still used for testing compilers and systems today, since the same code paths are used when running x86-64, aarch64, riscv, and power10, and NONE of those ISAs existed back in 2000. Similarly, when CPUv8 comes out it will live for a long time; and we want to establish the best baseline we can now. Regardless of whether ggml will be chosen from the list of benchmark candidates for CPUv8, this type of work can help the wider community. We hope that the optimizations we offer in the scalar path can provide hints to the folks crafting the ISA optimized paths, to make those even faster.
