### PR TITLE
test: fix OPT_STEP_ADAMW for test-backend-ops

### DIFF
--- a/include/ggml.h
+++ b/include/ggml.h
@@ -2052,6 +2052,7 @@ extern "C" {
     GGML_API struct ggml_tensor * ggml_opt_step_adamw(
             struct ggml_context * ctx,
             struct ggml_tensor  * a,
+            struct ggml_tensor  * grad,
             float                 alpha,
             float                 beta1,
             float                 beta2,

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -2751,7 +2751,10 @@ struct test_opt_step_adamw : public test_case {
         ggml_set_param(ctx, a); // Despite tensor a having gradients the output tensor will not.
         ggml_set_name(a, "a");
 
-        ggml_tensor * out = ggml_opt_step_adamw(ctx, a, alpha, beta1, beta2, eps, wd);
+        ggml_tensor * grad = ggml_new_tensor_4d(ctx, type, ne[0], ne[1], ne[2], ne[3]);
+        ggml_set_name(grad, "grad");
+
+        ggml_tensor * out = ggml_opt_step_adamw(ctx, a, grad, alpha, beta1, beta2, eps, wd);
         ggml_set_name(out, "out");
 
         return out;


### PR DESCRIPTION
Fixup for https://github.com/ggerganov/ggml/pull/966 .

When I tested `GGML_OP_OPT_STEP_ADAMW` I had mistyped the filter for `test-backend-ops` so I didn't notice that the test is broken. The problem is that the gradients for tensors are no longer being allocated unless a backward graph is constructed. This can simply be fixed by explicitly creating a tensor the gradients. Also I'm changing the interface for `ggml_opt_step_adamw` to accept a gradient tensor since the long term goal for `ggml_tensor.grad` is to remove it.