### PR TITLE
CUDA: remove bad assert

### DIFF
--- a/src/ggml-cuda/im2col.cu
+++ b/src/ggml-cuda/im2col.cu
@@ -69,7 +69,6 @@ void ggml_cuda_op_im2col(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     float * dst_d = (float *)dst->data;
     cudaStream_t stream = ctx.stream();
 
-    GGML_ASSERT(src0->type == GGML_TYPE_F16);
     GGML_ASSERT(src1->type == GGML_TYPE_F32);
     GGML_ASSERT( dst->type == GGML_TYPE_F16 || dst->type == GGML_TYPE_F32);
 


### PR DESCRIPTION
Removes a bad assert in the `IM2COL` CUDA code. `src0` is only used for its shape so the data type doesn't actually matter.