### PR TITLE
Create .gitmodules for the new kompute backend

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "kompute"]
+	path = src/ggml-kompute/kompute
+	url = https://github.com/nomic-ai/kompute.git


### PR DESCRIPTION
This pull request includes changes to add the `kompute` submodule.

Submodule addition:

* [`.gitmodules`](diffhunk://#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584R1-R3): Added the `kompute` submodule with the path `src/ggml-kompute/kompute` and URL `https://github.com/nomic-ai/kompute.git`.