### PR TITLE
Make it possible linking ggml as external lib

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1391,7 +1391,7 @@ if (EMSCRIPTEN)
 endif()
 
 target_compile_definitions(ggml PUBLIC    ${GGML_CDEF_PUBLIC})
-target_include_directories(ggml PUBLIC  ../include)
+target_include_directories(ggml PUBLIC    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include> $<INSTALL_INTERFACE:include>)
 target_include_directories(ggml PRIVATE . ${GGML_EXTRA_INCLUDES})
 target_link_directories   (ggml PRIVATE   ${GGML_EXTRA_LIBDIRS})
 target_compile_features   (ggml PRIVATE c_std_11) # don't bump


### PR DESCRIPTION
The use of a relative path in the linking prevents linking when ggml is used as a vended library

```
CMake Error in vendor/ggml/src/CMakeLists.txt:
  Target "ggml" INTERFACE_INCLUDE_DIRECTORIES property contains path:

    "/Volumes/workplace/ggml-impl/vendor/ggml/src/../include"

  which is prefixed in the source directory.
```