### PR TITLE
build: fix msvc build

### DIFF
--- a/examples/mnist/CMakeLists.txt
+++ b/examples/mnist/CMakeLists.txt
@@ -2,7 +2,7 @@
 # mnist-common
 
 set(TEST_TARGET mnist-common)
-add_library(${TEST_TARGET} mnist-common.cpp)
+add_library(${TEST_TARGET} STATIC mnist-common.cpp)
 target_link_libraries(${TEST_TARGET} PRIVATE ggml common)
 
 #


### PR DESCRIPTION
The Windows/msvc build currently fails because mnist-common generates a .dll and the mnist examples expect a .lib:

```
46>LINK : fatal error LNK1104: cannot open file 'Debug\mnist-common.lib'
```

The fix is to explicitly request a static library.

I've built this locally with Windows/msvc and WSL(ubuntu)/gcc.
