### PR TITLE
vulkan: fix compilation with GGML_VULKAN_DEBUG=ON

### DIFF
--- a/src/ggml-vulkan.cpp
+++ b/src/ggml-vulkan.cpp
@@ -2480,7 +2480,7 @@ static void ggml_vk_dispatch_pipeline(ggml_backend_vk_context* ctx, vk_context& 
     const uint32_t wg2 = CEIL_DIV(elements[2], pipeline->wg_denoms[2]);
     VK_LOG_DEBUG("ggml_vk_dispatch_pipeline(" << pipeline->name << ", {";
     for (auto& buffer : descriptor_buffer_infos) {
-        std::cerr << "(" << buffer << ", " << buffer.offset << ", " << buffer.size << "), ";
+        std::cerr << "(" << buffer.buffer << ", " << buffer.offset << ", " << buffer.range << "), ";
     }
     std::cerr << "}, (" << wg0 << "," << wg1 << "," << wg2 << "))");
     GGML_ASSERT(pipeline->descriptor_set_idx < pipeline->descriptor_sets.size());


### PR DESCRIPTION
the old code was trying to print a non-existent field (size) and the struct as a whole (which doesn't have a operator<< override defined).
Probably a typo happened during refactoring.