### PR TITLE
ggml-alloc : remove buffer_id from leaf_alloc

### DIFF
--- a/src/ggml-alloc.c
+++ b/src/ggml-alloc.c
@@ -348,7 +348,6 @@ struct tensor_alloc {
 };
 
 struct leaf_alloc {
-    int buffer_id;
     struct tensor_alloc leaf;
 };
 
@@ -740,7 +739,6 @@ bool ggml_gallocr_reserve_n(ggml_gallocr_t galloc, struct ggml_cgraph * graph, c
     for (int i = 0; i < graph->n_leafs; i++) {
         struct ggml_tensor * leaf = graph->leafs[i];
         struct hash_node * hn = ggml_gallocr_hash_get(galloc, leaf);
-        galloc->leaf_allocs[i].buffer_id = hn->buffer_id;
         if (leaf->view_src || leaf->data) {
             galloc->leaf_allocs[i].leaf.buffer_id = -1;
             galloc->leaf_allocs[i].leaf.offset = SIZE_MAX;


### PR DESCRIPTION
This commit removes the `buffer_id` field from the `leaf_alloc` struct.

The motivation for is that this field is only written to and never read/used as far as I can tell. Each `tensor_alloc` has a `buffer_id` field and this is what caused me to look into this more closely, to understand what the `buffer_id` in `leaf_alloc` was used for.

* [Notes on Graph Allocator](https://github.com/danbev/learning-ai/blob/main/notes/ggml.md#graph-allocator-galloc) (which is where/how I noticed this)