### PR TITLE
increase cuda_cpy block size

### DIFF
--- a/src/ggml-cuda/cpy.cuh
+++ b/src/ggml-cuda/cpy.cuh
@@ -1,6 +1,6 @@
 #include "common.cuh"
 
-#define CUDA_CPY_BLOCK_SIZE 32
+#define CUDA_CPY_BLOCK_SIZE 64
 
 void ggml_cuda_cpy(ggml_backend_cuda_context & ctx, const ggml_tensor * src0, ggml_tensor * src1);
 


### PR DESCRIPTION
This PR gives a small performance boost to cuda backend cpy op.  All test cases in test-backend-ops passed.