### PR TITLE
Do not include arm_neon.h when running under nvcc

### DIFF
--- a/src/ggml-impl.h
+++ b/src/ggml-impl.h
@@ -14,7 +14,7 @@
 #include <arm_sve.h>
 #endif // __ARM_FEATURE_SVE
 
-#if defined(__ARM_NEON)
+#if defined(__ARM_NEON) && !defined(__CUDACC__)
 // if YCM cannot find <arm_neon.h>, make a symbolic link to it, for example:
 //
 //   $ ln -sfn /Library/Developer/CommandLineTools/usr/lib/clang/13.1.6/include/arm_neon.h ./src/


### PR DESCRIPTION
I'm having trouble building llama.cpp with ARM and CUDA. The reason seems to be that the build process ends up trying to compile something with `nvcc` which includes the `arm_neon.h` header which uses a bunch of NEON intrinsics that `nvcc` doesn't know about.

See here: https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=1090459&view=logs&jobId=d93976e3-6ed1-588b-ebf8-e8a19c2becc4&j=d93976e3-6ed1-588b-ebf8-e8a19c2becc4&t=9243320e-a173-5427-7ff1-0cd57d39b91c

Following https://github.com/abseil/abseil-cpp/issues/1665 I've changed the code to conditionally include the header.