### PR TITLE
ggml/examples: add backend support for numerical optimization

### DIFF
--- a/examples/mnist/README.md
+++ b/examples/mnist/README.md
@@ -18,7 +18,7 @@ $ python3 mnist-train-fc.py mnist-fc-f32.gguf
 
 ...
 
-Test loss: 0.069983+-0.009196, Test accuracy: 97.94+-0.14%
+Test loss: 0.066051+-0.011630, Test accuracy: 98.07+-0.14%
 
 Model tensors saved to mnist-fc-f32.gguf:
 fc1.weight       (500, 784)
@@ -28,7 +28,7 @@ fc2.bias         (10,)
 ```
 
 The training script includes an evaluation of the model on the test set.
-To evaluate the model using GGML, run:
+To evaluate the model on the CPU using GGML, run:
 
 ```bash
 $ ../../build/bin/mnist-eval mnist-fc-f32.gguf data/MNIST/raw/t10k-images-idx3-ubyte data/MNIST/raw/t10k-labels-idx1-ubyte
@@ -37,26 +37,26 @@ ________________________________________________________
 ________________________________________________________
 ________________________________________________________
 ________________________________________________________
-________________________________######__________________
-____________________________########____________________
-________________________########________________________
-____________________########________________##__________
-__________________######____________________##__________
-________________######______________________####________
-______________######________________________####________
-____________######__________________________####________
-____________####____________________________####________
-__________####______________________________####________
-__________####______________________________####________
-__________##________________________________####________
-__________##______________________________####__________
-__________##____________________________######__________
-__________##__________________________######____________
-____________##____________________########______________
-____________##########################__________________
-______________##################________________________
-________________________________________________________
-________________________________________________________
+__________________________________####__________________
+______________________________########__________________
+__________________________##########____________________
+______________________##############____________________
+____________________######________####__________________
+__________________________________####__________________
+__________________________________####__________________
+________________________________####____________________
+______________________________####______________________
+________________________##########______________________
+______________________########__####____________________
+________________________##__________##__________________
+____________________________________##__________________
+__________________________________##____________________
+__________________________________##____________________
+________________________________##______________________
+____________________________####________________________
+__________##____________######__________________________
+__________##############________________________________
+________________####____________________________________
 ________________________________________________________
 ________________________________________________________
 ________________________________________________________
@@ -64,18 +64,23 @@ ________________________________________________________
 mnist_graph_eval: trying to load a ggml graph from mnist-fc-f32.gguf
 ggml_graph_import: invalid magic number, got 46554747
 mnist_graph_eval: could not load a ggml graph from mnist-fc-f32.gguf
+ggml_cuda_init: GGML_CUDA_FORCE_MMQ:    no
+ggml_cuda_init: GGML_CUDA_FORCE_CUBLAS: no
+ggml_cuda_init: found 1 CUDA devices:
+  Device 0: NVIDIA GeForce RTX 3090, compute capability 8.6, VMM: yes
+mnist_model: using CPU backend
 mnist_model_init_from_file: loading model weights from 'mnist-fc-f32.gguf'
 mnist_model_init_from_file: model arch is mnist-fc
 mnist_model_init_from_file: successfully loaded weights from mnist-fc-f32.gguf
-main: loaded model in 1.52 ms
-mnist_model_eval: model evaluation on 10000 images took 26.65 ms, 2.66 us/image
-main: predicted digit is 0
-main: test_loss=0.069983+-0.009196
-main: test_acc=97.94+-0.14%
+main: loaded model in 13.03 ms
+mnist_model_eval: model evaluation on 10000 images took 95.02 ms, 9.50 us/image
+main: predicted digit is 3
+main: test_loss=0.066051+-0.009343
+main: test_acc=98.07+-0.14%
 ```
 
 In addition to the evaluation on the test set the GGML evaluation also prints a random image from the test set as well as the model prediction for said image.
-To train a fully connected model using GGML run:
+To train a fully connected model on the CPU using GGML run:
 
 ``` bash
 $ ../../build/bin/mnist-train mnist-fc mnist-fc-f32.gguf data/MNIST/raw/train-images-idx3-ubyte data/MNIST/raw/train-labels-idx1-ubyte
@@ -96,12 +101,12 @@ $ python3 mnist-train-cnn.py mnist-cnn-f32.gguf
 
 ...
 
-Test loss: 0.046456
-Test accuracy: 98.40%
+Test loss: 0.045483
+Test accuracy: 98.56%
 GGUF model saved to 'mnist-cnn-f32.gguf'
 ```
 
-The saved model can be evaluated using the `mnist-eval` binary:
+The saved model can be evaluated on the CPU using the `mnist-eval` binary:
 
 ```bash
 $ ../../build/bin/mnist-eval mnist-fc-f32.gguf data/MNIST/raw/t10k-images-idx3-ubyte data/MNIST/raw/t10k-labels-idx1-ubyte
@@ -111,25 +116,25 @@ ________________________________________________________
 ________________________________________________________
 ________________________________________________________
 ________________________________________________________
-________________________________________________________
-________________________________________________________
-________________________####____________________________
-__________________________##____________________________
-__________________________##____________________________
-__________________________##____________________________
-__________________________##____________________________
-__________________________##____________________________
-____________________________##__________________________
-____________________________##__________________________
-____________________________##__________________________
-______________________________##________________________
-______________________________##________________________
-______________________________####______________________
-________________________________##______________________
-________________________________##______________________
-________________________________####____________________
+______________________________________##________________
+______________________________________##________________
+______________________________________##________________
+____________________________________##__________________
+__________________________________####__________________
 __________________________________##____________________
 ________________________________##______________________
+______________________________##________________________
+____________________________####________________________
+____________________________##__________________________
+__________________________##____________________________
+________________________##______________________________
+______________________##________________________________
+____________________####________________________________
+____________________##__________________________________
+__________________##____________________________________
+________________##______________________________________
+________________________________________________________
+________________________________________________________
 ________________________________________________________
 ________________________________________________________
 ________________________________________________________
@@ -137,23 +142,34 @@ ________________________________________________________
 mnist_graph_eval: trying to load a ggml graph from mnist-cnn-f32.gguf
 ggml_graph_import: invalid magic number, got 46554747
 mnist_graph_eval: could not load a ggml graph from mnist-cnn-f32.gguf
+ggml_cuda_init: GGML_CUDA_FORCE_MMQ:    no
+ggml_cuda_init: GGML_CUDA_FORCE_CUBLAS: no
+ggml_cuda_init: found 1 CUDA devices:
+  Device 0: NVIDIA GeForce RTX 3090, compute capability 8.6, VMM: yes
+mnist_model: using CPU backend
 mnist_model_init_from_file: loading model weights from 'mnist-cnn-f32.gguf'
 mnist_model_init_from_file: model arch is mnist-cnn
 mnist_model_init_from_file: successfully loaded weights from mnist-cnn-f32.gguf
-main: loaded model in 5.45 ms
-mnist_model_eval: model evaluation on 10000 images took 605.60 ms, 60.56 us/image
+main: loaded model in 11.88 ms
+mnist_model_eval: model evaluation on 10000 images took 1074.09 ms, 107.41 us/image
 main: predicted digit is 1
