### PR TITLE
FIX: CMAKE_RUNTIME_OUTPUT_DIDRECTORY is only set when GGML_STANDALONE

### DIFF
--- a/src/ggml-metal/CMakeLists.txt
+++ b/src/ggml-metal/CMakeLists.txt
@@ -26,9 +26,11 @@ if (GGML_METAL_USE_BF16)
 endif()
 
 # copy metal files to bin directory
-configure_file(../ggml-common.h  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ggml-common.h     COPYONLY)
-configure_file(ggml-metal.metal  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ggml-metal.metal  COPYONLY)
-configure_file(ggml-metal-impl.h ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ggml-metal-impl.h COPYONLY)
+if (GGML_STANDALONE)
+    configure_file(../ggml-common.h  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ggml-common.h     COPYONLY)
+    configure_file(ggml-metal.metal  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ggml-metal.metal  COPYONLY)
+    configure_file(ggml-metal-impl.h ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ggml-metal-impl.h COPYONLY)
+endif()
 
 if (GGML_METAL_EMBED_LIBRARY)
     enable_language(ASM)


### PR DESCRIPTION
configure_file for ggml-common.h, ggml-metal.metal, ggml-metal-impl.h should not be copied when not GGML_STANDALONE.