### PR TITLE
`NULL` assert error in MNIST example for current version on Mac 

### DIFF
--- a/examples/mnist/mnist-common.cpp
+++ b/examples/mnist/mnist-common.cpp
@@ -74,8 +74,8 @@ mnist_eval_result mnist_graph_eval(const std::string & fname, const float * imag
     fprintf(stderr, "%s: trying to load a ggml graph from %s\n", __func__, fname.c_str());
     mnist_eval_result result;
 
-    struct ggml_context * ctx_data;
-    struct ggml_context * ctx_eval;
+    struct ggml_context * ctx_data = NULL;
+    struct ggml_context * ctx_eval = NULL;
 
     struct ggml_cgraph * gf;
     {

--- a/examples/mnist/mnist-common.cpp
+++ b/examples/mnist/mnist-common.cpp
@@ -74,8 +74,8 @@ mnist_eval_result mnist_graph_eval(const std::string & fname, const float * imag
     fprintf(stderr, "%s: trying to load a ggml graph from %s\n", __func__, fname.c_str());
     mnist_eval_result result;
 
-    struct ggml_context * ctx_data = NULL;
-    struct ggml_context * ctx_eval = NULL;
+    struct ggml_context * ctx_data = nullptr;
+    struct ggml_context * ctx_eval = nullptr;
 
     struct ggml_cgraph * gf;
     {


### PR DESCRIPTION
I met this error on Mac when running mnist example on Mac M2. The program failed on `ggml.c` check of line 19771 and 19772. Those two checks are:

```cpp
    assert(*ctx_data == NULL);
    assert(*ctx_eval == NULL);
```

These two pointers passed through the caller function in [examples/mnist/mnist-common.cpp](https://github.com/ggerganov/ggml/blob/879dcb84e5e3224ce9719067a4b29fe36f6d66e9/examples/mnist/mnist-common.cpp#L73), which are initialized as below:

```cpp
    struct ggml_context * ctx_data;
    struct ggml_context * ctx_eval;
```

The error is obvious. It seems that not all compiler will make uninitialized pointer to NULL. 

