### PR TITLE
GGUF: ggml backend support for writing tensor data

### DIFF
--- a/examples/mnist/mnist-common.cpp
+++ b/examples/mnist/mnist-common.cpp
@@ -413,16 +413,6 @@ void mnist_model_train(mnist_model & model, ggml_opt_dataset_t dataset, const in
 void mnist_model_save(mnist_model & model, const std::string & fname) {
     printf("%s: saving model to '%s'\n", __func__, fname.c_str());
 
-    struct ggml_context * ggml_ctx;
-    {
-        struct ggml_init_params params = {
-            /*.mem_size   =*/ 100 * 1024*1024,
-            /*.mem_buffer =*/ NULL,
-            /*.no_alloc   =*/ false,
-        };
-        ggml_ctx = ggml_init(params);
-    }
-
     gguf_context * gguf_ctx = gguf_init_empty();
     gguf_set_val_str(gguf_ctx, "general.architecture", model.arch.c_str());
 
@@ -434,15 +424,11 @@ void mnist_model_save(mnist_model & model, const std::string & fname) {
     } else {
         GGML_ASSERT(false);
     }
-    for (struct ggml_tensor * t : weights) {
-        struct ggml_tensor * copy = ggml_dup_tensor(ggml_ctx, t);
-        ggml_set_name(copy, t->name);
-        ggml_backend_tensor_get(t, copy->data, 0, ggml_nbytes(t));
-        gguf_add_tensor(gguf_ctx, copy);
+    for (struct ggml_tensor * w : weights) {
+        gguf_add_tensor(gguf_ctx, w);
     }
     gguf_write_to_file(gguf_ctx, fname.c_str(), false);
 
-    ggml_free(ggml_ctx);
     gguf_free(gguf_ctx);
 }
 


### PR DESCRIPTION
This PR adds ggml backend support for writing tensor data to a GGUF file. Currently a workaround is needed where the data is first copied to new tensors with data in RAM, which the GGUF code can then access via `memcpy`. This PR makes it so that instead a fake tensor is reconstructed from `gguf_tensor_info` which can then be passed to `ggml_backend_tensor_get`. I'm not sure whether this is the best solution; a lot of the fileds in `gguf_tensor_info` are the same as in `ggml_tensor`, is there a reason why you couldn't just directly store a `ggml_tensor` as one of the fields in `gguf_tensor_info`?