### PR TITLE
ggml: remove bad assert

### DIFF
--- a/src/ggml.c
+++ b/src/ggml.c
@@ -3745,7 +3745,6 @@ static struct ggml_tensor * ggml_new_tensor_impl(
 
     size_t data_size = ggml_row_size(type, ne[0]);
     for (int i = 1; i < n_dims; i++) {
-        assert(ne[i] > 0);
         data_size *= ne[i];
     }
 


### PR DESCRIPTION
In https://github.com/ggerganov/ggml/pull/908 I added an assert that checks whether all dimensions of a new tensor are > 0. However, since the ggml API has functions like `ggml_is_empty` that check for zero-sized tensor dimensions this to me implies that it is actually intended for users to be able to create them (though they are an edge case that seems to not be properly handled by large parts of the code). This PR removes the assert again.