-main: test_loss=0.046456+-0.007354
-main: test_acc=98.40+-0.13%
+main: test_loss=0.045483+-0.006884
+main: test_acc=98.56+-0.12%
 ```
 
-Like with the fully connected network the convolutional network can also be trained using GGML:
+Like with the fully connected network the convolutional network can also be trained on the CPU using GGML:
 
 ``` bash
 $ ../../build/bin/mnist-train mnist-cnn mnist-cnn-f32.gguf data/MNIST/raw/train-images-idx3-ubyte data/MNIST/raw/train-labels-idx1-ubyte
 ```
 
 As always, the evaluation is done using `mnist-eval` and like with the fully connected network the GGML graph is exported to `mnist-cnn-f32.ggml`.
+
+## CUDA
+
+The fully connected model can be trained and evaluated using CUDA.
+`mnist-train` and `mnist-eval` accept an additional, optional argument behind those listed so far to specify the backend.
+The default is `CPU`, by specifying `CUDA0` the first available CUDA device can be used instead (make sure to compile GGML with CUDA cupport).
 
 ## Web demo
 

--- a/examples/mnist/mnist-common.cpp
+++ b/examples/mnist/mnist-common.cpp
@@ -264,8 +264,8 @@ mnist_model mnist_model_init_from_file(const std::string & fname, const std::str
 
         model.conv1_bias = ggml_get_tensor(model.ctx_weight, "conv1.bias");
         GGML_ASSERT(model.conv1_bias->type == GGML_TYPE_F32);
-        GGML_ASSERT(model.conv1_bias->ne[0] == MNIST_HW);
-        GGML_ASSERT(model.conv1_bias->ne[1] == MNIST_HW);
+        GGML_ASSERT(model.conv1_bias->ne[0] == 1);
+        GGML_ASSERT(model.conv1_bias->ne[1] == 1);
         GGML_ASSERT(model.conv1_bias->ne[2] == MNIST_CNN_NCB);
         GGML_ASSERT(model.conv1_bias->ne[3] == 1);
 
@@ -278,8 +278,8 @@ mnist_model mnist_model_init_from_file(const std::string & fname, const std::str
 
         model.conv2_bias = ggml_get_tensor(model.ctx_weight, "conv2.bias");
         GGML_ASSERT(model.conv2_bias->type == GGML_TYPE_F32);
-        GGML_ASSERT(model.conv2_bias->ne[0] == MNIST_HW/2);
-        GGML_ASSERT(model.conv2_bias->ne[1] == MNIST_HW/2);
+        GGML_ASSERT(model.conv2_bias->ne[0] == 1);
+        GGML_ASSERT(model.conv2_bias->ne[1] == 1);
         GGML_ASSERT(model.conv2_bias->ne[2] == MNIST_CNN_NCB*2);
         GGML_ASSERT(model.conv2_bias->ne[3] == 1);
 

--- a/examples/mnist/mnist-common.cpp
+++ b/examples/mnist/mnist-common.cpp
@@ -556,15 +556,6 @@ void mnist_model_train(mnist_model & model, const float * images, const float * 
                 ggml_backend_graph_compute(model.backend, gb_opt);
                 ggml_graph_reset(gb_grad); // Set gradients to zero, do not reset optimizer.
             }
-            for (int j = 0; j < gb_grad->n_nodes; ++j) {
-                struct ggml_tensor * node = gb_grad->nodes[j];
-
-                if (node->op != GGML_OP_OPT_STEP_ADAM) {
-                    continue;
-                }
-
-                node->op_params[0]++;
-            }
 
             ggml_backend_tensor_get(model.loss,   &loss,         0, ggml_nbytes(model.loss));
             ggml_backend_tensor_get(model.logits, logits.data(), 0, ggml_nbytes(model.logits));

--- a/examples/mnist/mnist-common.cpp
+++ b/examples/mnist/mnist-common.cpp
@@ -530,13 +530,16 @@ mnist_eval_result mnist_model_eval(mnist_model & model, const float * images, co
 void mnist_model_train(mnist_model & model, const float * images, const float * labels, const int nex, const int nepoch, const float val_split) {
     const int64_t t_start_us = ggml_time_us();
 
+    // gf == graph forward, forward pass only.
     struct ggml_cgraph * gf = ggml_new_graph_custom(model.ctx_compute, GGML_DEFAULT_GRAPH_SIZE, /*grads =*/ true); // Forward pass.
     ggml_build_forward_expand(gf, model.loss);
 
-    struct ggml_cgraph * gb_grad = ggml_graph_dup(model.ctx_compute, gf); // Backward pass, gradients.
+    // gb_grad == graph backward gradients, forward pass, then backward pass to calculate gradients.
+    struct ggml_cgraph * gb_grad = ggml_graph_dup(model.ctx_compute, gf);
     ggml_build_backward_expand(model.ctx_compute, gf, gb_grad, /*accumulate =*/ true, false);
 
-    struct ggml_cgraph * gb_opt = ggml_graph_dup(model.ctx_compute, gf); // Backward pass, gradients + optimizer.
+    // gb_opt == graph backward optimize, forward pass, then backward pass to calculate gradients, then optimizer step.
+    struct ggml_cgraph * gb_opt = ggml_graph_dup(model.ctx_compute, gb_grad);
     ggml_build_opt_adamw(model.ctx_compute, gf, gb_opt, 1e-3f, 0.9f, 0.999f, 1e-8f, 0.0f);
 
     model.buf_compute = ggml_backend_alloc_ctx_tensors(model.ctx_compute, model.backend);
@@ -556,8 +559,6 @@ void mnist_model_train(mnist_model & model, const float * images, const float * 
         for (; iex0 < iex_split; iex0 += model.nbatch_physical) {
             ggml_backend_tensor_set(model.images, images + iex0*MNIST_NINPUT,   0, ggml_nbytes(model.images));
             ggml_backend_tensor_set(model.labels, labels + iex0*MNIST_NCLASSES, 0, ggml_nbytes(model.labels));
-
-            ggml_backend_graph_compute(model.backend, gf); // Always compute forward pass.
 
             // With a period of nbatch_logical/nbatch_physical iterations:
             if ((iex0 + model.nbatch_physical) % model.nbatch_logical != 0) {

--- a/examples/mnist/mnist-common.cpp
+++ b/examples/mnist/mnist-common.cpp
@@ -537,7 +537,7 @@ void mnist_model_train(mnist_model & model, const float * images, const float * 
     ggml_build_backward_expand(model.ctx_compute, gf, gb_grad, /*accumulate =*/ true, false);
 
     struct ggml_cgraph * gb_opt = ggml_graph_dup(model.ctx_compute, gf); // Backward pass, gradients + optimizer.
-    ggml_build_opt_adam(model.ctx_compute, gf, gb_opt, 1e-3f, 0.9f, 0.999f, 1e-8f, 0.0f);
+    ggml_build_opt_adamw(model.ctx_compute, gf, gb_opt, 1e-3f, 0.9f, 0.999f, 1e-8f, 0.0f);
 
     model.buf_compute = ggml_backend_alloc_ctx_tensors(model.ctx_compute, model.backend);
     ggml_graph_reset(gb_opt); // Set gradients to zero, reset optimizer.

--- a/examples/mnist/mnist-common.cpp
+++ b/examples/mnist/mnist-common.cpp
@@ -530,7 +530,7 @@ mnist_eval_result mnist_model_eval(mnist_model & model, const float * images, co
 void mnist_model_train(mnist_model & model, const float * images, const float * labels, const int nex, const int nepoch, const float val_split) {
     const int64_t t_start_us = ggml_time_us();
 
-    struct ggml_cgraph * gf = ggml_new_graph_custom(model.ctx_compute, 16384, true); // Forward pass.
+    struct ggml_cgraph * gf = ggml_new_graph_custom(model.ctx_compute, GGML_DEFAULT_GRAPH_SIZE, /*grads =*/ true); // Forward pass.
     ggml_build_forward_expand(gf, model.loss);
 
     struct ggml_cgraph * gb_grad = ggml_graph_dup(model.ctx_compute, gf); // Backward pass, gradients.
@@ -634,7 +634,7 @@ void mnist_model_save(mnist_model & model, const std::string & fname) {
     struct ggml_context * ggml_ctx;
     {
         struct ggml_init_params params = {
-            /*.mem_size   =*/ model.size_weight,
+            /*.mem_size   =*/ 100 * 1024*1024,
             /*.mem_buffer =*/ NULL,
             /*.no_alloc   =*/ false,
         };

--- a/examples/mnist/mnist-common.cpp
+++ b/examples/mnist/mnist-common.cpp
@@ -156,8 +156,8 @@ mnist_eval_result mnist_graph_eval(const std::string & fname, const float * imag
     return result;
 }
 
-mnist_model mnist_model_init_from_file(const std::string & fname) {
-    mnist_model model;
+mnist_model mnist_model_init_from_file(const std::string & fname, const std::string & backend) {
+    mnist_model model(backend);
     fprintf(stderr, "%s: loading model weights from '%s'\n", __func__, fname.c_str());
 
     struct gguf_context * ctx_be; // be == backend
@@ -286,8 +286,8 @@ mnist_model mnist_model_init_from_file(const std::string & fname) {
     return model;
 }
 
-mnist_model mnist_model_init_random(const std::string & arch) {
-    mnist_model model;
+mnist_model mnist_model_init_random(const std::string & arch, const std::string & backend) {
+    mnist_model model(backend);
     model.arch = arch;
 
     std::random_device rd{};
@@ -665,7 +665,7 @@ int wasm_eval(uint8_t * digitPtr) {
     std::vector<float> digit(digitPtr, digitPtr + MNIST_NINPUT);
     std::vector<float> labels(MNIST_NCLASSES);
 
-    mnist_model model = mnist_model_init_from_file("mnist-f32.gguf");
+    mnist_model model = mnist_model_init_from_file("mnist-f32.gguf", "CPU");
     mnist_model_build(model, 1);
     mnist_eval_result result = mnist_model_eval(model, digit.data(), labels.data(), 1, 1);
 

--- a/examples/mnist/mnist-common.cpp
+++ b/examples/mnist/mnist-common.cpp
@@ -524,6 +524,7 @@ void mnist_model_train(mnist_model & model, const float * images, const float * 
 
     struct ggml_cgraph * gb = ggml_graph_dup(model.ctx_compute, gf);
     ggml_build_backward_expand(model.ctx_compute, gf, gb, false);
+    ggml_build_opt_adam(       model.ctx_compute, gf, gb, 1e-3f, 0.9f, 0.999f, 1e-8f, 0.0f);
 
     struct ggml_opt_context opt_ctx;
     struct ggml_opt_params  opt_pars = ggml_opt_default_params(GGML_OPT_TYPE_ADAM);

--- a/examples/mnist/mnist-common.cpp
+++ b/examples/mnist/mnist-common.cpp
@@ -565,7 +565,7 @@ void mnist_model_train(mnist_model & model, const float * images, const float * 
                 ggml_backend_graph_compute(model.backend, gb_grad);
             } else {
                 // For the last iteration, calculate gradients and also apply the optimizer:
-                ggml_backend_graph_compute(model.backend, gb_opt);
+                ggml_backend_graph_compute(model.backend, gb_opt); // gb_opt contains all nodes of gb_grad so no extra call for gb_grad is needed.
                 ggml_graph_reset(gb_grad); // Set gradients to zero, do not reset optimizer.
             }
 

--- a/examples/mnist/mnist-common.cpp
+++ b/examples/mnist/mnist-common.cpp
@@ -604,15 +604,16 @@ void mnist_model_train(mnist_model & model, const float * images, const float * 
 
             const int64_t t_epoch_us = ggml_time_us() - t_start_us;
             const double t_epoch_s = 1e-6*t_epoch_us;
-            fprintf(stderr, "done, took %.2lfs, train_loss=%.6lf, train_acc=%.2f%%, ", t_epoch_s, loss_mean, percent_correct);
+            fprintf(stderr, "done, took %.2lfs, train_loss=%.6lf, train_acc=%.2f%%", t_epoch_s, loss_mean, percent_correct);
         }
 
-        {
+        if (iex_split < nex) {
             const std::pair<double, double> loss = mnist_loss(result_val);
             const std::pair<double, double> acc  = mnist_accuracy(result_val, labels + iex_split*MNIST_NCLASSES);
 
-            fprintf(stderr, "val_loss=%.6lf+-%.6lf, train_acc=%.2f+-%.2f%%\n", loss.first, loss.second, 100.0*acc.first, 100.0*acc.second);
+            fprintf(stderr, ", val_loss=%.6lf+-%.6lf, train_acc=%.2f+-%.2f%%", loss.first, loss.second, 100.0*acc.first, 100.0*acc.second);
         }
+        fprintf(stderr, "\n");
     }
 
     const int64_t t_total_us = ggml_time_us() - t_start_us;

--- a/examples/mnist/mnist-common.cpp
+++ b/examples/mnist/mnist-common.cpp
@@ -611,7 +611,7 @@ void mnist_model_train(mnist_model & model, const float * images, const float * 
             const std::pair<double, double> loss = mnist_loss(result_val);
             const std::pair<double, double> acc  = mnist_accuracy(result_val, labels + iex_split*MNIST_NCLASSES);
 
-            fprintf(stderr, ", val_loss=%.6lf+-%.6lf, train_acc=%.2f+-%.2f%%", loss.first, loss.second, 100.0*acc.first, 100.0*acc.second);
+            fprintf(stderr, ", val_loss=%.6lf+-%.6lf, val_acc=%.2f+-%.2f%%", loss.first, loss.second, 100.0*acc.first, 100.0*acc.second);
         }
         fprintf(stderr, "\n");
     }

--- a/examples/mnist/mnist-common.cpp
+++ b/examples/mnist/mnist-common.cpp
@@ -337,14 +337,17 @@ mnist_model mnist_model_init_random(const std::string & arch) {
         fprintf(stderr, "%s: unknown model arch: %s\n", __func__, model.arch.c_str());
     }
 
+    model.buf_weightt = ggml_backend_alloc_ctx_tensors(model.ctx_weight, model.backend);
+
     for (ggml_tensor * t : init_tensors) {
         GGML_ASSERT(t->type == GGML_TYPE_F32);
-        float * data = ggml_get_data_f32(t);
         const int64_t ne = ggml_nelements(t);
+        std::vector<float> tmp(ne);
 
         for (int64_t i = 0; i < ne; ++i) {
-            data[i] = nd(gen);
+            tmp[i] = nd(gen);
         }
+        ggml_backend_tensor_set(t, tmp.data(), 0, ggml_nbytes(t));
     }
 
     return model;
@@ -451,8 +454,6 @@ void mnist_model_build(mnist_model & model, const int nbatch) {
     GGML_ASSERT(model.loss->ne[1] == 1);
     GGML_ASSERT(model.loss->ne[2] == 1);
     GGML_ASSERT(model.loss->ne[3] == 1);
-
-    model.buf_compute = ggml_backend_alloc_ctx_tensors(model.ctx_compute, model.backend);
 }
 
 mnist_eval_result mnist_model_eval(const mnist_model & model, const float * images, const float * labels, const int nex, const int nthreads) {
@@ -505,32 +506,43 @@ void mnist_model_train(mnist_model & model, const float * images, const float * 
     ggml_build_forward_expand(gf, model.loss);
 
     struct ggml_cgraph * gb = ggml_graph_dup(model.ctx_compute, gf);
-    ggml_build_backward_expand(model.ctx_compute, gf, gb, true);
+    ggml_build_backward_expand(model.ctx_compute, gf, gb, false);
 
     struct ggml_opt_context opt_ctx;
     struct ggml_opt_params  opt_pars = ggml_opt_default_params(GGML_OPT_TYPE_ADAM);
     opt_pars.print_forward_graph = false;
     opt_pars.print_backward_graph = false;
-    opt_pars.n_threads = nthreads;
+    opt_pars.n_threads = std::thread::hardware_concurrency();
     opt_pars.adam.n_iter = 1; // per call of ggml_opt_resume_g
     ggml_opt_init(model.ctx_compute, &opt_ctx, opt_pars, 0);
+
+    model.buf_compute = ggml_backend_alloc_ctx_tensors(model.ctx_compute, model.backend);
 
     for (int epoch = 0; epoch < 20; ++epoch) {
         fprintf(stderr, "%s: epoch %d start...", __func__, epoch);
         const int64_t t_start_us = ggml_time_us();
+
+        float loss;
+        std::vector<float> logits(model.nbatch*MNIST_NCLASSES);
+
         mnist_eval_result result;
         for (int iex0 = 0; iex0 < nex; iex0 += model.nbatch) {
-            memcpy(model.images->data, images + iex0*MNIST_NINPUT,   ggml_nbytes(model.images));
-            memcpy(model.labels->data, labels + iex0*MNIST_NCLASSES, ggml_nbytes(model.labels));
+            ggml_backend_tensor_set(model.images, images + iex0*MNIST_NINPUT,   0, ggml_nbytes(model.images));
+            ggml_backend_tensor_set(model.labels, labels + iex0*MNIST_NCLASSES, 0, ggml_nbytes(model.labels));
 
-            enum ggml_opt_result opt_result = ggml_opt_resume_g(model.ctx_compute, &opt_ctx, model.loss, gf, gb, NULL, NULL);
-            GGML_ASSERT(opt_result == GGML_OPT_RESULT_OK || opt_result == GGML_OPT_RESULT_DID_NOT_CONVERGE);
+            const float onef = 1.0f;
+            ggml_backend_graph_compute(model.backend, gf);
+            ggml_backend_tensor_set(model.loss->grad, &onef, 0, sizeof(float));
+            ggml_backend_graph_compute(model.backend, gb);
 
-            result.loss.push_back(*ggml_get_data_f32(model.loss));
+            ggml_backend_tensor_get(model.loss,   &loss,         0, ggml_nbytes(model.loss));
+            ggml_backend_tensor_get(model.logits, logits.data(), 0, ggml_nbytes(model.logits));
+
+            result.loss.push_back(loss);
 
             for (int iexb = 0; iexb < model.nbatch; ++iexb) {
-                const float * ptr_p = (const float *) model.logits->data + iexb*MNIST_NCLASSES;
-                result.pred.push_back(std::max_element(ptr_p, ptr_p + MNIST_NCLASSES) - ptr_p);
+                const float * logits_iexb = logits.data() + iexb*MNIST_NCLASSES;
+                result.pred.push_back(std::max_element(logits_iexb, logits_iexb + MNIST_NCLASSES) - logits_iexb);
             }
         }
 

--- a/examples/mnist/mnist-common.cpp
+++ b/examples/mnist/mnist-common.cpp
@@ -299,7 +299,7 @@ mnist_model mnist_model_init_from_file(const std::string & fname, const std::str
     } else {
         fprintf(stderr, "%s: unknown model arch: %s\n", __func__, model.arch.c_str());
     }
-    model.buf_weightt = ggml_backend_alloc_ctx_tensors(model.ctx_weight, model.backend);
+    model.buf_weight = ggml_backend_alloc_ctx_tensors(model.ctx_weight, model.backend);
 
     if(!load_from_gguf(fname.c_str(), model.ctx_weight, ctx)) {
         fprintf(stderr, "%s: loading weights from %s failed\n", __func__, fname.c_str());
@@ -361,7 +361,7 @@ mnist_model mnist_model_init_random(const std::string & arch, const std::string 
         fprintf(stderr, "%s: unknown model arch: %s\n", __func__, model.arch.c_str());
     }
 
-    model.buf_weightt = ggml_backend_alloc_ctx_tensors(model.ctx_weight, model.backend);
+    model.buf_weight = ggml_backend_alloc_ctx_tensors(model.ctx_weight, model.backend);
 
     for (ggml_tensor * t : init_tensors) {
         GGML_ASSERT(t->type == GGML_TYPE_F32);

--- a/examples/mnist/mnist-common.h
+++ b/examples/mnist/mnist-common.h
@@ -52,12 +52,10 @@ struct mnist_model {
     static const size_t size_weight  = 100 *      1024*1024;
     static const size_t size_compute =   1 * 1024*1024*1024;
 
-    void                * buf_weight  = nullptr;
     struct ggml_context * ctx_weight  = nullptr;
-    void                * buf_compute = nullptr;
     struct ggml_context * ctx_compute = nullptr;
-    ggml_backend_buffer_t buf_backend = nullptr;
-    ggml_backend_buffer_t buf_weightt = nullptr;
+    ggml_backend_buffer_t buf_weight  = nullptr;
+    ggml_backend_buffer_t buf_compute = nullptr;
 
     mnist_model(const std::string & backend_name) {
         const size_t backend_index = ggml_backend_reg_find_by_name(backend_name.c_str());
@@ -75,7 +73,6 @@ struct mnist_model {
             ggml_backend_cpu_set_n_threads(backend, std::thread::hardware_concurrency());
         }
 
-        buf_weight = malloc(size_weight);
         {
             struct ggml_init_params params = {
                 /*.mem_size   =*/ size_weight,
@@ -85,7 +82,6 @@ struct mnist_model {
             ctx_weight = ggml_init(params);
         }
 
-        buf_compute = malloc(size_compute);
         {
             struct ggml_init_params params = {
                 /*.mem_size   =*/ size_compute,
@@ -100,11 +96,8 @@ struct mnist_model {
         ggml_free(ctx_weight);
         ggml_free(ctx_compute);
 
-        free(buf_weight);
-        free(buf_compute);
-
-        ggml_backend_buffer_free(buf_weightt);
-        ggml_backend_buffer_free(buf_backend);
+        ggml_backend_buffer_free(buf_weight);
+        ggml_backend_buffer_free(buf_compute);
         ggml_backend_free(backend);
     }
 };

--- a/examples/mnist/mnist-common.h
+++ b/examples/mnist/mnist-common.h
@@ -57,9 +57,9 @@ struct mnist_model {
     ggml_backend_buffer_t buf_weightt = nullptr;
 
     mnist_model() {
-        backend = ggml_backend_cuda_init(0);
-        // backend = ggml_backend_cpu_init();
-        // ggml_backend_cpu_set_n_threads(backend, std::thread::hardware_concurrency());
+        // backend = ggml_backend_cuda_init(0);
+        backend = ggml_backend_cpu_init();
+        ggml_backend_cpu_set_n_threads(backend, std::thread::hardware_concurrency()/2);
 
         buf_weight = malloc(size_weight);
         {

--- a/examples/mnist/mnist-common.h
+++ b/examples/mnist/mnist-common.h
@@ -71,6 +71,9 @@ struct mnist_model {
 
         fprintf(stderr, "%s: using %s backend\n", __func__, backend_name.c_str());
         backend = ggml_backend_reg_init_backend(backend_index, nullptr);
+        if (ggml_backend_is_cpu(backend)) {
+            ggml_backend_cpu_set_n_threads(backend, std::thread::hardware_concurrency());
+        }
 
         buf_weight = malloc(size_weight);
         {
@@ -122,8 +125,8 @@ mnist_eval_result mnist_graph_eval(const std::string & fname, const float * imag
 mnist_model       mnist_model_init_from_file(const std::string & fname, const std::string & backend);
 mnist_model       mnist_model_init_random(const std::string & arch, const std::string & backend);
 void              mnist_model_build(mnist_model & model, const int nbatch_logical, const int nbatch_physical);
-mnist_eval_result mnist_model_eval(mnist_model & model, const float * images, const float * labels, const int nex, const int nthreads);
-void              mnist_model_train(mnist_model & model, const float * images, const float * labels, const int nex, const int nthreads);
+mnist_eval_result mnist_model_eval(mnist_model & model, const float * images, const float * labels, const int nex);
+void              mnist_model_train(mnist_model & model, const float * images, const float * labels, const int nex);
 void              mnist_model_save(mnist_model & model, const std::string & fname);
 
 std::pair<double, double> mnist_loss(const mnist_eval_result & result);

--- a/examples/mnist/mnist-common.h
+++ b/examples/mnist/mnist-common.h
@@ -119,7 +119,7 @@ mnist_model       mnist_model_init_from_file(const std::string & fname, const st
 mnist_model       mnist_model_init_random(const std::string & arch, const std::string & backend);
 void              mnist_model_build(mnist_model & model, const int nbatch_logical, const int nbatch_physical);
 mnist_eval_result mnist_model_eval(mnist_model & model, const float * images, const float * labels, const int nex);
-void              mnist_model_train(mnist_model & model, const float * images, const float * labels, const int nex);
+void              mnist_model_train(mnist_model & model, const float * images, const float * labels, const int nex, const int nepoch, const float val_split);
 void              mnist_model_save(mnist_model & model, const std::string & fname);
 
 std::pair<double, double> mnist_loss(const mnist_eval_result & result);

--- a/examples/mnist/mnist-common.h
+++ b/examples/mnist/mnist-common.h
@@ -57,9 +57,12 @@ struct mnist_model {
     ggml_backend_buffer_t buf_weightt = nullptr;
 
     mnist_model() {
-        // backend = ggml_backend_cuda_init(0);
-        backend = ggml_backend_cpu_init();
-        ggml_backend_cpu_set_n_threads(backend, std::thread::hardware_concurrency()/2);
+        backend = ggml_backend_cuda_init(0);
+        if (!backend) {
+            fprintf(stderr, "%s: CUDA backend could not be initialized, using CPU backend as a fallback\n", __func__);
+            backend = ggml_backend_cpu_init();
+            ggml_backend_cpu_set_n_threads(backend, std::thread::hardware_concurrency()/2);
+        }
 
         buf_weight = malloc(size_weight);
         {
@@ -111,7 +114,7 @@ mnist_eval_result mnist_graph_eval(const std::string & fname, const float * imag
 mnist_model       mnist_model_init_from_file(const std::string & fname);
 mnist_model       mnist_model_init_random(const std::string & arch);
 void              mnist_model_build(mnist_model & model, const int nbatch);
-mnist_eval_result mnist_model_eval(const mnist_model & model, const float * images, const float * labels, const int nex, const int nthreads);
+mnist_eval_result mnist_model_eval(mnist_model & model, const float * images, const float * labels, const int nex, const int nthreads);
 void              mnist_model_train(mnist_model & model, const float * images, const float * labels, const int nex, const int nthreads);
 void              mnist_model_save(mnist_model & model, const std::string & fname);
 

--- a/examples/mnist/mnist-common.h
+++ b/examples/mnist/mnist-common.h
@@ -7,12 +7,14 @@
 #include "ggml-backend.h"
 #include "ggml.h"
 
-#define MNIST_NTRAIN 60000
-#define MNIST_NTEST  10000
-#define MNIST_NBATCH 500
+#define MNIST_NTRAIN          60000
+#define MNIST_NTEST           10000
+#define MNIST_NBATCH_LOGICAL   1000
+#define MNIST_NBATCH_PHYSICAL   500
 
-static_assert(MNIST_NTRAIN % MNIST_NBATCH == 0, "MNIST_NTRAIN % MNIST_BATCH != 0");
-static_assert(MNIST_NTEST  % MNIST_NBATCH == 0, "MNIST_NTRAIN % MNIST_BATCH != 0");
+static_assert(MNIST_NBATCH_LOGICAL % MNIST_NBATCH_PHYSICAL == 0, "MNIST_NBATCH_LOGICAL % MNIST_NBATCH_PHYSICAL != 0");
+static_assert(MNIST_NTRAIN % MNIST_NBATCH_LOGICAL == 0, "MNIST_NTRAIN % MNIST_NBATCH_LOGICAL != 0");
+static_assert(MNIST_NTEST  % MNIST_NBATCH_LOGICAL == 0, "MNIST_NTRAIN % MNIST_NBATCH_LOGICAL != 0");
 
 #define MNIST_HW       28
 #define MNIST_NINPUT   (MNIST_HW*MNIST_HW)
@@ -26,7 +28,8 @@ static_assert(MNIST_NTEST  % MNIST_NBATCH == 0, "MNIST_NTRAIN % MNIST_BATCH != 0
 struct mnist_model {
     std::string arch;
     ggml_backend_t backend;
-    int nbatch;
+    int nbatch_logical;
+    int nbatch_physical;
 
     struct ggml_tensor  * images = nullptr;
     struct ggml_tensor  * labels = nullptr;
@@ -118,7 +121,7 @@ mnist_eval_result mnist_graph_eval(const std::string & fname, const float * imag
 
 mnist_model       mnist_model_init_from_file(const std::string & fname, const std::string & backend);
 mnist_model       mnist_model_init_random(const std::string & arch, const std::string & backend);
-void              mnist_model_build(mnist_model & model, const int nbatch);
+void              mnist_model_build(mnist_model & model, const int nbatch_logical, const int nbatch_physical);
 mnist_eval_result mnist_model_eval(mnist_model & model, const float * images, const float * labels, const int nex, const int nthreads);
 void              mnist_model_train(mnist_model & model, const float * images, const float * labels, const int nex, const int nthreads);
 void              mnist_model_save(mnist_model & model, const std::string & fname);

--- a/examples/mnist/mnist-eval.cpp
+++ b/examples/mnist/mnist-eval.cpp
@@ -19,8 +19,8 @@ int main(int argc, char ** argv) {
     srand(time(NULL));
     ggml_time_init();
 
-    if (argc != 4) {
-        fprintf(stderr, "Usage: %s mnist-fc-f32.gguf data/MNIST/raw/t10k-images-idx3-ubyte data/MNIST/raw/t10k-labels-idx1-ubyte\n", argv[0]);
+    if (argc != 4 && argc != 5) {
+        fprintf(stderr, "Usage: %s mnist-fc-f32.gguf data/MNIST/raw/t10k-images-idx3-ubyte data/MNIST/raw/t10k-labels-idx1-ubyte [CPU/CUDA0]\n", argv[0]);
         exit(1);
     }
 
@@ -58,7 +58,7 @@ int main(int argc, char ** argv) {
 
     const int64_t t_start_us = ggml_time_us();
 
-    mnist_model model = mnist_model_init_from_file(argv[1]);
+    mnist_model model = mnist_model_init_from_file(argv[1], argc >= 5 ? argv[4] : "CPU");
 
     mnist_model_build(model, MNIST_NBATCH);
 

--- a/examples/mnist/mnist-eval.cpp
+++ b/examples/mnist/mnist-eval.cpp
@@ -36,36 +36,42 @@ int main(int argc, char ** argv) {
         return 1;
     }
 
-    const int nthreads = std::thread::hardware_concurrency();
-
     const int iex = rand() % MNIST_NTEST;
     const std::vector<float> digit(images.begin() + iex*MNIST_NINPUT, images.begin() + (iex+1)*MNIST_NINPUT);
 
     mnist_image_print(stdout, images.data() + iex*MNIST_NINPUT);
 
-    // mnist_eval_result result_eval = mnist_graph_eval(argv[1], images.data(), labels.data(), MNIST_NTEST, nthreads);
-    // if (result_eval.success) {
-    //     fprintf(stdout, "%s: predicted digit is %d\n", __func__, result_eval.pred[iex]);
+    const std::string backend = argc >= 5 ? argv[4] : "CPU";
 
-    //     std::pair<double, double> result_loss = mnist_loss(result_eval);
-    //     fprintf(stdout, "%s: test_loss=%.6lf+-%.6lf\n", __func__, result_loss.first, result_loss.second);
+    mnist_eval_result result_eval;
 
-    //     std::pair<double, double> result_acc = mnist_accuracy(result_eval, labels.data());
-    //     fprintf(stdout, "%s: test_acc=%.2lf+-%.2lf%%\n", __func__, 100.0*result_acc.first, 100.0*result_acc.second);
+    if (backend == "CPU") {
+        result_eval = mnist_graph_eval(argv[1], images.data(), labels.data(), MNIST_NTEST, std::thread::hardware_concurrency());
+        if (result_eval.success) {
+            fprintf(stdout, "%s: predicted digit is %d\n", __func__, result_eval.pred[iex]);
 
-    //     return 0;
-    // }
+            std::pair<double, double> result_loss = mnist_loss(result_eval);
+            fprintf(stdout, "%s: test_loss=%.6lf+-%.6lf\n", __func__, result_loss.first, result_loss.second);
+
+            std::pair<double, double> result_acc = mnist_accuracy(result_eval, labels.data());
+            fprintf(stdout, "%s: test_acc=%.2lf+-%.2lf%%\n", __func__, 100.0*result_acc.first, 100.0*result_acc.second);
+
+            return 0;
+        }
+    } else {
+        fprintf(stdout, "%s: not trying to load a GGML graph from %s because this is only supported for the CPU backend\n", __func__, argv[1]);
+    }
 
     const int64_t t_start_us = ggml_time_us();
 
-    mnist_model model = mnist_model_init_from_file(argv[1], argc >= 5 ? argv[4] : "CPU");
+    mnist_model model = mnist_model_init_from_file(argv[1], backend);
 
     mnist_model_build(model, MNIST_NBATCH_LOGICAL, MNIST_NBATCH_PHYSICAL);
 
     const int64_t t_load_us = ggml_time_us() - t_start_us;
 
     fprintf(stdout, "%s: loaded model in %.2lf ms\n", __func__, t_load_us / 1000.0);
-    mnist_eval_result result_eval = mnist_model_eval(model, images.data(), labels.data(), MNIST_NTEST, nthreads);
+    result_eval = mnist_model_eval(model, images.data(), labels.data(), MNIST_NTEST);
     fprintf(stdout, "%s: predicted digit is %d\n", __func__, result_eval.pred[iex]);
 
     std::pair<double, double> result_loss = mnist_loss(result_eval);

--- a/examples/mnist/mnist-eval.cpp
+++ b/examples/mnist/mnist-eval.cpp
@@ -60,7 +60,7 @@ int main(int argc, char ** argv) {
 
     mnist_model model = mnist_model_init_from_file(argv[1], argc >= 5 ? argv[4] : "CPU");
 
-    mnist_model_build(model, MNIST_NBATCH);
+    mnist_model_build(model, MNIST_NBATCH_LOGICAL, MNIST_NBATCH_PHYSICAL);
 
     const int64_t t_load_us = ggml_time_us() - t_start_us;
 

--- a/examples/mnist/mnist-eval.cpp
+++ b/examples/mnist/mnist-eval.cpp
@@ -43,18 +43,18 @@ int main(int argc, char ** argv) {
 
     mnist_image_print(stdout, images.data() + iex*MNIST_NINPUT);
 
-    mnist_eval_result result_eval = mnist_graph_eval(argv[1], images.data(), labels.data(), MNIST_NTEST, nthreads);
-    if (result_eval.success) {
-        fprintf(stdout, "%s: predicted digit is %d\n", __func__, result_eval.pred[iex]);
+    // mnist_eval_result result_eval = mnist_graph_eval(argv[1], images.data(), labels.data(), MNIST_NTEST, nthreads);
+    // if (result_eval.success) {
+    //     fprintf(stdout, "%s: predicted digit is %d\n", __func__, result_eval.pred[iex]);
 
-        std::pair<double, double> result_loss = mnist_loss(result_eval);
-        fprintf(stdout, "%s: test_loss=%.6lf+-%.6lf\n", __func__, result_loss.first, result_loss.second);
+    //     std::pair<double, double> result_loss = mnist_loss(result_eval);
+    //     fprintf(stdout, "%s: test_loss=%.6lf+-%.6lf\n", __func__, result_loss.first, result_loss.second);
 
-        std::pair<double, double> result_acc = mnist_accuracy(result_eval, labels.data());
-        fprintf(stdout, "%s: test_acc=%.2lf+-%.2lf%%\n", __func__, 100.0*result_acc.first, 100.0*result_acc.second);
+    //     std::pair<double, double> result_acc = mnist_accuracy(result_eval, labels.data());
+    //     fprintf(stdout, "%s: test_acc=%.2lf+-%.2lf%%\n", __func__, 100.0*result_acc.first, 100.0*result_acc.second);
 
-        return 0;
-    }
+    //     return 0;
+    // }
 
     const int64_t t_start_us = ggml_time_us();
 
@@ -65,7 +65,7 @@ int main(int argc, char ** argv) {
     const int64_t t_load_us = ggml_time_us() - t_start_us;
 
     fprintf(stdout, "%s: loaded model in %.2lf ms\n", __func__, t_load_us / 1000.0);
-    result_eval = mnist_model_eval(model, images.data(), labels.data(), MNIST_NTEST, nthreads);
+    mnist_eval_result result_eval = mnist_model_eval(model, images.data(), labels.data(), MNIST_NTEST, nthreads);
     fprintf(stdout, "%s: predicted digit is %d\n", __func__, result_eval.pred[iex]);
 
     std::pair<double, double> result_loss = mnist_loss(result_eval);

--- a/examples/mnist/mnist-eval.cpp
+++ b/examples/mnist/mnist-eval.cpp
@@ -46,7 +46,9 @@ int main(int argc, char ** argv) {
     mnist_eval_result result_eval;
 
     if (backend == "CPU") {
-        result_eval = mnist_graph_eval(argv[1], images.data(), labels.data(), MNIST_NTEST, std::thread::hardware_concurrency());
+        const int ncores_logical = std::thread::hardware_concurrency();
+        result_eval = mnist_graph_eval(
+            argv[1], images.data(), labels.data(), MNIST_NTEST, std::min(ncores_logical, (ncores_logical + 4)/2));
         if (result_eval.success) {
             fprintf(stdout, "%s: predicted digit is %d\n", __func__, result_eval.pred[iex]);
 

--- a/examples/mnist/mnist-train-cnn.py
+++ b/examples/mnist/mnist-train-cnn.py
@@ -42,8 +42,8 @@ def train(model_path):
     )
 
     model.summary()
-    batch_size = 500
-    epochs = 20
+    batch_size = 1000
+    epochs = 30
     model.compile(loss="categorical_crossentropy", optimizer="adam", metrics=["accuracy"])
 
     t_start = time()

--- a/examples/mnist/mnist-train-cnn.py
+++ b/examples/mnist/mnist-train-cnn.py
@@ -61,16 +61,14 @@ def train(model_path):
     gguf_writer.add_tensor("conv1.kernel", conv1_kernel, raw_shape=(8, 1, 3, 3))
 
     conv1_bias = model.layers[0].weights[1].numpy()
-    conv1_bias = np.repeat(conv1_bias, 28*28)
-    gguf_writer.add_tensor("conv1.bias", conv1_bias, raw_shape=(1, 8, 28, 28))
+    gguf_writer.add_tensor("conv1.bias", conv1_bias, raw_shape=(1, 8, 1, 1))
 
     conv2_kernel = model.layers[2].weights[0].numpy()
     conv2_kernel = np.moveaxis(conv2_kernel, [0, 1, 2, 3], [2, 3, 1, 0])
     gguf_writer.add_tensor("conv2.kernel", conv2_kernel, raw_shape=(16, 8, 3, 3))
 
     conv2_bias = model.layers[2].weights[1].numpy()
-    conv2_bias = np.repeat(conv2_bias, 14*14)
-    gguf_writer.add_tensor("conv2.bias", conv2_bias, raw_shape=(1, 16, 14, 14))
+    gguf_writer.add_tensor("conv2.bias", conv2_bias, raw_shape=(1, 16, 1, 1))
 
     dense_weight = model.layers[-1].weights[0].numpy()
     dense_weight = dense_weight.transpose()

--- a/examples/mnist/mnist-train-fc.py
+++ b/examples/mnist/mnist-train-fc.py
@@ -38,8 +38,9 @@ def train(model_path):
     assert len(train_data) == 60000
     assert len(test_data)  == 10000
 
-    train_gen = torch.utils.data.DataLoader(dataset=train_data, batch_size=batch_size, shuffle=True)
-    test_gen  = torch.utils.data.DataLoader(dataset=test_data,  batch_size=batch_size, shuffle=False)
+    kwargs_train_test = dict(batch_size=batch_size, num_workers=4, pin_memory=True)
+    train_gen = torch.utils.data.DataLoader(dataset=train_data, shuffle=True,  **kwargs_train_test)
+    test_gen  = torch.utils.data.DataLoader(dataset=test_data,  shuffle=False, **kwargs_train_test)
 
     net = Net(input_size, hidden_size, num_classes)
 

--- a/examples/mnist/mnist-train-fc.py
+++ b/examples/mnist/mnist-train-fc.py
@@ -12,8 +12,8 @@ from time import time
 input_size  = 784  # img_size = (28,28) ---> 28*28=784 in total
 hidden_size = 500  # number of nodes at hidden layer
 num_classes = 10   # number of output classes discrete range [0,9]
-num_epochs  = 20   # number of times which the entire dataset is passed throughout the model
-batch_size  = 500  # the size of input data took for one iteration
+num_epochs  = 30   # number of times which the entire dataset is passed throughout the model
+batch_size  = 1000 # the size of input data used for one iteration
 lr          = 1e-3 # size of step
 
 

--- a/examples/mnist/mnist-train.cpp
+++ b/examples/mnist/mnist-train.cpp
@@ -33,7 +33,7 @@ int main(int argc, char ** argv) {
 
     mnist_model_build(model, MNIST_NBATCH_LOGICAL, MNIST_NBATCH_PHYSICAL);
 
-    mnist_model_train(model, images.data(), labels.data(), MNIST_NTRAIN, std::thread::hardware_concurrency());
+    mnist_model_train(model, images.data(), labels.data(), MNIST_NTRAIN);
 
     mnist_model_save(model, argv[2]);
 }

--- a/examples/mnist/mnist-train.cpp
+++ b/examples/mnist/mnist-train.cpp
@@ -33,7 +33,7 @@ int main(int argc, char ** argv) {
 
     mnist_model_build(model, MNIST_NBATCH_LOGICAL, MNIST_NBATCH_PHYSICAL);
 
-    mnist_model_train(model, images.data(), labels.data(), MNIST_NTRAIN);
+    mnist_model_train(model, images.data(), labels.data(), MNIST_NTRAIN, /*nepoch =*/ 30, /*val_split =*/ 0.05f);
 
     mnist_model_save(model, argv[2]);
 }

--- a/examples/mnist/mnist-train.cpp
+++ b/examples/mnist/mnist-train.cpp
@@ -31,7 +31,7 @@ int main(int argc, char ** argv) {
 
     mnist_model model = mnist_model_init_random(argv[1], argc >= 6 ? argv[5] : "CPU");
 
-    mnist_model_build(model, MNIST_NBATCH);
+    mnist_model_build(model, MNIST_NBATCH_LOGICAL, MNIST_NBATCH_PHYSICAL);
 
     mnist_model_train(model, images.data(), labels.data(), MNIST_NTRAIN, std::thread::hardware_concurrency());
 

--- a/examples/mnist/mnist-train.cpp
+++ b/examples/mnist/mnist-train.cpp
@@ -12,8 +12,8 @@
 #endif
 
 int main(int argc, char ** argv) {
-    if (argc != 5) {
-        fprintf(stderr, "Usage: %s mnist-fc mnist-fc-f32.gguf data/MNIST/raw/train-images-idx3-ubyte data/MNIST/raw/train-labels-idx1-ubyte\n", argv[0]);
+    if (argc != 5 && argc != 6) {
+        fprintf(stderr, "Usage: %s mnist-fc mnist-fc-f32.gguf data/MNIST/raw/train-images-idx3-ubyte data/MNIST/raw/train-labels-idx1-ubyte [CPU/CUDA0]\n", argv[0]);
         exit(0);
     }
 
@@ -29,7 +29,7 @@ int main(int argc, char ** argv) {
         return 1;
     }
 
-    mnist_model model = mnist_model_init_random(argv[1]);
+    mnist_model model = mnist_model_init_random(argv[1], argc >= 6 ? argv[5] : "CPU");
 
     mnist_model_build(model, MNIST_NBATCH);
 

--- a/include/ggml-backend.h
+++ b/include/ggml-backend.h
@@ -66,6 +66,7 @@ extern "C" {
     // "offset" refers to the offset of the tensor data for setting/getting data
     GGML_API GGML_CALL void ggml_backend_tensor_set(      struct ggml_tensor * tensor, const void * data, size_t offset, size_t size);
     GGML_API GGML_CALL void ggml_backend_tensor_get(const struct ggml_tensor * tensor,       void * data, size_t offset, size_t size);
+    GGML_API GGML_CALL void ggml_backend_tensor_memset(   struct ggml_tensor * tensor,     uint8_t value, size_t offset, size_t size);
 
     GGML_API void ggml_backend_synchronize(ggml_backend_t backend);
 

--- a/include/ggml-backend.h
+++ b/include/ggml-backend.h
@@ -123,7 +123,7 @@ extern "C" {
     // The backend registry is a registry of all the available backends, and allows initializing backends in a generic way
 
     GGML_API size_t                     ggml_backend_reg_get_count(void);
-    GGML_API size_t                     ggml_backend_reg_find_by_name(const char * name);
+    GGML_API size_t                     ggml_backend_reg_find_by_name(const char * name); // returns index of backend with name, or SIZE_MAX if not found
     GGML_API ggml_backend_t             ggml_backend_reg_init_backend_from_str(const char * backend_str); // str is backend_name:params (params is optional)
     GGML_API const char *               ggml_backend_reg_get_name(size_t i);
     GGML_API ggml_backend_t             ggml_backend_reg_init_backend(size_t i, const char * params); // params is backend-specific

--- a/include/ggml.h
+++ b/include/ggml.h
@@ -2102,6 +2102,16 @@ extern "C" {
     GGML_API void ggml_build_forward_expand (struct ggml_cgraph * cgraph, struct ggml_tensor * tensor);
     GGML_API void ggml_build_backward_expand(struct ggml_context * ctx, struct ggml_cgraph * gf, struct ggml_cgraph * gb, bool keep);
 
+    GGML_API void ggml_build_opt_adam(
+            struct ggml_context * ctx,
+            struct ggml_cgraph  * gf,
+            struct ggml_cgraph  * gb,
+            float                 alpha,
+            float                 beta1,
+            float                 beta2,
+            float                 eps,
+            float                 l1);
+
     // graph allocation in a context
     GGML_API struct ggml_cgraph * ggml_new_graph         (struct ggml_context * ctx); // size = GGML_DEFAULT_GRAPH_SIZE, grads = false
     GGML_API struct ggml_cgraph * ggml_new_graph_custom  (struct ggml_context * ctx, size_t size, bool grads);

--- a/include/ggml.h
+++ b/include/ggml.h
@@ -2122,7 +2122,7 @@ extern "C" {
     GGML_API struct ggml_cgraph * ggml_graph_dup         (struct ggml_context * ctx, struct ggml_cgraph * cgraph);
     GGML_API struct ggml_cgraph   ggml_graph_view        (struct ggml_cgraph * cgraph, int i0, int i1);
     GGML_API void                 ggml_graph_cpy         (struct ggml_cgraph * src, struct ggml_cgraph * dst);
-    GGML_API void                 ggml_graph_reset       (struct ggml_cgraph * cgraph);  // zero grads
+    GGML_API void                 ggml_graph_reset       (struct ggml_cgraph * cgraph); // set regular grads + optimizer momenta to 0, set loss grad to 1
     GGML_API void                 ggml_graph_clear       (struct ggml_cgraph * cgraph);
 
     GGML_API size_t ggml_graph_overhead(void);

--- a/include/ggml.h
+++ b/include/ggml.h
@@ -2100,7 +2100,7 @@ extern "C" {
 
 
     GGML_API void ggml_build_forward_expand (struct ggml_cgraph * cgraph, struct ggml_tensor * tensor);
-    GGML_API void ggml_build_backward_expand(struct ggml_context * ctx, struct ggml_cgraph * gf, struct ggml_cgraph * gb, bool keep);
+    GGML_API void ggml_build_backward_expand(struct ggml_context * ctx, struct ggml_cgraph * gf, struct ggml_cgraph * gb, bool accumulate, bool keep);
 
     GGML_API void ggml_build_opt_adam(
             struct ggml_context * ctx,

--- a/include/ggml.h
+++ b/include/ggml.h
@@ -533,7 +533,7 @@ extern "C" {
 
         GGML_OP_CROSS_ENTROPY_LOSS,
         GGML_OP_CROSS_ENTROPY_LOSS_BACK,
-        GGML_OP_OPT_STEP_ADAM,
+        GGML_OP_OPT_STEP_ADAMW,
 
         GGML_OP_COUNT,
     };
@@ -2082,14 +2082,17 @@ extern "C" {
             struct ggml_tensor          * b,
             struct ggml_tensor          * c);
 
-    GGML_API struct ggml_tensor * ggml_opt_step_adam(
+    // AdamW optimizer step
+    // Paper: https://arxiv.org/pdf/1711.05101v3.pdf
+    // PyTorch: https://pytorch.org/docs/stable/generated/torch.optim.AdamW.html
+    GGML_API struct ggml_tensor * ggml_opt_step_adamw(
             struct ggml_context * ctx,
             struct ggml_tensor  * a,
             float                 alpha,
             float                 beta1,
             float                 beta2,
             float                 eps,
-            float                 l1);
+            float                 wd); // weight decay
 
     //
     // automatic differentiation
@@ -2102,7 +2105,7 @@ extern "C" {
     GGML_API void ggml_build_forward_expand (struct ggml_cgraph * cgraph, struct ggml_tensor * tensor);
     GGML_API void ggml_build_backward_expand(struct ggml_context * ctx, struct ggml_cgraph * gf, struct ggml_cgraph * gb, bool accumulate, bool keep);
 
-    GGML_API void ggml_build_opt_adam(
+    GGML_API void ggml_build_opt_adamw(
             struct ggml_context * ctx,
             struct ggml_cgraph  * gf,
             struct ggml_cgraph  * gb,
@@ -2110,7 +2113,7 @@ extern "C" {
             float                 beta1,
             float                 beta2,
             float                 eps,
-            float                 l1);
+            float                 wd); // weight decay
 
     // graph allocation in a context
     GGML_API struct ggml_cgraph * ggml_new_graph         (struct ggml_context * ctx); // size = GGML_DEFAULT_GRAPH_SIZE, grads = false

--- a/include/ggml.h
+++ b/include/ggml.h
@@ -2084,7 +2084,6 @@ extern "C" {
     GGML_API struct ggml_tensor * ggml_opt_step_adam(
             struct ggml_context * ctx,
             struct ggml_tensor  * a,
-            float                 sched,
             float                 alpha,
             float                 beta1,
             float                 beta2,

--- a/include/ggml.h
+++ b/include/ggml.h
@@ -574,6 +574,7 @@ extern "C" {
         GGML_TENSOR_FLAG_INPUT  = 1,
         GGML_TENSOR_FLAG_OUTPUT = 2,
         GGML_TENSOR_FLAG_PARAM  = 4,
+        GGML_TENSOR_FLAG_LOSS   = 8,
     };
 
     // ggml object
@@ -2094,9 +2095,8 @@ extern "C" {
     // automatic differentiation
     //
 
-    GGML_API void ggml_set_param(
-            struct ggml_context * ctx,
-            struct ggml_tensor  * tensor);
+    GGML_API void ggml_set_param(struct ggml_context * ctx, struct ggml_tensor * tensor);
+    GGML_API void ggml_set_loss(struct ggml_tensor * tensor);
 
 
     GGML_API void ggml_build_forward_expand (struct ggml_cgraph * cgraph, struct ggml_tensor * tensor);

--- a/include/ggml.h
+++ b/include/ggml.h
@@ -570,11 +570,13 @@ extern "C" {
         GGML_LOG_LEVEL_DEBUG = 5
     };
 
+    // this tensor...
     enum ggml_tensor_flag {
-        GGML_TENSOR_FLAG_INPUT  = 1,
-        GGML_TENSOR_FLAG_OUTPUT = 2,
-        GGML_TENSOR_FLAG_PARAM  = 4,
-        GGML_TENSOR_FLAG_LOSS   = 8,
+        GGML_TENSOR_FLAG_INPUT    =  1, // ...is an input for the GGML comptue graph
+        GGML_TENSOR_FLAG_OUTPUT   =  2, // ...is an output for the GGML comptue graph
+        GGML_TENSOR_FLAG_PARAM    =  4, // ...contains trainable parameters
+        GGML_TENSOR_FLAG_GRAD_ACC =  8, // ...is an accumulator for gradients
+        GGML_TENSOR_FLAG_LOSS     = 16, // ...defines loss for numerical optimization (multiple loss tensors add up)
     };
 
     // ggml object

--- a/include/ggml.h
+++ b/include/ggml.h
@@ -533,6 +533,7 @@ extern "C" {
 
         GGML_OP_CROSS_ENTROPY_LOSS,
         GGML_OP_CROSS_ENTROPY_LOSS_BACK,
+        GGML_OP_OPT_STEP_ADAM,
 
         GGML_OP_COUNT,
     };
@@ -2079,6 +2080,11 @@ extern "C" {
             struct ggml_tensor          * a,
             struct ggml_tensor          * b,
             struct ggml_tensor          * c);
+
+    GGML_API struct ggml_tensor * ggml_opt_step_adam(
+            struct ggml_context * ctx,
+            struct ggml_tensor  * a,
+            float                 alpha);
 
     //
     // automatic differentiation

--- a/include/ggml.h
+++ b/include/ggml.h
@@ -2084,7 +2084,11 @@ extern "C" {
     GGML_API struct ggml_tensor * ggml_opt_step_adam(
             struct ggml_context * ctx,
             struct ggml_tensor  * a,
-            float                 alpha);
+            float                 sched,
+            float                 alpha,
+            float                 beta1,
+            float                 beta2,
+            float                 eps);
 
     //
     // automatic differentiation

--- a/include/ggml.h
+++ b/include/ggml.h
@@ -2087,7 +2087,8 @@ extern "C" {
             float                 alpha,
             float                 beta1,
             float                 beta2,
-            float                 eps);
+            float                 eps,
+            float                 l1);
 
     //
     // automatic differentiation

--- a/include/ggml.h
+++ b/include/ggml.h
@@ -572,11 +572,10 @@ extern "C" {
 
     // this tensor...
     enum ggml_tensor_flag {
-        GGML_TENSOR_FLAG_INPUT    =  1, // ...is an input for the GGML comptue graph
-        GGML_TENSOR_FLAG_OUTPUT   =  2, // ...is an output for the GGML comptue graph
-        GGML_TENSOR_FLAG_PARAM    =  4, // ...contains trainable parameters
-        GGML_TENSOR_FLAG_GRAD_ACC =  8, // ...is an accumulator for gradients
-        GGML_TENSOR_FLAG_LOSS     = 16, // ...defines loss for numerical optimization (multiple loss tensors add up)
+        GGML_TENSOR_FLAG_INPUT    = 1, // ...is an input for the GGML comptue graph
+        GGML_TENSOR_FLAG_OUTPUT   = 2, // ...is an output for the GGML comptue graph
+        GGML_TENSOR_FLAG_PARAM    = 4, // ...contains trainable parameters
+        GGML_TENSOR_FLAG_LOSS     = 8, // ...defines loss for numerical optimization (multiple loss tensors add up)
     };
 
     // ggml object

--- a/include/ggml.h
+++ b/include/ggml.h
@@ -572,8 +572,8 @@ extern "C" {
 
     // this tensor...
     enum ggml_tensor_flag {
-        GGML_TENSOR_FLAG_INPUT    = 1, // ...is an input for the GGML comptue graph
-        GGML_TENSOR_FLAG_OUTPUT   = 2, // ...is an output for the GGML comptue graph
+        GGML_TENSOR_FLAG_INPUT    = 1, // ...is an input for the GGML compute graph
+        GGML_TENSOR_FLAG_OUTPUT   = 2, // ...is an output for the GGML compute graph
         GGML_TENSOR_FLAG_PARAM    = 4, // ...contains trainable parameters
         GGML_TENSOR_FLAG_LOSS     = 8, // ...defines loss for numerical optimization (multiple loss tensors add up)
     };

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -284,7 +284,7 @@ if (GGML_CUDA)
             if (GGML_CUDA_F16 OR GGML_CUDA_DMMV_F16)
                 set(CMAKE_CUDA_ARCHITECTURES "60;61;70;75")
             else()
-                set(CMAKE_CUDA_ARCHITECTURES "52;61;70;75")
+                set(CMAKE_CUDA_ARCHITECTURES "86")
                 #set(CMAKE_CUDA_ARCHITECTURES "OFF") # use this to compile much faster, but only F16 models work
             endif()
         endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -284,7 +284,7 @@ if (GGML_CUDA)
             if (GGML_CUDA_F16 OR GGML_CUDA_DMMV_F16)
                 set(CMAKE_CUDA_ARCHITECTURES "60;61;70;75")
             else()
-                set(CMAKE_CUDA_ARCHITECTURES "86")
+                set(CMAKE_CUDA_ARCHITECTURES "52;61;70;75")
                 #set(CMAKE_CUDA_ARCHITECTURES "OFF") # use this to compile much faster, but only F16 models work
             endif()
         endif()

--- a/src/ggml-backend-impl.h
+++ b/src/ggml-backend-impl.h
@@ -38,15 +38,16 @@ extern "C" {
     typedef void * ggml_backend_buffer_context_t;
 
     struct ggml_backend_buffer_i {
-        const char * (*GGML_CALL get_name)   (ggml_backend_buffer_t buffer);
-        void         (*GGML_CALL free_buffer)(ggml_backend_buffer_t buffer);
-        void *       (*GGML_CALL get_base)   (ggml_backend_buffer_t buffer);
-        void         (*GGML_CALL init_tensor)(ggml_backend_buffer_t buffer, struct ggml_tensor * tensor);
-        void         (*GGML_CALL set_tensor) (ggml_backend_buffer_t buffer,       struct ggml_tensor * tensor, const void * data, size_t offset, size_t size);
-        void         (*GGML_CALL get_tensor) (ggml_backend_buffer_t buffer, const struct ggml_tensor * tensor,       void * data, size_t offset, size_t size);
-        bool         (*GGML_CALL cpy_tensor) (ggml_backend_buffer_t buffer, const struct ggml_tensor * src, struct ggml_tensor * dst); // dst is in the buffer, src may be in any buffer
-        void         (*GGML_CALL clear)      (ggml_backend_buffer_t buffer, uint8_t value);
-        void         (*GGML_CALL reset)      (ggml_backend_buffer_t buffer); // reset any internal state due to tensor initialization, such as tensor extras
+        const char * (*GGML_CALL get_name)      (ggml_backend_buffer_t buffer);
+        void         (*GGML_CALL free_buffer)   (ggml_backend_buffer_t buffer);
+        void *       (*GGML_CALL get_base)      (ggml_backend_buffer_t buffer);
+        void         (*GGML_CALL init_tensor)   (ggml_backend_buffer_t buffer, struct ggml_tensor * tensor);
+        void         (*GGML_CALL memset_tensor) (ggml_backend_buffer_t buffer,       struct ggml_tensor * tensor,     uint8_t value, size_t offset, size_t size);
+        void         (*GGML_CALL set_tensor)    (ggml_backend_buffer_t buffer,       struct ggml_tensor * tensor, const void * data, size_t offset, size_t size);
+        void         (*GGML_CALL get_tensor)    (ggml_backend_buffer_t buffer, const struct ggml_tensor * tensor,       void * data, size_t offset, size_t size);
+        bool         (*GGML_CALL cpy_tensor)    (ggml_backend_buffer_t buffer, const struct ggml_tensor * src, struct ggml_tensor * dst); // dst is in the buffer, src may be in any buffer
+        void         (*GGML_CALL clear)         (ggml_backend_buffer_t buffer, uint8_t value);
+        void         (*GGML_CALL reset)         (ggml_backend_buffer_t buffer); // reset any internal state due to tensor initialization, such as tensor extras
     };
 
     struct ggml_backend_buffer {

--- a/src/ggml-backend.c
+++ b/src/ggml-backend.c
@@ -256,6 +256,8 @@ GGML_API GGML_CALL void ggml_backend_tensor_memset(struct ggml_tensor * tensor, 
     if (!size) {
         return;
     }
+    
+    GGML_ASSERT(buf->iface.memset_tensor != NULL && "memset not supported by backend buffer");
 
     buf->iface.memset_tensor(buf, tensor, value, offset, size);
 }

--- a/src/ggml-backend.c
+++ b/src/ggml-backend.c
@@ -246,6 +246,20 @@ GGML_CALL void ggml_backend_tensor_get(const struct ggml_tensor * tensor, void *
     buf->iface.get_tensor(buf, tensor, data, offset, size);
 }
 
+GGML_API GGML_CALL void ggml_backend_tensor_memset(struct ggml_tensor * tensor, uint8_t value, size_t offset, size_t size) {
+    ggml_backend_buffer_t buf = tensor->view_src ? tensor->view_src->buffer : tensor->buffer;
+
+    GGML_ASSERT(buf != NULL && "tensor buffer not set");
+    GGML_ASSERT(tensor->data != NULL && "tensor not allocated");
+    GGML_ASSERT(offset + size <= ggml_nbytes(tensor) && "tensor write out of bounds");
+
+    if (!size) {
+        return;
+    }
+
+    buf->iface.memset_tensor(buf, tensor, value, offset, size);
+}
+
 void ggml_backend_synchronize(ggml_backend_t backend) {
     if (backend->iface.synchronize == NULL) {
         return;
@@ -569,6 +583,12 @@ GGML_CALL static void ggml_backend_cpu_buffer_free_buffer(ggml_backend_buffer_t 
     free(buffer->context);
 }
 
+GGML_CALL static void ggml_backend_cpu_buffer_memset_tensor(ggml_backend_buffer_t buffer, struct ggml_tensor * tensor, uint8_t value, size_t offset, size_t size) {
+    memset((char *)tensor->data + offset, value, size);
+
+    GGML_UNUSED(buffer);
+}
+
 GGML_CALL static void ggml_backend_cpu_buffer_set_tensor(ggml_backend_buffer_t buffer, struct ggml_tensor * tensor, const void * data, size_t offset, size_t size) {
     memcpy((char *)tensor->data + offset, data, size);
 
@@ -600,6 +620,7 @@ static struct ggml_backend_buffer_i cpu_backend_buffer_i = {
     /* .free_buffer     = */ ggml_backend_cpu_buffer_free_buffer,
     /* .get_base        = */ ggml_backend_cpu_buffer_get_base,
     /* .init_tensor     = */ NULL, // no initialization required
+    /* .memset_tensor   = */ ggml_backend_cpu_buffer_memset_tensor,
     /* .set_tensor      = */ ggml_backend_cpu_buffer_set_tensor,
     /* .get_tensor      = */ ggml_backend_cpu_buffer_get_tensor,
     /* .cpy_tensor      = */ ggml_backend_cpu_buffer_cpy_tensor,
@@ -613,6 +634,7 @@ static struct ggml_backend_buffer_i cpu_backend_buffer_i_from_ptr = {
     /* .free_buffer     = */ NULL, // ptr is not owned by the buffer, so it does not need to be freed
     /* .get_base        = */ ggml_backend_cpu_buffer_get_base,
     /* .init_tensor     = */ NULL, // no initialization required
+    /* .memset_tensor   = */ ggml_backend_cpu_buffer_memset_tensor,
     /* .set_tensor      = */ ggml_backend_cpu_buffer_set_tensor,
     /* .get_tensor      = */ ggml_backend_cpu_buffer_get_tensor,
     /* .cpy_tensor      = */ ggml_backend_cpu_buffer_cpy_tensor,
@@ -980,6 +1002,7 @@ static struct ggml_backend_buffer_i ggml_backend_multi_buffer_context_interface(
         /* .free_buffer     = */ ggml_backend_multi_buffer_free_buffer,
         /* .get_base        = */ NULL,
         /* .init_tensor     = */ NULL,
+        /* .memset_tensor   = */ NULL,
         /* .set_tensor      = */ NULL,
         /* .get_tensor      = */ NULL,
         /* .cpy_tensor      = */ NULL,

--- a/src/ggml-cann.cpp
+++ b/src/ggml-cann.cpp
@@ -1036,6 +1036,7 @@ static ggml_backend_buffer_i ggml_backend_cann_buffer_interface = {
     /* .free_buffer     = */ ggml_backend_cann_buffer_free_buffer,
     /* .get_base        = */ ggml_backend_cann_buffer_get_base,
     /* .init_tensor     = */ ggml_backend_cann_buffer_init_tensor,
+    /* .memset_tensor   = */ NULL,
     /* .set_tensor      = */ ggml_backend_cann_buffer_set_tensor,
     /* .get_tensor      = */ ggml_backend_cann_buffer_get_tensor,
     /* .cpy_tensor      = */ ggml_backend_cann_buffer_cpy_tensor,

--- a/src/ggml-cuda.cu
+++ b/src/ggml-cuda.cu
@@ -2334,6 +2334,9 @@ static bool ggml_cuda_compute_forward(ggml_backend_cuda_context & ctx, struct gg
         case GGML_OP_CROSS_ENTROPY_LOSS:
             ggml_cuda_cross_entropy_loss(ctx, dst);
             break;
+        case GGML_OP_CROSS_ENTROPY_LOSS_BACK:
+            ggml_cuda_cross_entropy_loss_back(ctx, dst);
+            break;
         default:
             return false;
     }
@@ -2941,9 +2944,10 @@ GGML_CALL static bool ggml_backend_cuda_supports_op(ggml_backend_t backend, cons
             }
             return ggml_cuda_info().devices[cuda_ctx->device].cc >= CC_VOLTA &&
                 op->src[1]->type == GGML_TYPE_F16 && op->src[2]->type == GGML_TYPE_F16;
-        case GGML_OP_CROSS_ENTROPY_LOSS:
-            return true;
 #endif // defined(GGML_USE_HIPBLAS) && defined(__HIP_PLATFORM_AMD__)
+        case GGML_OP_CROSS_ENTROPY_LOSS:
+        case GGML_OP_CROSS_ENTROPY_LOSS_BACK:
+            return true;
         default:
             return false;
     }

--- a/src/ggml-cuda.cu
+++ b/src/ggml-cuda.cu
@@ -2900,7 +2900,7 @@ GGML_CALL static bool ggml_backend_cuda_supports_op(ggml_backend_t backend, cons
                 return src0_type != GGML_TYPE_I32 && src0_type != GGML_TYPE_I16;
             } break;
         case GGML_OP_REPEAT_BACK:
-                return op->type == GGML_TYPE_F32 && op->ne[0] == op->src[0]->ne[0] && op->ne[1] == 1 && op->src[0]->ne[2] == 1 && op->src[0]->ne[3] == 1;
+                return op->type == GGML_TYPE_F32 && op->src[0]->ne[3] == 1;
         case GGML_OP_CONCAT:
             {
                 ggml_type src0_type = op->src[0]->type;

--- a/src/ggml-cuda.cu
+++ b/src/ggml-cuda.cu
@@ -21,7 +21,7 @@
 #include "ggml-cuda/mmq.cuh"
 #include "ggml-cuda/mmvq.cuh"
 #include "ggml-cuda/norm.cuh"
-#include "ggml-cuda/opt-step-adam.cuh"
+#include "ggml-cuda/opt-step-adamw.cuh"
 #include "ggml-cuda/out-prod.cuh"
 #include "ggml-cuda/pad.cuh"
 #include "ggml-cuda/pool2d.cuh"
@@ -2348,8 +2348,8 @@ static bool ggml_cuda_compute_forward(ggml_backend_cuda_context & ctx, struct gg
         case GGML_OP_CROSS_ENTROPY_LOSS_BACK:
             ggml_cuda_cross_entropy_loss_back(ctx, dst);
             break;
-        case GGML_OP_OPT_STEP_ADAM:
-            ggml_cuda_opt_step_adam(ctx, dst);
+        case GGML_OP_OPT_STEP_ADAMW:
+            ggml_cuda_opt_step_adamw(ctx, dst);
             break;
         default:
             return false;
@@ -2970,7 +2970,7 @@ GGML_CALL static bool ggml_backend_cuda_supports_op(ggml_backend_t backend, cons
 #endif // defined(GGML_USE_HIPBLAS) && defined(__HIP_PLATFORM_AMD__)
         case GGML_OP_CROSS_ENTROPY_LOSS:
         case GGML_OP_CROSS_ENTROPY_LOSS_BACK:
-        case GGML_OP_OPT_STEP_ADAM:
+        case GGML_OP_OPT_STEP_ADAMW:
             return true;
         default:
             return false;

--- a/src/ggml-cuda.cu
+++ b/src/ggml-cuda.cu
@@ -493,6 +493,14 @@ GGML_CALL static void ggml_backend_cuda_buffer_init_tensor(ggml_backend_buffer_t
     }
 }
 
+GGML_CALL static void ggml_backend_cuda_buffer_memset_tensor(ggml_backend_buffer_t buffer, ggml_tensor * tensor, uint8_t value, size_t offset, size_t size) {
+    ggml_backend_cuda_buffer_context * ctx = (ggml_backend_cuda_buffer_context *)buffer->context;
+
+    ggml_cuda_set_device(ctx->device);
+    CUDA_CHECK(cudaMemsetAsync((char *)tensor->data + offset, value, size, cudaStreamPerThread));
+    CUDA_CHECK(cudaStreamSynchronize(cudaStreamPerThread));
+}
+
 GGML_CALL static void ggml_backend_cuda_buffer_set_tensor(ggml_backend_buffer_t buffer, ggml_tensor * tensor, const void * data, size_t offset, size_t size) {
     ggml_backend_cuda_buffer_context * ctx = (ggml_backend_cuda_buffer_context *)buffer->context;
 
@@ -544,6 +552,7 @@ static ggml_backend_buffer_i ggml_backend_cuda_buffer_interface = {
     /* .free_buffer     = */ ggml_backend_cuda_buffer_free_buffer,
     /* .get_base        = */ ggml_backend_cuda_buffer_get_base,
     /* .init_tensor     = */ ggml_backend_cuda_buffer_init_tensor,
+    /* .memset_tensor   = */ ggml_backend_cuda_buffer_memset_tensor,
     /* .set_tensor      = */ ggml_backend_cuda_buffer_set_tensor,
     /* .get_tensor      = */ ggml_backend_cuda_buffer_get_tensor,
     /* .cpy_tensor      = */ ggml_backend_cuda_buffer_cpy_tensor,
@@ -860,6 +869,7 @@ static struct ggml_backend_buffer_i ggml_backend_cuda_split_buffer_interface = {
     /* .free_buffer     = */ ggml_backend_cuda_split_buffer_free_buffer,
     /* .get_base        = */ ggml_backend_cuda_split_buffer_get_base,
     /* .init_tensor     = */ ggml_backend_cuda_split_buffer_init_tensor,
+    /* .memset_tensor   = */ NULL,
     /* .set_tensor      = */ ggml_backend_cuda_split_buffer_set_tensor,
     /* .get_tensor      = */ ggml_backend_cuda_split_buffer_get_tensor,
     /* .cpy_tensor      = */ NULL,

--- a/src/ggml-cuda.cu
+++ b/src/ggml-cuda.cu
@@ -21,6 +21,8 @@
 #include "ggml-cuda/mmq.cuh"
 #include "ggml-cuda/mmvq.cuh"
 #include "ggml-cuda/norm.cuh"
+#include "ggml-cuda/opt-step-adam.cuh"
+#include "ggml-cuda/out-prod.cuh"
 #include "ggml-cuda/pad.cuh"
 #include "ggml-cuda/pool2d.cuh"
 #include "ggml-cuda/quantize.cuh"
@@ -2178,6 +2180,9 @@ static bool ggml_cuda_compute_forward(ggml_backend_cuda_context & ctx, struct gg
         case GGML_OP_REPEAT:
             ggml_cuda_op_repeat(ctx, dst);
             break;
+        case GGML_OP_REPEAT_BACK:
+            ggml_cuda_op_repeat_back(ctx, dst);
+            break;
         case GGML_OP_GET_ROWS:
             ggml_cuda_op_get_rows(ctx, dst);
             break;
@@ -2210,6 +2215,9 @@ static bool ggml_cuda_compute_forward(ggml_backend_cuda_context & ctx, struct gg
             switch (ggml_get_unary_op(dst)) {
                 case GGML_UNARY_OP_NEG:
                     ggml_cuda_op_neg(ctx, dst);
+                    break;
+                case GGML_UNARY_OP_STEP:
+                    ggml_cuda_op_step(ctx, dst);
                     break;
                 case GGML_UNARY_OP_GELU:
                     ggml_cuda_op_gelu(ctx, dst);
@@ -2277,6 +2285,9 @@ static bool ggml_cuda_compute_forward(ggml_backend_cuda_context & ctx, struct gg
         case GGML_OP_MUL_MAT_ID:
             ggml_cuda_mul_mat_id(ctx, dst);
             break;
+        case GGML_OP_OUT_PROD:
+            ggml_cuda_out_prod(ctx, dst);
+            break;
         case GGML_OP_SCALE:
             ggml_cuda_op_scale(ctx, dst);
             break;
@@ -2336,6 +2347,9 @@ static bool ggml_cuda_compute_forward(ggml_backend_cuda_context & ctx, struct gg
             break;
         case GGML_OP_CROSS_ENTROPY_LOSS_BACK:
             ggml_cuda_cross_entropy_loss_back(ctx, dst);
+            break;
+        case GGML_OP_OPT_STEP_ADAM:
+            ggml_cuda_opt_step_adam(ctx, dst);
             break;
         default:
             return false;
@@ -2770,6 +2784,7 @@ GGML_CALL static bool ggml_backend_cuda_supports_op(ggml_backend_t backend, cons
         case GGML_OP_UNARY:
             switch (ggml_get_unary_op(op)) {
                 case GGML_UNARY_OP_NEG:
+                case GGML_UNARY_OP_STEP:
                 case GGML_UNARY_OP_GELU:
                 case GGML_UNARY_OP_SILU:
                 case GGML_UNARY_OP_RELU:
@@ -2822,6 +2837,8 @@ GGML_CALL static bool ggml_backend_cuda_supports_op(ggml_backend_t backend, cons
                         return false;
                 }
             } break;
+        case GGML_OP_OUT_PROD:
+            return op->type == GGML_TYPE_F32 && op->src[0]->type == GGML_TYPE_F32 && op->src[1]->type == GGML_TYPE_F32 && op->ne[2] == 1 && op->ne[3] == 1;
         case GGML_OP_GET_ROWS:
             {
                 switch (op->src[0]->type) {
@@ -2878,6 +2895,12 @@ GGML_CALL static bool ggml_backend_cuda_supports_op(ggml_backend_t backend, cons
             } break;
         case GGML_OP_DUP:
         case GGML_OP_REPEAT:
+            {
+                ggml_type src0_type = op->src[0]->type;
+                return src0_type != GGML_TYPE_I32 && src0_type != GGML_TYPE_I16;
+            } break;
+        case GGML_OP_REPEAT_BACK:
+                return op->type == GGML_TYPE_F32 && op->ne[0] == op->src[0]->ne[0] && op->ne[1] == 1 && op->src[0]->ne[2] == 1 && op->src[0]->ne[3] == 1;
         case GGML_OP_CONCAT:
             {
                 ggml_type src0_type = op->src[0]->type;
@@ -2947,6 +2970,7 @@ GGML_CALL static bool ggml_backend_cuda_supports_op(ggml_backend_t backend, cons
 #endif // defined(GGML_USE_HIPBLAS) && defined(__HIP_PLATFORM_AMD__)
         case GGML_OP_CROSS_ENTROPY_LOSS:
         case GGML_OP_CROSS_ENTROPY_LOSS_BACK:
+        case GGML_OP_OPT_STEP_ADAM:
             return true;
         default:
             return false;

--- a/src/ggml-cuda/binbcast.cuh
+++ b/src/ggml-cuda/binbcast.cuh
@@ -5,3 +5,5 @@ void ggml_cuda_op_add(ggml_backend_cuda_context & ctx, ggml_tensor * dst);
 void ggml_cuda_op_sub(ggml_backend_cuda_context & ctx, ggml_tensor * dst);
 void ggml_cuda_op_mul(ggml_backend_cuda_context & ctx, ggml_tensor * dst);
 void ggml_cuda_op_div(ggml_backend_cuda_context & ctx, ggml_tensor * dst);
+
+void ggml_cuda_op_repeat_back(ggml_backend_cuda_context & ctx, ggml_tensor * dst);

--- a/src/ggml-cuda/cross-entropy-loss.cu
+++ b/src/ggml-cuda/cross-entropy-loss.cu
@@ -71,6 +71,32 @@ static __global__ void cross_entropy_loss_f32(const float * logits, const float 
     dst[blockIdx.x] = loss;
 }
 
+static __global__ void cross_entropy_loss_back_f32(const float * logits, const float * labels, const float * loss, float * dst, const int nclasses) {
+    extern __shared__ float tmp[];
+
+    float maxval = -INFINITY;
+    for (int i = threadIdx.x; i < nclasses; i += WARP_SIZE) {
+        const float val = logits[blockIdx.x*nclasses + i];
+        maxval = fmaxf(maxval, val);
+        tmp[i] = val;
+    }
+    maxval = warp_reduce_max(maxval);
+
+    float sum = 0.0f;
+    for (int i = threadIdx.x; i < nclasses; i += WARP_SIZE) {
+        const float val = expf(tmp[i] - maxval);
+        sum += val;
+        tmp[i] = val;
+    }
+    sum = warp_reduce_sum(sum);
+    const float sm_scale = 1.0f/sum;
+
+    const float d_by_nrows = *loss/gridDim.x;
+    for (int i = threadIdx.x; i < nclasses; i += WARP_SIZE) {
+        dst[blockIdx.x*nclasses + i] = (tmp[i]*sm_scale - labels[blockIdx.x*nclasses + i])*d_by_nrows;
+    }
+}
+
 void ggml_cuda_cross_entropy_loss(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     const ggml_tensor * src0 = dst->src[0];
     const ggml_tensor * src1 = dst->src[1];
@@ -103,4 +129,38 @@ void ggml_cuda_cross_entropy_loss(ggml_backend_cuda_context & ctx, ggml_tensor *
 
     // Combine results from individual blocks:
     sum_f32_cuda(pool, dst_tmp.ptr, dst_d, blocks_num.x, stream);
+}
+
+void ggml_cuda_cross_entropy_loss_back(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
+    const ggml_tensor * src0 = dst->src[0];
+    const ggml_tensor * src1 = dst->src[1];
+    const ggml_tensor * opt0 = dst->src[2];
+
+    GGML_ASSERT(src0->type == GGML_TYPE_F32);
+    GGML_ASSERT(src1->type == GGML_TYPE_F32);
+    GGML_ASSERT(opt0->type == GGML_TYPE_F32);
+    GGML_ASSERT( dst->type == GGML_TYPE_F32);
+
+    GGML_ASSERT(ggml_is_contiguous(src0));
+    GGML_ASSERT(ggml_is_contiguous(src1));
+    GGML_ASSERT(ggml_is_contiguous(opt0));
+    GGML_ASSERT(ggml_is_contiguous(dst));
+    GGML_ASSERT(ggml_are_same_shape(src0, src1));
+    GGML_ASSERT(ggml_are_same_shape(src0, dst));
+
+    const int64_t ne00  = src0->ne[0];
+    const int64_t nrows = ggml_nrows(src0);
+
+    const float * src0_d = (const float *) src0->data;
+    const float * src1_d = (const float *) src1->data;
+    const float * opt0_d = (const float *) opt0->data;
+    float       * dst_d  = (float       *) dst->data;
+
+    cudaStream_t stream = ctx.stream();
+
+    const dim3 blocks_dim(WARP_SIZE, 1, 1);
+    const dim3 blocks_num(nrows, 1, 1);
+    const int shmem = ne00*sizeof(float);
+
+    cross_entropy_loss_back_f32<<<blocks_num, blocks_dim, shmem, stream>>>(src0_d, src1_d, opt0_d, dst_d, ne00);
 }

--- a/src/ggml-cuda/cross-entropy-loss.cuh
+++ b/src/ggml-cuda/cross-entropy-loss.cuh
@@ -3,3 +3,5 @@
 #define CUDA_CROSS_ENTROPY_LOSS_BLOCK_SIZE 256
 
 void ggml_cuda_cross_entropy_loss(ggml_backend_cuda_context & ctx, ggml_tensor * dst);
+
+void ggml_cuda_cross_entropy_loss_back(ggml_backend_cuda_context & ctx, ggml_tensor * dst);

--- a/src/ggml-cuda/opt-step-adam.cu
+++ b/src/ggml-cuda/opt-step-adam.cu
@@ -4,8 +4,8 @@
 
 static __global__ void opt_step_adam_f32(
     float * __restrict__ x, const float * __restrict__ g, float * __restrict__ g_m, float * __restrict__ g_v, const int64_t k,
-    const float alpha, const float beta1, const float beta2, const float eps,
-    const float beta1h, const float beta2h, const float p_decay) {
+    const float alpha, const float beta1, const float beta2, const float eps, const float l1,
+    const float beta1h, const float beta2h) {
 
     const int64_t i = (int64_t) blockIdx.x*blockDim.x + threadIdx.x;
 
@@ -23,17 +23,17 @@ static __global__ void opt_step_adam_f32(
     const float mh =       gmi*beta1h;
     const float vh = sqrtf(gvi*beta2h) + eps;
 
-    x[i] = x[i]*(1.0f - p_decay) - mh/vh;
+    x[i] = x[i]*(1.0f - alpha*l1) - mh/vh;
 }
 
 static void opt_step_adam_f32_cuda(
     float * x, const float * g, float * g_m, float * g_v, const int64_t k,
-    const float alpha, const float beta1, const float beta2, const float eps,
-    const float beta1h, const float beta2h, const float p_decay, cudaStream_t stream) {
+    const float alpha, const float beta1, const float beta2, const float eps, const float l1,
+    const float beta1h, const float beta2h, cudaStream_t stream) {
 
     const dim3 block_dims(CUDA_OPT_STEP_ADAM_BLOCK_SIZE, 1, 1);
     const dim3 block_nums((k + CUDA_OPT_STEP_ADAM_BLOCK_SIZE - 1) / CUDA_OPT_STEP_ADAM_BLOCK_SIZE, 1, 1);
-    opt_step_adam_f32<<<block_nums, block_dims, 0, stream>>>(x, g, g_m, g_v, k, alpha, beta1, beta2, eps, beta1h, beta2h, p_decay);
+    opt_step_adam_f32<<<block_nums, block_dims, 0, stream>>>(x, g, g_m, g_v, k, alpha, beta1, beta2, eps, l1, beta1h, beta2h);
 }
 
 void ggml_cuda_opt_step_adam(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
@@ -68,10 +68,10 @@ void ggml_cuda_opt_step_adam(ggml_backend_cuda_context & ctx, ggml_tensor * dst)
     float   beta1; memcpy(&beta1, &dst->op_params[2], sizeof(float));
     float   beta2; memcpy(&beta2, &dst->op_params[3], sizeof(float));
     float   eps;   memcpy(&eps,   &dst->op_params[4], sizeof(float));
+    float   l1;    memcpy(&l1,    &dst->op_params[5], sizeof(float));
 
     const float beta1h  = alpha/(1.0f - powf(beta1, iter));
     const float beta2h  =  1.0f/(1.0f - powf(beta2, iter));
-    const float p_decay = 0.0f;
 
-    opt_step_adam_f32_cuda(src0_d, src0_grad_d, src0_grad_m_d, src0_grad_v_d, ne, alpha, beta1, beta2, eps, beta1h, beta2h, p_decay, stream);
+    opt_step_adam_f32_cuda(src0_d, src0_grad_d, src0_grad_m_d, src0_grad_v_d, ne, alpha, beta1, beta2, eps, l1, beta1h, beta2h, stream);
 }

--- a/src/ggml-cuda/opt-step-adam.cu
+++ b/src/ggml-cuda/opt-step-adam.cu
@@ -63,15 +63,18 @@ void ggml_cuda_opt_step_adam(ggml_backend_cuda_context & ctx, ggml_tensor * dst)
 
     const int64_t ne = ggml_nelements(src0);
 
-    int32_t iter;  memcpy(&iter,  &dst->op_params[0], sizeof(float));
-    float   alpha; memcpy(&alpha, &dst->op_params[1], sizeof(float));
-    float   beta1; memcpy(&beta1, &dst->op_params[2], sizeof(float));
-    float   beta2; memcpy(&beta2, &dst->op_params[3], sizeof(float));
-    float   eps;   memcpy(&eps,   &dst->op_params[4], sizeof(float));
-    float   l1;    memcpy(&l1,    &dst->op_params[5], sizeof(float));
+    int64_t iter;  memcpy(&iter,  &dst->op_params[0], sizeof(int64_t));
+    float   alpha; memcpy(&alpha, &dst->op_params[2], sizeof(float));
+    float   beta1; memcpy(&beta1, &dst->op_params[3], sizeof(float));
+    float   beta2; memcpy(&beta2, &dst->op_params[4], sizeof(float));
+    float   eps;   memcpy(&eps,   &dst->op_params[5], sizeof(float));
+    float   l1;    memcpy(&l1,    &dst->op_params[6], sizeof(float));
 
     const float beta1h  = alpha/(1.0f - powf(beta1, iter));
     const float beta2h  =  1.0f/(1.0f - powf(beta2, iter));
 
     opt_step_adam_f32_cuda(src0_d, src0_grad_d, src0_grad_m_d, src0_grad_v_d, ne, alpha, beta1, beta2, eps, l1, beta1h, beta2h, stream);
+
+    iter++;
+    memcpy(&dst->op_params[0], &iter, sizeof(int64_t));
 }

--- a/src/ggml-cuda/opt-step-adam.cu
+++ b/src/ggml-cuda/opt-step-adam.cu
@@ -1,0 +1,78 @@
+#include "opt-step-adam.cuh"
+
+#include <cstdint>
+
+static __global__ void opt_step_adam_f32(
+    float * __restrict__ x, const float * __restrict__ g, float * __restrict__ g_m, float * __restrict__ g_v, const int64_t k,
+    const float sched, const float alpha, const float beta1, const float beta2, const float eps,
+    const float beta1h, const float beta2h, const float p_decay) {
+
+    const int64_t i = (int64_t) blockIdx.x*blockDim.x + threadIdx.x;
+
+    if (i >= k) {
+        return;
+    }
+
+    const float gi = g[i];
+    const float gmi = g_m[i]*beta1 +    gi*(1.0f - beta1);
+    const float gvi = g_v[i]*beta2 + gi*gi*(1.0f - beta2);
+
+    g_m[i] = gmi;
+    g_v[i] = gvi;
+
+    const float mh =       gmi*beta1h;
+    const float vh = sqrtf(gvi*beta2h) + eps;
+
+    x[i] = x[i]*(1.0f - p_decay) - mh/vh;
+}
+
+static void opt_step_adam_f32_cuda(
+    float * x, const float * g, float * g_m, float * g_v, const int64_t k,
+    const float sched, const float alpha, const float beta1, const float beta2, const float eps,
+    const float beta1h, const float beta2h, const float p_decay, cudaStream_t stream) {
+
+    const dim3 block_dims(CUDA_OPT_STEP_ADAM_BLOCK_SIZE, 1, 1);
+    const dim3 block_nums((k + CUDA_OPT_STEP_ADAM_BLOCK_SIZE - 1) / CUDA_OPT_STEP_ADAM_BLOCK_SIZE, 1, 1);
+    opt_step_adam_f32<<<block_nums, block_dims, 0, stream>>>(x, g, g_m, g_v, k, sched, alpha, beta1, beta2, eps, beta1h, beta2h, p_decay);
+}
+
+void ggml_cuda_opt_step_adam(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
+    const ggml_tensor * src0        = dst->src[0];
+    const ggml_tensor * src0_grad   = dst->src[1];
+    const ggml_tensor * src0_grad_m = dst->src[2];
+    const ggml_tensor * src0_grad_v = dst->src[3];
+
+    GGML_ASSERT(src0->type        == GGML_TYPE_F32);
+    GGML_ASSERT(src0_grad->type   == GGML_TYPE_F32);
+    GGML_ASSERT(src0_grad_m->type == GGML_TYPE_F32);
+    GGML_ASSERT(src0_grad_v->type == GGML_TYPE_F32);
+    GGML_ASSERT(ggml_is_contiguous(src0));
+    GGML_ASSERT(ggml_is_contiguous(src0_grad));
+    GGML_ASSERT(ggml_is_contiguous(src0_grad_m));
+    GGML_ASSERT(ggml_is_contiguous(src0_grad_v));
+    GGML_ASSERT(ggml_are_same_shape(src0, src0_grad));
+    GGML_ASSERT(ggml_are_same_shape(src0, src0_grad_m));
+    GGML_ASSERT(ggml_are_same_shape(src0, src0_grad_v));
+
+    float       * src0_d        = (float       *) src0->data;
+    const float * src0_grad_d   = (const float *) src0_grad->data;
+    float       * src0_grad_m_d = (float       *) src0_grad_m->data;
+    float       * src0_grad_v_d = (float       *) src0_grad_v->data;
+
+    cudaStream_t stream = ctx.stream();
+
+    const int64_t ne = ggml_nelements(src0);
+
+    int32_t iter;  memcpy(&iter,  &dst->op_params[0], sizeof(float));
+    float   sched; memcpy(&sched, &dst->op_params[1], sizeof(float));
+    float   alpha; memcpy(&alpha, &dst->op_params[2], sizeof(float));
+    float   beta1; memcpy(&beta1, &dst->op_params[3], sizeof(float));
+    float   beta2; memcpy(&beta2, &dst->op_params[4], sizeof(float));
+    float   eps;   memcpy(&eps,   &dst->op_params[5], sizeof(float));
+
+    const float beta1h  = alpha*sched/(1.0f - powf(beta1, iter));
+    const float beta2h  =        1.0f/(1.0f - powf(beta2, iter));
+    const float p_decay = 0.0f;
+
+    opt_step_adam_f32_cuda(src0_d, src0_grad_d, src0_grad_m_d, src0_grad_v_d, ne, sched, alpha, beta1, beta2, eps, beta1h, beta2h, p_decay, stream);
+}

--- a/src/ggml-cuda/opt-step-adam.cuh
+++ b/src/ggml-cuda/opt-step-adam.cuh
@@ -1,0 +1,5 @@
+#include "common.cuh"
+
+#define CUDA_OPT_STEP_ADAM_BLOCK_SIZE 256
+
+void ggml_cuda_opt_step_adam(ggml_backend_cuda_context & ctx, ggml_tensor * dst);

--- a/src/ggml-cuda/opt-step-adam.cuh
+++ b/src/ggml-cuda/opt-step-adam.cuh
@@ -1,5 +1,0 @@
-#include "common.cuh"
-
-#define CUDA_OPT_STEP_ADAM_BLOCK_SIZE 256
-
-void ggml_cuda_opt_step_adam(ggml_backend_cuda_context & ctx, ggml_tensor * dst);

--- a/src/ggml-cuda/opt-step-adamw.cu
+++ b/src/ggml-cuda/opt-step-adamw.cu
@@ -1,10 +1,10 @@
-#include "opt-step-adam.cuh"
+#include "opt-step-adamw.cuh"
 
 #include <cstdint>
 
-static __global__ void opt_step_adam_f32(
+static __global__ void opt_step_adamw_f32(
     float * __restrict__ x, const float * __restrict__ g, float * __restrict__ g_m, float * __restrict__ g_v, const int64_t k,
-    const float alpha, const float beta1, const float beta2, const float eps, const float l1,
+    const float alpha, const float beta1, const float beta2, const float eps, const float wd,
     const float beta1h, const float beta2h) {
 
     const int64_t i = (int64_t) blockIdx.x*blockDim.x + threadIdx.x;
@@ -23,20 +23,20 @@ static __global__ void opt_step_adam_f32(
     const float mh =       gmi*beta1h;
     const float vh = sqrtf(gvi*beta2h) + eps;
 
-    x[i] = x[i]*(1.0f - alpha*l1) - mh/vh;
+    x[i] = x[i]*(1.0f - alpha*wd) - mh/vh;
 }
 
-static void opt_step_adam_f32_cuda(
+static void opt_step_adamw_f32_cuda(
     float * x, const float * g, float * g_m, float * g_v, const int64_t k,
-    const float alpha, const float beta1, const float beta2, const float eps, const float l1,
+    const float alpha, const float beta1, const float beta2, const float eps, const float wd,
     const float beta1h, const float beta2h, cudaStream_t stream) {
 
-    const dim3 block_dims(CUDA_OPT_STEP_ADAM_BLOCK_SIZE, 1, 1);
-    const dim3 block_nums((k + CUDA_OPT_STEP_ADAM_BLOCK_SIZE - 1) / CUDA_OPT_STEP_ADAM_BLOCK_SIZE, 1, 1);
-    opt_step_adam_f32<<<block_nums, block_dims, 0, stream>>>(x, g, g_m, g_v, k, alpha, beta1, beta2, eps, l1, beta1h, beta2h);
+    const dim3 block_dims(CUDA_OPT_STEP_ADAMW_BLOCK_SIZE, 1, 1);
+    const dim3 block_nums((k + CUDA_OPT_STEP_ADAMW_BLOCK_SIZE - 1) / CUDA_OPT_STEP_ADAMW_BLOCK_SIZE, 1, 1);
+    opt_step_adamw_f32<<<block_nums, block_dims, 0, stream>>>(x, g, g_m, g_v, k, alpha, beta1, beta2, eps, wd, beta1h, beta2h);
 }
 
-void ggml_cuda_opt_step_adam(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
+void ggml_cuda_opt_step_adamw(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     const ggml_tensor * src0        = dst->src[0];
     const ggml_tensor * src0_grad   = dst->src[1];
     const ggml_tensor * src0_grad_m = dst->src[2];
@@ -68,12 +68,12 @@ void ggml_cuda_opt_step_adam(ggml_backend_cuda_context & ctx, ggml_tensor * dst)
     float   beta1; memcpy(&beta1, &dst->op_params[3], sizeof(float));
     float   beta2; memcpy(&beta2, &dst->op_params[4], sizeof(float));
     float   eps;   memcpy(&eps,   &dst->op_params[5], sizeof(float));
-    float   l1;    memcpy(&l1,    &dst->op_params[6], sizeof(float));
+    float   wd;    memcpy(&wd,    &dst->op_params[6], sizeof(float));
 
     const float beta1h  = alpha/(1.0f - powf(beta1, iter));
     const float beta2h  =  1.0f/(1.0f - powf(beta2, iter));
 
-    opt_step_adam_f32_cuda(src0_d, src0_grad_d, src0_grad_m_d, src0_grad_v_d, ne, alpha, beta1, beta2, eps, l1, beta1h, beta2h, stream);
+    opt_step_adamw_f32_cuda(src0_d, src0_grad_d, src0_grad_m_d, src0_grad_v_d, ne, alpha, beta1, beta2, eps, wd, beta1h, beta2h, stream);
 
     iter++;
     memcpy(&dst->op_params[0], &iter, sizeof(int64_t));

--- a/src/ggml-cuda/opt-step-adamw.cuh
+++ b/src/ggml-cuda/opt-step-adamw.cuh
@@ -1,0 +1,5 @@
+#include "common.cuh"
+
+#define CUDA_OPT_STEP_ADAMW_BLOCK_SIZE 256
+
+void ggml_cuda_opt_step_adamw(ggml_backend_cuda_context & ctx, ggml_tensor * dst);

--- a/src/ggml-cuda/out-prod.cu
+++ b/src/ggml-cuda/out-prod.cu
@@ -1,5 +1,4 @@
 #include "out-prod.cuh"
-#include "opt-step-adam.cuh"
 #include "vendors/cuda.h"
 
 #include <cstdint>

--- a/src/ggml-cuda/out-prod.cu
+++ b/src/ggml-cuda/out-prod.cu
@@ -1,0 +1,59 @@
+#include "opt-step-adam.cuh"
+#include "vendors/cuda.h"
+
+#include <cstdint>
+
+void ggml_cuda_out_prod(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
+    const ggml_tensor * src0 = dst->src[0];
+    const ggml_tensor * src1 = dst->src[1];
+
+    GGML_ASSERT(src0->type == GGML_TYPE_F32);
+    GGML_ASSERT(src1->type == GGML_TYPE_F32);
+    GGML_ASSERT(dst->type  == GGML_TYPE_F32);
+    GGML_ASSERT(ggml_is_contiguous(src0));
+    GGML_ASSERT(ggml_is_contiguous(dst));
+
+    const int64_t ne00 = src0->ne[0];
+    const int64_t ne01 = src0->ne[1];
+
+    const int64_t ne10 = src1->ne[0];
+    const int64_t ne11 = src1->ne[1];
+
+    GGML_ASSERT(ne01 == ne11);
+
+    const int64_t ne0 = dst->ne[0];
+    const int64_t ne1 = dst->ne[1];
+    const int64_t ne2 = dst->ne[2];
+    const int64_t ne3 = dst->ne[3];
+
+    GGML_ASSERT(ne0 == ne00);
+    GGML_ASSERT(ne1 == ne10);
+
+    GGML_ASSERT(ne2 == src0->ne[2]);
+    GGML_ASSERT(ne2 == src1->ne[2]);
+    GGML_ASSERT(ne3 == src0->ne[3]);
+    GGML_ASSERT(ne3 == src1->ne[3]);
+
+    const float * src0_d = (const float *) src0->data;
+    const float * src1_d = (const float *) src1->data;
+    float       *  dst_d = (float       *)  dst->data;
+
+    cudaStream_t   stream = ctx.stream();
+    cublasHandle_t handle = ctx.cublas_handle();
+
+    const float alpha = 1.0f;
+    const float beta = 0.0f;
+
+    GGML_ASSERT(ne2 == 1);
+    GGML_ASSERT(ne3 == 1);
+    CUBLAS_CHECK(cublasSetStream(handle, stream));
+
+    const cublasOperation_t src1_cublas_op = ggml_is_transposed(src1) ? CUBLAS_OP_N : CUBLAS_OP_T;
+    const int64_t           ldb            = ggml_is_transposed(src1) ? ne11        : ne10;
+    CUBLAS_CHECK(
+        cublasSgemm(handle, CUBLAS_OP_N, src1_cublas_op,
+                ne0, ne1, ne01,
+                &alpha, src0_d, ne00,
+                        src1_d, ldb,
+                &beta,  dst_d,  ne0));
+}

--- a/src/ggml-cuda/out-prod.cu
+++ b/src/ggml-cuda/out-prod.cu
@@ -1,3 +1,4 @@
+#include "out-prod.cuh"
 #include "opt-step-adam.cuh"
 #include "vendors/cuda.h"
 

--- a/src/ggml-cuda/out-prod.cuh
+++ b/src/ggml-cuda/out-prod.cuh
@@ -1,0 +1,3 @@
+#include "common.cuh"
+
+void ggml_cuda_out_prod(ggml_backend_cuda_context & ctx, ggml_tensor * dst);

--- a/src/ggml-cuda/unary.cuh
+++ b/src/ggml-cuda/unary.cuh
@@ -1,6 +1,7 @@
 #include "common.cuh"
 
 #define CUDA_NEG_BLOCK_SIZE 256
+#define CUDA_STEP_BLOCK_SIZE 256
 #define CUDA_GELU_BLOCK_SIZE 256
 #define CUDA_SILU_BLOCK_SIZE 256
 #define CUDA_TANH_BLOCK_SIZE 256
@@ -14,6 +15,8 @@
 #define CUDA_COS_BLOCK_SIZE 256
 
 void ggml_cuda_op_neg(ggml_backend_cuda_context & ctx, ggml_tensor * dst);
+
+void ggml_cuda_op_step(ggml_backend_cuda_context & ctx, ggml_tensor * dst);
 
 void ggml_cuda_op_gelu(ggml_backend_cuda_context & ctx, ggml_tensor * dst);
 

--- a/src/ggml-kompute.cpp
+++ b/src/ggml-kompute.cpp
@@ -1872,6 +1872,7 @@ static ggml_backend_buffer_i ggml_backend_kompute_buffer_i = {
     /* .free_buffer     = */ ggml_backend_kompute_buffer_free_buffer,
     /* .get_base        = */ ggml_backend_kompute_buffer_get_base,
     /* .init_tensor     = */ NULL,
+    /* .memset_tensor   = */ NULL,
     /* .set_tensor      = */ ggml_backend_kompute_buffer_set_tensor,
     /* .get_tensor      = */ ggml_backend_kompute_buffer_get_tensor,
     /* .cpy_tensor      = */ NULL,

--- a/src/ggml-metal.m
+++ b/src/ggml-metal.m
@@ -3165,6 +3165,7 @@ static struct ggml_backend_buffer_i ggml_backend_metal_buffer_i = {
     /* .free_buffer     = */ ggml_backend_metal_buffer_free_buffer,
     /* .get_base        = */ ggml_backend_metal_buffer_get_base,
     /* .init_tensor     = */ NULL,
+    /* .memset_tensor   = */ NULL,
     /* .set_tensor      = */ ggml_backend_metal_buffer_set_tensor,
     /* .get_tensor      = */ ggml_backend_metal_buffer_get_tensor,
     /* .cpy_tensor      = */ ggml_backend_metal_buffer_cpy_tensor,

--- a/src/ggml-rpc.cpp
+++ b/src/ggml-rpc.cpp
@@ -469,6 +469,7 @@ static ggml_backend_buffer_i ggml_backend_rpc_buffer_interface = {
     /* .free_buffer     = */ ggml_backend_rpc_buffer_free_buffer,
     /* .get_base        = */ ggml_backend_rpc_buffer_get_base,
     /* .init_tensor     = */ ggml_backend_rpc_buffer_init_tensor,
+    /* .memset_tensor   = */ NULL,
     /* .set_tensor      = */ ggml_backend_rpc_buffer_set_tensor,
     /* .get_tensor      = */ ggml_backend_rpc_buffer_get_tensor,
     /* .cpy_tensor      = */ ggml_backend_rpc_buffer_cpy_tensor,

--- a/src/ggml-sycl.cpp
+++ b/src/ggml-sycl.cpp
@@ -4318,6 +4318,7 @@ static struct ggml_backend_buffer_i ggml_backend_sycl_buffer_interface = {
     /* .free_buffer     = */ ggml_backend_sycl_buffer_free_buffer,
     /* .get_base        = */ ggml_backend_sycl_buffer_get_base,
     /* .init_tensor     = */ ggml_backend_sycl_buffer_init_tensor,
+    /* .memset_tensor   = */ NULL,
     /* .set_tensor      = */ ggml_backend_sycl_buffer_set_tensor,
     /* .get_tensor      = */ ggml_backend_sycl_buffer_get_tensor,
     /* .cpy_tensor      = */ ggml_backend_sycl_buffer_cpy_tensor,

--- a/src/ggml-vulkan.cpp
+++ b/src/ggml-vulkan.cpp
@@ -6221,6 +6221,7 @@ static ggml_backend_buffer_i ggml_backend_vk_buffer_interface = {
     /* .free_buffer     = */ ggml_backend_vk_buffer_free_buffer,
     /* .get_base        = */ ggml_backend_vk_buffer_get_base,
     /* .init_tensor     = */ ggml_backend_vk_buffer_init_tensor,
+    /* .memset_tensor   = */ NULL,
     /* .set_tensor      = */ ggml_backend_vk_buffer_set_tensor,
     /* .get_tensor      = */ ggml_backend_vk_buffer_get_tensor,
     /* .cpy_tensor      = */ ggml_backend_vk_buffer_cpy_tensor,

--- a/src/ggml.c
+++ b/src/ggml.c
@@ -21161,18 +21161,6 @@ static enum ggml_opt_result ggml_opt_adam(
     GGML_ASSERT(ggml_is_scalar(f));
     GGML_ASSERT(f->type == GGML_TYPE_F32);
 
-    // initialize
-    if (opt->just_initialized) {
-        ggml_set_zero(opt->adam.m);
-        ggml_set_zero(opt->adam.v);
-        if (opt->adam.pf) {
-            ggml_set_zero(opt->adam.pf);
-        }
-
-        opt->adam.n_no_improvement = 0;
-        opt->just_initialized = false;
-    }
-
     // these will store the parameters we want to optimize
     struct ggml_tensor * ps[GGML_MAX_PARAMS];
 
@@ -21245,6 +21233,12 @@ static enum ggml_opt_result ggml_opt_adam(
 
     opt->loss_before = opt->adam.fx_prev;
     opt->loss_after  = opt->adam.fx_prev;
+
+    // initialize
+    if (opt->just_initialized) {
+        opt->adam.n_no_improvement = 0;
+        opt->just_initialized = false;
+    }
 
     float * fx_best = &opt->adam.fx_best;
     float * fx_prev = &opt->adam.fx_prev;
@@ -21892,6 +21886,11 @@ GGML_API void ggml_opt_init(
                 opt->adam.pf = params.past > 0
                     ? ggml_new_tensor_1d(opt->ctx, GGML_TYPE_F32, params.past)
                     : NULL;
+                ggml_set_zero(opt->adam.m);
+                ggml_set_zero(opt->adam.v);
+                if (opt->adam.pf) {
+                    ggml_set_zero(opt->adam.pf);
+                }
             } break;
         case GGML_OPT_TYPE_LBFGS:
             {

--- a/src/ggml.c
+++ b/src/ggml.c
@@ -19141,18 +19141,29 @@ void ggml_build_backward_expand(struct ggml_context * ctx, struct ggml_cgraph * 
         }
     }
 
+    ggml_hash_set_free(&zero_table);
+}
+
+void ggml_build_opt_adam(
+        struct ggml_context * ctx,
+        struct ggml_cgraph  * gf,
+        struct ggml_cgraph  * gb,
+        float                 alpha,
+        float                 beta1,
+        float                 beta2,
+        float                 eps,
+        float                 l1) {
     for (int i = 0; i < gf->n_nodes; i++) {
         struct ggml_tensor * node = gf->nodes[i];
 
         if (node->flags & GGML_TENSOR_FLAG_PARAM) {
             GGML_PRINT_DEBUG("%s: found root node %p\n", __func__, (void *) node);
-            struct ggml_tensor * opt_step = ggml_opt_step_adam(ctx, node, 1e-3f, 0.9f, 0.999f, 1e-8f, 1e-3f);
+            struct ggml_tensor * opt_step = ggml_opt_step_adam(ctx, node, alpha, beta1, beta2, eps, l1);
             ggml_build_forward_expand(gb, opt_step);
         }
     }
-
-    ggml_hash_set_free(&zero_table);
 }
+
 
 static void * incr_ptr_aligned(void ** p, size_t size, size_t align) {
     void * ptr = *p;

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -3229,7 +3229,7 @@ static bool test_backend(ggml_backend_t backend, test_mode mode, const char * op
     test_cases.emplace_back(new test_conv_transpose_1d({3,2,1,1}, {3,1,2,1}, 1, 0, 1));
     test_cases.emplace_back(new test_conv_transpose_1d({2,1,1,1}, {3,1,1,1}, 1, 0, 1));
 
-    for (const int64_t & ne3 : {1, 3}) { // CUDA only supports ne3 == 1
+    for (const int64_t & ne3 : {1, 3}) { // CUDA backwards pass only supports ne3 == 1
         test_cases.emplace_back(new test_repeat(GGML_TYPE_F32, {10, 5, 4, ne3}, {1, 1, 1, 1}));
         test_cases.emplace_back(new test_repeat(GGML_TYPE_F32, {10, 5, 4, ne3}, {2, 1, 1, 1}));
         test_cases.emplace_back(new test_repeat(GGML_TYPE_F32, {10, 5, 4, ne3}, {1, 2, 1, 1}));

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -3229,7 +3229,7 @@ static bool test_backend(ggml_backend_t backend, test_mode mode, const char * op
     test_cases.emplace_back(new test_conv_transpose_1d({3,2,1,1}, {3,1,2,1}, 1, 0, 1));
     test_cases.emplace_back(new test_conv_transpose_1d({2,1,1,1}, {3,1,1,1}, 1, 0, 1));
 
-    for (const int64_t & ne3 : {1, 3}) { // CUDA backwards pass only supports ne3 == 1
+    for (int ne3 : {1, 3}) { // CUDA backwards pass only supports ne3 == 1
         test_cases.emplace_back(new test_repeat(GGML_TYPE_F32, {10, 5, 4, ne3}, {1, 1, 1, 1}));
         test_cases.emplace_back(new test_repeat(GGML_TYPE_F32, {10, 5, 4, ne3}, {2, 1, 1, 1}));
         test_cases.emplace_back(new test_repeat(GGML_TYPE_F32, {10, 5, 4, ne3}, {1, 2, 1, 1}));

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -1671,7 +1671,7 @@ struct test_mul_mat_id : public test_case {
     }
 };
 
-// GGML_OP_MUL_MAT
+// GGML_OP_OUT_PROD
 struct test_out_prod : public test_case {
     const ggml_type type_a;
     const ggml_type type_b;

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -2709,6 +2709,7 @@ struct test_opt_step_adam : public test_case {
     const float beta1;
     const float beta2;
     const float eps;
+    const float l1;
 
     std::string vars() override {
         return VARS_TO_STR2(type, ne);
@@ -2719,15 +2720,16 @@ struct test_opt_step_adam : public test_case {
             float alpha = 1e-3f,
             float beta1 = 0.9f,
             float beta2 = 0.999f,
-            float eps = 1e-8f)
-        : type(type), ne(ne), alpha(alpha), beta1(beta1), beta2(beta2), eps(eps) {}
+            float eps = 1e-8f,
+            float l1 = 0.0f)
+        : type(type), ne(ne), alpha(alpha), beta1(beta1), beta2(beta2), eps(eps), l1(l1) {}
 
     ggml_tensor * build_graph(ggml_context * ctx) override {
         ggml_tensor * a = ggml_new_tensor_4d(ctx, type, ne[0], ne[1], ne[2], ne[3]);
         ggml_set_param(ctx, a); // Despite tensor a having gradients the output tensor will not.
         ggml_set_name(a, "a");
 
-        ggml_tensor * out = ggml_opt_step_adam(ctx, a, alpha, beta1, beta2, eps);
+        ggml_tensor * out = ggml_opt_step_adam(ctx, a, alpha, beta1, beta2, eps, l1);
         ggml_set_name(out, "out");
 
         return out;
@@ -3574,7 +3576,9 @@ static bool test_backend(ggml_backend_t backend, test_mode mode, const char * op
     }
 
     test_cases.emplace_back(new test_cross_entropy_loss());
-    test_cases.emplace_back(new test_opt_step_adam(GGML_TYPE_F32, {10, 5, 4, 3}, 1.0f, 1e-3f, 0.9f, 0.999f));
+    for (const float & l1 : {0.0f, 1e-3f}) {
+        test_cases.emplace_back(new test_opt_step_adam(GGML_TYPE_F32, {10, 5, 4, 3}, 1.0f, 1e-3f, 0.9f, 0.999f, l1));
+    }
 
     // these tests are disabled to save execution time, but they can be handy for debugging
 #if 0

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -3567,7 +3567,7 @@ static bool test_backend(ggml_backend_t backend, test_mode mode, const char * op
     }
 
     test_cases.emplace_back(new test_cross_entropy_loss());
-    for (const float & wd : {0.0f, 1e-2f}) {
+    for (float wd : {0.0f, 1e-2f}) {
         test_cases.emplace_back(new test_opt_step_adamw(GGML_TYPE_F32, {10, 5, 4, 3}, 1.0f, 1e-3f, 0.9f, 0.999f, wd));
     }
 

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -3229,14 +3229,15 @@ static bool test_backend(ggml_backend_t backend, test_mode mode, const char * op
     test_cases.emplace_back(new test_conv_transpose_1d({3,2,1,1}, {3,1,2,1}, 1, 0, 1));
     test_cases.emplace_back(new test_conv_transpose_1d({2,1,1,1}, {3,1,1,1}, 1, 0, 1));
 
-
-    test_cases.emplace_back(new test_repeat(GGML_TYPE_F32, {10, 1, 1, 1}, {1, 1, 1, 1}));
-    test_cases.emplace_back(new test_repeat(GGML_TYPE_F32, {10, 1, 1, 1}, {2, 1, 1, 1}));
-    test_cases.emplace_back(new test_repeat(GGML_TYPE_F32, {10, 1, 1, 1}, {1, 2, 1, 1}));
-    test_cases.emplace_back(new test_repeat(GGML_TYPE_F32, {10, 1, 1, 1}, {1, 1, 2, 1}));
-    test_cases.emplace_back(new test_repeat(GGML_TYPE_F32, {10, 1, 1, 1}, {1, 1, 1, 2}));
-    test_cases.emplace_back(new test_repeat(GGML_TYPE_I32, {10, 1, 1, 1}, {2, 1, 1, 1}));
-    test_cases.emplace_back(new test_repeat(GGML_TYPE_I16, {10, 1, 1, 1}, {1, 1, 1, 2}));
+    for (const int64_t & ne3 : {1, 3}) { // CUDA only supports ne3 == 1
+        test_cases.emplace_back(new test_repeat(GGML_TYPE_F32, {10, 5, 4, ne3}, {1, 1, 1, 1}));
+        test_cases.emplace_back(new test_repeat(GGML_TYPE_F32, {10, 5, 4, ne3}, {2, 1, 1, 1}));
+        test_cases.emplace_back(new test_repeat(GGML_TYPE_F32, {10, 5, 4, ne3}, {1, 2, 1, 1}));
+        test_cases.emplace_back(new test_repeat(GGML_TYPE_F32, {10, 5, 4, ne3}, {1, 1, 2, 1}));
+        test_cases.emplace_back(new test_repeat(GGML_TYPE_F32, {10, 5, 4, ne3}, {1, 1, 1, 2}));
+        test_cases.emplace_back(new test_repeat(GGML_TYPE_I32, {10, 5, 4, ne3}, {2, 1, 1, 1}));
+        test_cases.emplace_back(new test_repeat(GGML_TYPE_I16, {10, 5, 4, ne3}, {1, 1, 1, 2}));
+    }
 
     test_cases.emplace_back(new test_dup(GGML_TYPE_F32));
     test_cases.emplace_back(new test_dup(GGML_TYPE_F16));

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -2702,7 +2702,7 @@ struct test_opt_step_adamw : public test_case {
     const float wd;
 
     std::string vars() override {
-        return VARS_TO_STR2(type, ne);
+        return VARS_TO_STR7(type, ne, alpha, beta1, beta2, eps, wd);
     }
 
     test_opt_step_adamw(ggml_type type = GGML_TYPE_F32,

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -803,7 +803,7 @@ struct test_case {
 
         ggml_build_forward_expand(gf, out);
         ggml_graph_cpy(gf, gb);
-        ggml_build_backward_expand(ctx, gf, gb, false);
+        ggml_build_backward_expand(ctx, gf, gb, false, false);
         if (expect.size() != 1 || expect[0] != 0.0f) {
             GGML_ASSERT(gb->n_nodes > gf->n_nodes);
             for (ggml_tensor * t = ggml_get_first_tensor(ctx); t != NULL; t = ggml_get_next_tensor(ctx, t)) {

--- a/tests/test-grad0.cpp
+++ b/tests/test-grad0.cpp
@@ -240,7 +240,7 @@ static bool check_gradient(
     struct ggml_cgraph * gb = ggml_new_graph_custom(ctx0, GGML_DEFAULT_GRAPH_SIZE, true);
     ggml_build_forward_expand(gf, f);
     ggml_graph_cpy(gf, gb);
-    ggml_build_backward_expand(ctx0, gf, gb, false);
+    ggml_build_backward_expand(ctx0, gf, gb, false, false);
 
     ggml_graph_compute_with_ctx(ctx0, gf, n_threads);
 

--- a/tests/test-mul-mat0.c
+++ b/tests/test-mul-mat0.c
@@ -100,7 +100,7 @@ bool check_gradient(
     struct ggml_cgraph * gf = ggml_new_graph_custom(ctx0, GGML_DEFAULT_GRAPH_SIZE, true);
     ggml_build_forward_expand(gf, f);
     struct ggml_cgraph * gb = ggml_graph_dup(ctx0, gf);
-    ggml_build_backward_expand(ctx0, gf, gb, false);
+    ggml_build_backward_expand(ctx0, gf, gb, false, false);
 
     ggml_graph_compute_with_ctx(ctx0, gf, n_threads);
     ggml_graph_reset  (gf);

--- a/tests/test1.c
+++ b/tests/test1.c
@@ -31,7 +31,7 @@ int main(int argc, const char ** argv) {
         struct ggml_cgraph * gf = ggml_new_graph_custom(ctx0, GGML_DEFAULT_GRAPH_SIZE, true);
         ggml_build_forward_expand(gf, f);
         struct ggml_cgraph * gb = ggml_graph_dup(ctx0, gf);
-        ggml_build_backward_expand(ctx0, gf, gb, false);
+        ggml_build_backward_expand(ctx0, gf, gb, false, false);
 
         ggml_set_f32(x, 2.0f);
         ggml_set_f32(a, 3.0f);
@@ -83,7 +83,7 @@ int main(int argc, const char ** argv) {
         struct ggml_cgraph * gf = ggml_new_graph_custom(ctx0, GGML_DEFAULT_GRAPH_SIZE, true);
         ggml_build_forward_expand(gf, y);
         struct ggml_cgraph * gb = ggml_graph_dup(ctx0, gf);
-        ggml_build_backward_expand(ctx0, gf, gb, false);
+        ggml_build_backward_expand(ctx0, gf, gb, false, false);
 
         ggml_graph_reset(gf);
         ggml_set_f32(y->grad, 1.0f);
@@ -103,7 +103,7 @@ int main(int argc, const char ** argv) {
 
         struct ggml_cgraph * gbb = ggml_graph_dup(ctx0, gb);
 
-        ggml_build_backward_expand(ctx0, gb, gbb, true);
+        ggml_build_backward_expand(ctx0, gb, gbb, false, true);
 
         ggml_graph_reset(gb);
         ggml_set_f32(g1->grad, 1.0f);
@@ -134,7 +134,7 @@ int main(int argc, const char ** argv) {
         struct ggml_cgraph * gf = ggml_new_graph_custom(ctx0, GGML_DEFAULT_GRAPH_SIZE, true);
         ggml_build_forward_expand(gf, y);
         struct ggml_cgraph * gb = ggml_graph_dup(ctx0, gf);
-        ggml_build_backward_expand(ctx0, gf, gb, false);
+        ggml_build_backward_expand(ctx0, gf, gb, false, false);
 
         ggml_set_f32(x1, 3.0f);
         ggml_set_f32(x2, 4.0f);
@@ -172,7 +172,7 @@ int main(int argc, const char ** argv) {
         struct ggml_cgraph * gf = ggml_new_graph_custom(ctx0, GGML_DEFAULT_GRAPH_SIZE, true);
         ggml_build_forward_expand(gf, y);
         struct ggml_cgraph * gb = ggml_graph_dup(ctx0, gf);
-        ggml_build_backward_expand(ctx0, gf, gb, false);
+        ggml_build_backward_expand(ctx0, gf, gb, false, false);
 
         ggml_set_f32(x1, 1.0f);
         ggml_set_f32(x2, 2.0f);
@@ -199,7 +199,7 @@ int main(int argc, const char ** argv) {
 
         struct ggml_cgraph * gbb = ggml_graph_dup(ctx0, gb);
 
-        ggml_build_backward_expand(ctx0, gb, gbb, true);
+        ggml_build_backward_expand(ctx0, gb, gbb, false, true);
 
         ggml_graph_reset(gb);
         ggml_set_f32(g1->grad, 1.0f);
@@ -235,7 +235,7 @@ int main(int argc, const char ** argv) {
         struct ggml_cgraph * gf = ggml_new_graph_custom(ctx0, GGML_DEFAULT_GRAPH_SIZE, true);
         ggml_build_forward_expand(gf, y);
         struct ggml_cgraph * gb = ggml_graph_dup(ctx0, gf);
-        ggml_build_backward_expand(ctx0, gf, gb, false);
+        ggml_build_backward_expand(ctx0, gf, gb, false, false);
 
         ggml_set_f32(x1, 3.0f);
         ggml_set_f32(x2, 5.0f);
@@ -290,7 +290,7 @@ int main(int argc, const char ** argv) {
         struct ggml_cgraph * gf = ggml_new_graph_custom(ctx0, GGML_DEFAULT_GRAPH_SIZE, true);
         ggml_build_forward_expand(gf, y);
         struct ggml_cgraph * gb = ggml_graph_dup(ctx0, gf);
-        ggml_build_backward_expand(ctx0, gf, gb, false);
+        ggml_build_backward_expand(ctx0, gf, gb, false, false);
 
         ggml_set_f32(x1, 3.0f);
         ggml_set_f32(x2, 5.0f);
@@ -345,7 +345,7 @@ int main(int argc, const char ** argv) {
         struct ggml_cgraph * gf = ggml_new_graph_custom(ctx0, GGML_DEFAULT_GRAPH_SIZE, true);
         ggml_build_forward_expand(gf, y);
         struct ggml_cgraph * gb = ggml_graph_dup(ctx0, gf);
-        ggml_build_backward_expand(ctx0, gf, gb, false);
+        ggml_build_backward_expand(ctx0, gf, gb, false, false);
 
         ggml_set_f32(x1, 3.0f);
         ggml_set_f32(x2, 5.0f);
@@ -394,7 +394,7 @@ int main(int argc, const char ** argv) {
         struct ggml_cgraph * gf = ggml_new_graph_custom(ctx0, GGML_DEFAULT_GRAPH_SIZE, true);
         ggml_build_forward_expand(gf, y);
         struct ggml_cgraph * gb = ggml_graph_dup(ctx0, gf);
-        ggml_build_backward_expand(ctx0, gf, gb, false);
+        ggml_build_backward_expand(ctx0, gf, gb, false, false);
 
         ggml_set_f32(x1, 3.0f);
         ggml_set_f32(x2, 5.0f);


### PR DESCRIPTION
The ultimate goal of this PR is to add backend support for numerical optimization, namely Adam and L-BFGS. As of right now the corresponding computations are done by a single thread outside any of the GGML graphs. As a consequence only a single thread is used and only the CPU backend is compatible. I think the correct way to remedy this is to make the optimizers part of the GGML compute graphs. This also fixes some allocation issues where the optimization code allocates extra tensors to hold persistent extra data for the optimizers. 

As of right now this PR contains my WIP version that only supports stochastic gradient descent and the CPU backend. The training is ~3x faster than on master (but the overall rate of convergence is worse than fully featured Adam).

The overall design that I envision is that the optimizer is specified when creating the backwards graph. If no optimizer is specified, calculate the gradients without touching the weights. If an optimizer is specified, apply it to all parameters after the gradients have been calculated by adding an extra GGML op on top (could probably be optimized to overwrite gradients that are no longer needed). During backwards graph creation also specify any extra tensors needed for the optimizer so they can be correctly allocated for all backends. Functions like `ggml_opt` would then mainly be calling the backwards graph in a loop and check convergence. One potential issue is that the convergence logic would require calls to `ggml_backend_tensor_get` which would make `ggml.c` depend on `ggml_backend.c` (which it currently does not). If that is a problem the optimization code could maybe be moved to a new file like `ggml-algo.c`.

If there are issues with my design please let me know early.