### PR TITLE
feat: add `GGML_OP_CONV_TRANSPOSE_1D` Metal kernels

### DIFF
--- a/src/ggml-metal/ggml-metal.m
+++ b/src/ggml-metal/ggml-metal.m
@@ -987,6 +987,7 @@ static bool ggml_metal_supports_op(const struct ggml_backend_metal_device_contex
         case GGML_OP_REPEAT:
         case GGML_OP_SCALE:
         case GGML_OP_CLAMP:
+        case GGML_OP_CONV_TRANSPOSE_1D:
             return true;
         case GGML_OP_SQR:
         case GGML_OP_SQRT:

--- a/src/ggml-metal/ggml-metal.metal
+++ b/src/ggml-metal/ggml-metal.metal
@@ -2564,26 +2564,40 @@ kernel void kernel_im2col_ext(
 template [[host_name("kernel_im2col_ext_f32")]] kernel im2col_ext_t kernel_im2col_ext<float>;
 template [[host_name("kernel_im2col_ext_f16")]] kernel im2col_ext_t kernel_im2col_ext<half>;
 
-kernel void kernel_conv_transpose_1d_f32(
+typedef void (conv_transpose_1d_t)(
         device const float * src0,
         device const float * src1,
         device        char * dst,
         constant   int32_t & IC,
         constant   int32_t & IL,
         constant   int32_t & K,
+        constant   int32_t & s0,
         constant  uint64_t & nb0,
         constant  uint64_t & nb1,
+        uint3   tgpig[[threadgroup_position_in_grid]],
+        uint3    tgpg[[threadgroups_per_grid]]);
+
+template <typename T>
+kernel void kernel_conv_transpose_1d(
+        device const     T * src0,
+        device const float * src1,
+        device        char * dst,
+        constant   int32_t & IC,
+        constant   int32_t & IL,
+        constant   int32_t & K,
         constant   int32_t & s0,
+        constant  uint64_t & nb0,
+        constant  uint64_t & nb1,
         uint3   tgpig[[threadgroup_position_in_grid]],
         uint3   tgpg[[threadgroups_per_grid]]) {
 
     float v = 0.0f;
 
-    for (int c = 0; c < IC; c++) {
+    for (int64_t c = 0; c < IC; c++) {
         const int32_t kernel_offset = c * tgpg[1] * K + K * tgpig[1];
         const int32_t input_offset = c * IL;
 
-        for (int i = 0; i < IL; i++) {
+        for (int64_t i = 0; i < IL; i++) {
             if (tgpig[0] >= i * s0 && tgpig[0] < i * s0 + K) {
                 v += src0[kernel_offset + tgpig[0] - i * s0] * src1[input_offset + i];
             }
@@ -2594,6 +2608,34 @@ kernel void kernel_conv_transpose_1d_f32(
 
     dst_ptr[0] = v;
 }
+
+template [[host_name("kernel_conv_transpose_1d_f32_f32")]]
+kernel void kernel_conv_transpose_1d<float>(
+    device const float * src0,
+    device const float * src1,
+    device        char * dst,
+    constant   int32_t & IC,
+    constant   int32_t & IL,
+    constant   int32_t & K,
+    constant   int32_t & s0,
+    constant  uint64_t & nb0,
+    constant  uint64_t & nb1,
+    uint3   tgpig[[threadgroup_position_in_grid]],
+    uint3    tgpg[[threadgroups_per_grid]]);
+
+template [[host_name("kernel_conv_transpose_1d_f16_f32")]]
+kernel void kernel_conv_transpose_1d<half>(
+    device const half  * src0,
+    device const float * src1,
+    device        char * dst,
+    constant   int32_t & IC,
+    constant   int32_t & IL,
+    constant   int32_t & K,
+    constant   int32_t & s0,
+    constant  uint64_t & nb0,
+    constant  uint64_t & nb1,
+    uint3   tgpig[[threadgroup_position_in_grid]],
+    uint3    tgpg[[threadgroups_per_grid]]);
 
 kernel void kernel_upscale_f32(
     device  const char * src0,


### PR DESCRIPTION
This PR adds two Metal kernels: `GGML_METAL_KERNEL_TYPE_CONV_TRANSPOSE_1D_F32_F32` and `GGML_METAL_KERNEL_TYPE_CONV_TRANSPOSE_1D_F16_F32`.

It is necessary to port [Encodec.cpp](https://github.com/PABannier/encodec.cpp) and [Bark.cpp](https://github.com/PABannier/bark.cpp) on Metal.

All tests from `test-backend-ops.cpp` and `test-conv-transpose-1d.cpp` pass.