### PR TITLE
feat: add `GGML_UNARY_OP_ARGMAX` Metal kernel

### DIFF
--- a/src/ggml-metal/ggml-metal.m
+++ b/src/ggml-metal/ggml-metal.m
@@ -3485,7 +3485,8 @@ static void ggml_metal_encode_node(
                 [encoder setComputePipelineState:pipeline];
                 [encoder setBuffer:id_src0 offset:offs_src0        atIndex:0];
                 [encoder setBuffer:id_dst  offset:offs_dst         atIndex:1];
-                [encoder setBytes:&nb01    length:sizeof( int64_t) atIndex:2];
+                [encoder setBytes:&ne00    length:sizeof( int64_t) atIndex:2];
+                [encoder setBytes:&nb01    length:sizeof(uint64_t) atIndex:3];
 
                 [encoder dispatchThreadgroups:MTLSizeMake(nrows, 1, 1) threadsPerThreadgroup:MTLSizeMake(1, 1, 1)];
             } break;

--- a/src/ggml-metal/ggml-metal.m
+++ b/src/ggml-metal/ggml-metal.m
@@ -3475,6 +3475,8 @@ static void ggml_metal_encode_node(
             case GGML_OP_ARGMAX:
             {
                 GGML_ASSERT(src0->type == GGML_TYPE_F32);
+                GGML_ASSERT(ggml_is_contiguous_1(src0));
+                GGML_ASSERT(nb00 == ggml_type_size(src0->type));
 
                 const int64_t nrows = ggml_nrows(src0);
 

--- a/src/ggml-metal/ggml-metal.m
+++ b/src/ggml-metal/ggml-metal.m
@@ -3485,7 +3485,7 @@ static void ggml_metal_encode_node(
                 [encoder setBuffer:id_dst  offset:offs_dst         atIndex:1];
                 [encoder setBytes:&ne00    length:sizeof( int64_t) atIndex:2];
 
-                [encoder dispatchThreadgroups:MTLSizeMake(1, 1, 1) threadsPerThreadgroup:MTLSizeMake(nrows, 1, 1)];
+                [encoder dispatchThreadgroups:MTLSizeMake(nrows, 1, 1) threadsPerThreadgroup:MTLSizeMake(1, 1, 1)];
             } break;
        default:
             {

--- a/src/ggml-metal/ggml-metal.m
+++ b/src/ggml-metal/ggml-metal.m
@@ -3483,7 +3483,7 @@ static void ggml_metal_encode_node(
                 [encoder setComputePipelineState:pipeline];
                 [encoder setBuffer:id_src0 offset:offs_src0        atIndex:0];
                 [encoder setBuffer:id_dst  offset:offs_dst         atIndex:1];
-                [encoder setBytes:&ne00    length:sizeof( int64_t) atIndex:2];
+                [encoder setBytes:&nb01    length:sizeof( int64_t) atIndex:2];
 
                 [encoder dispatchThreadgroups:MTLSizeMake(nrows, 1, 1) threadsPerThreadgroup:MTLSizeMake(1, 1, 1)];
             } break;

--- a/src/ggml-metal/ggml-metal.metal
+++ b/src/ggml-metal/ggml-metal.metal
@@ -1353,8 +1353,8 @@ kernel void kernel_argmax(
         threadgroup int32_t * shared_argmax [[threadgroup(1)]],
         uint  tgpig[[threadgroup_position_in_grid]],
         uint  tpitg[[thread_position_in_threadgroup]],
-        uint sgitg[[simdgroup_index_in_threadgroup]],
-        uint tiisg[[thread_index_in_simdgroup]],
+        uint  sgitg[[simdgroup_index_in_threadgroup]],
+        uint  tiisg[[thread_index_in_simdgroup]],
         uint    ntg[[threads_per_threadgroup]]) {
     device const float * x_row = (device const float *) ((device const char *) x + tgpig * nb01);
 

--- a/src/ggml-metal/ggml-metal.metal
+++ b/src/ggml-metal/ggml-metal.metal
@@ -1348,10 +1348,9 @@ kernel void kernel_argmax(
         device   const void * x,
         device      int32_t * dst,
         constant    int64_t & ncols,
-        uint tpitg[[thread_position_in_threadgroup]]) {
-    device const float * x_row = (device const float *) ((device const char *) x + tpitg * ncols * sizeof(float));
+        uint tgpig[[threadgroup_position_in_grid]]) {
+    device const float * x_row = (device const float *) ((device const char *) x + tgpig * ncols * sizeof(float));
 
-    // initialize
     dst[tpitg] = 0;
 
     for (int i = 0; i < ncols; i++) {

--- a/src/ggml-metal/ggml-metal.metal
+++ b/src/ggml-metal/ggml-metal.metal
@@ -1349,16 +1349,56 @@ kernel void kernel_argmax(
         device      int32_t * dst,
         constant    int64_t & ncols,
         constant   uint64_t & nb01,
-        uint tgpig[[threadgroup_position_in_grid]]) {
+        threadgroup   float * shared_maxval [[threadgroup(0)]],
+        threadgroup int32_t * shared_argmax [[threadgroup(1)]],
+        uint  tgpig[[threadgroup_position_in_grid]],
+        uint  tpitg[[thread_position_in_threadgroup]],
+        uint sgitg[[simdgroup_index_in_threadgroup]],
+        uint tiisg[[thread_index_in_simdgroup]],
+        uint    ntg[[threads_per_threadgroup]]) {
     device const float * x_row = (device const float *) ((device const char *) x + tgpig * nb01);
 
-    dst[tgpig] = 0;
+    float   lmax = -INFINITY;
+    int32_t larg = -1;
 
-    for (int i = 0; i < ncols; i++) {
-        if (x_row[i] > x_row[dst[tgpig]]) {
-            dst[tgpig] = i;
+    for (int i00 = tpitg; i00 < ncols; i00 += ntg) {
+        if (x_row[i00] > lmax) {
+            lmax = x_row[i00];
+            larg = i00;
         }
     }
+
+    // find the argmax value in the block
+    float max_val = simd_max(lmax);
+    int32_t arg_val = simd_max(select(-1, larg, lmax == max_val));
+
+    if (ntg > N_SIMDWIDTH) {
+        if (sgitg == 0) {
+            shared_maxval[tiisg] = -INFINITY;
+            shared_argmax[tiisg] = -1;
+        }
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        if (tiisg == 0) {
+            shared_maxval[sgitg] = max_val;
+            shared_argmax[sgitg] = arg_val;
+        }
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        max_val = shared_maxval[tiisg];
+        arg_val = shared_argmax[tiisg];
+
+        float max_val_reduced   = simd_max(max_val);
+        int32_t arg_val_reduced = simd_max(select(-1, arg_val, max_val == max_val_reduced));
+
+        dst[tgpig] = arg_val_reduced;
+
+        return;
+    }
+
+    dst[tgpig] = arg_val;
 }
 
 kernel void kernel_norm(

--- a/src/ggml-metal/ggml-metal.metal
+++ b/src/ggml-metal/ggml-metal.metal
@@ -1347,9 +1347,9 @@ kernel void kernel_ssm_scan_f32(
 kernel void kernel_argmax(
         device   const void * x,
         device      int32_t * dst,
-        constant    int64_t & ncols,
+        constant    int64_t & nb01,
         uint tgpig[[threadgroup_position_in_grid]]) {
-    device const float * x_row = (device const float *) ((device const char *) x + tgpig * ncols * sizeof(float));
+    device const float * x_row = (device const float *) ((device const char *) x + tgpig * nb01);
 
     dst[tpitg] = 0;
 

--- a/src/ggml-metal/ggml-metal.metal
+++ b/src/ggml-metal/ggml-metal.metal
@@ -1347,15 +1347,16 @@ kernel void kernel_ssm_scan_f32(
 kernel void kernel_argmax(
         device   const void * x,
         device      int32_t * dst,
-        constant    int64_t & nb01,
+        constant    int64_t & ncols,
+        constant   uint64_t & nb01,
         uint tgpig[[threadgroup_position_in_grid]]) {
     device const float * x_row = (device const float *) ((device const char *) x + tgpig * nb01);
 
-    dst[tpitg] = 0;
+    dst[tgpig] = 0;
 
     for (int i = 0; i < ncols; i++) {
-        if (x_row[i] > x_row[dst[tpitg]]) {
-            dst[tpitg] = i;
+        if (x_row[i] > x_row[dst[tgpig]]) {
+            dst[tgpig] = i;
         }
     }
 }

--- a/src/ggml-metal/ggml-metal.metal
+++ b/src/ggml-metal/ggml-metal.metal
@@ -1344,6 +1344,23 @@ kernel void kernel_ssm_scan_f32(
     }
 }
 
+kernel void kernel_argmax(
+        device   const void * x,
+        device      int32_t * dst,
+        constant    int64_t & ncols,
+        uint tpitg[[thread_position_in_threadgroup]]) {
+    device const float * x_row = (device const float *) ((device const char *) x + tpitg * ncols * sizeof(float));
+
+    // initialize
+    dst[tpitg] = 0;
+
+    for (int i = 0; i < ncols; i++) {
+        if (x_row[i] > x_row[dst[tpitg]]) {
+            dst[tpitg] = i;
+        }
+    }
+}
+
 kernel void kernel_norm(
         device const  void * src0,
         device       float * dst,

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -3824,6 +3824,10 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_perf() {
     test_cases.emplace_back(new test_bin_bcast(ggml_add, GGML_TYPE_F32, {4096, 1, 1, 1}, {1,   1, 1, 1}));
     test_cases.emplace_back(new test_bin_bcast(ggml_add, GGML_TYPE_F32, {4096, 1, 1, 1}, {1, 512, 1, 1}));
 
+    test_cases.emplace_back(new test_argmax(GGML_TYPE_F32, {10, 100 , 1, 1}));
+    test_cases.emplace_back(new test_argmax(GGML_TYPE_F32, {12, 1024, 1, 1}));
+    test_cases.emplace_back(new test_argmax(GGML_TYPE_F32, {3 , 5438, 1, 1}));
+
     test_cases.emplace_back(new test_cpy(GGML_TYPE_F32, GGML_TYPE_F16, {512, 3072, 1, 1}));
 
     for (int bs : {1, 512}) {

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -3440,9 +3440,9 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_conv_transpose_1d({3,2,1,1}, {3,1,2,1}, 1, 0, 1));
     test_cases.emplace_back(new test_conv_transpose_1d({2,1,1,1}, {3,1,1,1}, 1, 0, 1));
 
-    test_cases.emplace_back(new test_argmax(GGML_TYPE_F32, {10, 100 , 1, 1}));
-    test_cases.emplace_back(new test_argmax(GGML_TYPE_F32, {12, 1024, 1, 1}));
-    test_cases.emplace_back(new test_argmax(GGML_TYPE_F32, {3 , 5438, 1, 1}));
+    test_cases.emplace_back(new test_argmax(GGML_TYPE_F32, { 100, 10, 1, 1}));
+    test_cases.emplace_back(new test_argmax(GGML_TYPE_F32, {1024, 12, 1, 1}));
+    test_cases.emplace_back(new test_argmax(GGML_TYPE_F32, {5438,  3, 1, 1}));
 
     test_cases.emplace_back(new test_count_equal());
 
@@ -3824,9 +3824,9 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_perf() {
     test_cases.emplace_back(new test_bin_bcast(ggml_add, GGML_TYPE_F32, {4096, 1, 1, 1}, {1,   1, 1, 1}));
     test_cases.emplace_back(new test_bin_bcast(ggml_add, GGML_TYPE_F32, {4096, 1, 1, 1}, {1, 512, 1, 1}));
 
-    test_cases.emplace_back(new test_argmax(GGML_TYPE_F32, {10, 100 , 1, 1}));
-    test_cases.emplace_back(new test_argmax(GGML_TYPE_F32, {12, 1024, 1, 1}));
-    test_cases.emplace_back(new test_argmax(GGML_TYPE_F32, {3 , 5438, 1, 1}));
+    test_cases.emplace_back(new test_argmax(GGML_TYPE_F32, { 100, 10, 1, 1}));
+    test_cases.emplace_back(new test_argmax(GGML_TYPE_F32, {1024, 12, 1, 1}));
+    test_cases.emplace_back(new test_argmax(GGML_TYPE_F32, {5438,  3, 1, 1}));
 
     test_cases.emplace_back(new test_cpy(GGML_TYPE_F32, GGML_TYPE_F16, {512, 3072, 1, 1}));
 

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -3824,10 +3824,6 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_perf() {
     test_cases.emplace_back(new test_bin_bcast(ggml_add, GGML_TYPE_F32, {4096, 1, 1, 1}, {1,   1, 1, 1}));
     test_cases.emplace_back(new test_bin_bcast(ggml_add, GGML_TYPE_F32, {4096, 1, 1, 1}, {1, 512, 1, 1}));
 
-    test_cases.emplace_back(new test_argmax(GGML_TYPE_F32, { 100, 10, 1, 1}));
-    test_cases.emplace_back(new test_argmax(GGML_TYPE_F32, {1024, 12, 1, 1}));
-    test_cases.emplace_back(new test_argmax(GGML_TYPE_F32, {5438,  3, 1, 1}));
-
     test_cases.emplace_back(new test_cpy(GGML_TYPE_F32, GGML_TYPE_F16, {512, 3072, 1, 1}));
 
     for (int bs : {1, 512}) {

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -3440,7 +3440,10 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_conv_transpose_1d({3,2,1,1}, {3,1,2,1}, 1, 0, 1));
     test_cases.emplace_back(new test_conv_transpose_1d({2,1,1,1}, {3,1,1,1}, 1, 0, 1));
 
-    test_cases.emplace_back(new test_argmax());
+    test_cases.emplace_back(new test_argmax(GGML_TYPE_F32, {10, 100 , 1, 1}));
+    test_cases.emplace_back(new test_argmax(GGML_TYPE_F32, {12, 1024, 1, 1}));
+    test_cases.emplace_back(new test_argmax(GGML_TYPE_F32, {3 , 5438, 1, 1}));
+
     test_cases.emplace_back(new test_count_equal());
 
     for (int ne3 : {1, 3}) { // CUDA backward pass only supports ne3 == 1


### PR DESCRIPTION
This PR implements the Metal kernel used for the `GGML_UNARY_OP_ARGMAX` operation.

It is necessary for [Encodec.cpp](https://github.com/PABannier/encodec.cpp) to run on the Metal backend.