### PR TITLE
examples: add dataset, data shuffling to MNIST

### DIFF
--- a/examples/mnist/mnist-eval.cpp
+++ b/examples/mnist/mnist-eval.cpp
@@ -24,22 +24,17 @@ int main(int argc, char ** argv) {
         exit(1);
     }
 
-    std::vector<float> images;
-    images.resize(MNIST_NTEST*MNIST_NINPUT);
-    if (!mnist_image_load(argv[2], images.data(), MNIST_NTEST)) {
+    struct mnist_dataset dataset(/*nex =*/ MNIST_NTEST, /*shard_size =*/ MNIST_NBATCH_PHYSICAL);
+
+    if (!mnist_image_load(argv[2], dataset)) {
         return 1;
     }
-
-    std::vector<float> labels;
-    labels.resize(MNIST_NTEST*MNIST_NCLASSES);
-    if (!mnist_label_load(argv[3], labels.data(), MNIST_NTEST)) {
+    if (!mnist_label_load(argv[3], dataset)) {
         return 1;
     }
 
     const int iex = rand() % MNIST_NTEST;
-    const std::vector<float> digit(images.begin() + iex*MNIST_NINPUT, images.begin() + (iex+1)*MNIST_NINPUT);
-
-    mnist_image_print(stdout, images.data() + iex*MNIST_NINPUT);
+    mnist_image_print(stdout, dataset, iex);
 
     const std::string backend = argc >= 5 ? argv[4] : "CPU";
 
@@ -48,7 +43,7 @@ int main(int argc, char ** argv) {
     if (backend == "CPU") {
         const int ncores_logical = std::thread::hardware_concurrency();
         result_eval = mnist_graph_eval(
-            argv[1], images.data(), labels.data(), MNIST_NTEST, std::min(ncores_logical, (ncores_logical + 4)/2));
+            argv[1], ggml_get_data_f32(dataset.data), ggml_get_data_f32(dataset.labels), MNIST_NTEST, std::min(ncores_logical, (ncores_logical + 4)/2));
         if (result_eval.success) {
             fprintf(stdout, "%s: predicted digit is %d\n", __func__, result_eval.pred[iex]);
 
@@ -73,7 +68,7 @@ int main(int argc, char ** argv) {
     const int64_t t_load_us = ggml_time_us() - t_start_us;
 
     fprintf(stdout, "%s: loaded model in %.2lf ms\n", __func__, t_load_us / 1000.0);
-    result_eval = mnist_model_eval(model, images.data(), labels.data(), MNIST_NTEST);
+    result_eval = mnist_model_eval(model, dataset);
     fprintf(stdout, "%s: predicted digit is %d\n", __func__, result_eval.pred[iex]);
 
     std::pair<double, double> result_loss = mnist_loss(result_eval);

--- a/examples/mnist/mnist-train.cpp
+++ b/examples/mnist/mnist-train.cpp
@@ -5,7 +5,6 @@
 #include <cstring>
 #include <ctime>
 #include <string>
-#include <thread>
 
 #if defined(_MSC_VER)
 #pragma warning(disable: 4244 4267) // possible loss of data
@@ -17,15 +16,15 @@ int main(int argc, char ** argv) {
         exit(0);
     }
 
-    std::vector<float> images;
-    images.resize(MNIST_NTRAIN*MNIST_NINPUT);
-    if (!mnist_image_load(argv[3], images.data(), MNIST_NTRAIN)) {
+    // The MNIST model is so small that the overhead from data shuffling is non-negligible, especially with CUDA.
+    // With a shard size of 10 this overhead is greatly reduced at the cost of less shuffling (does not seem to have a significant impact).
+    // A batch of 500 images then consists of 50 random shards of size 10 instead of 500 random shards of size 1.
+    struct mnist_dataset dataset(/*nex =*/ MNIST_NTRAIN, /*shard_size =*/ 10);
+
+    if (!mnist_image_load(argv[3], dataset)) {
         return 1;
     }
-
-    std::vector<float> labels;
-    labels.resize(MNIST_NTRAIN*MNIST_NCLASSES);
-    if (!mnist_label_load(argv[4], labels.data(), MNIST_NTRAIN)) {
+    if (!mnist_label_load(argv[4], dataset)) {
         return 1;
     }
 
@@ -33,7 +32,7 @@ int main(int argc, char ** argv) {
 
     mnist_model_build(model, MNIST_NBATCH_LOGICAL, MNIST_NBATCH_PHYSICAL);
 
-    mnist_model_train(model, images.data(), labels.data(), MNIST_NTRAIN, /*nepoch =*/ 30, /*val_split =*/ 0.05f);
+    mnist_model_train(model, dataset, /*nepoch =*/ 30, /*val_split =*/ 0.05f);
 
     mnist_model_save(model, argv[2]);
 }


### PR DESCRIPTION
This PR adds an explicit datatype to represent a dataset to the MNIST example. The dataset also has support for shuffling the data. This works by separating the data into shards and creating a vector of integers as a permutation of those shards. The dataset is shuffled by shuffling the permutation which then dictates which shards are retrieved with `get_batch`. With a shard size of 1 this then requires a lot more individual data transfers per batch, making the CUDA training ~10x slower compared to transferring the entire batch in one contiguous block. With a shard size of 10 the CUDA training is still ~2x slower but this is largely compensated by faster convergence per epoch. For actual use the overhead from shuffling is probably negligible, especially once asynchronous data loading is implemented.

My next goals will be to add dataset support to GGML, create a more high-level API, add `ggml_backend_sched` support, and add more tests. I think after that it would make sense to start looking into actual applications such as finetuning in llama.cpp.