### PR TITLE
ggml : remove return from ggml_gallocr_allocate_node

### DIFF
--- a/src/ggml-alloc.c
+++ b/src/ggml-alloc.c
@@ -534,7 +534,6 @@ static void ggml_gallocr_allocate_node(ggml_gallocr_t galloc, struct ggml_tensor
         size_t offset = ggml_dyn_tallocr_alloc(alloc, size, node);
         hn->buffer_id = buffer_id;
         hn->offset = offset;
-        return;
     }
 }
 


### PR DESCRIPTION
This commit removes the return statement from `ggml_gallocr_allocate_node` function.

The motivation behind this change is to make the code more readable and consistent.