### PR TITLE
fix: a bug in examples/simple/simple-backend

### DIFF
--- a/examples/simple/simple-backend.cpp
+++ b/examples/simple/simple-backend.cpp
@@ -190,9 +190,9 @@ int main(void) {
     ggml_backend_tensor_get(result, out_data.data(), 0, ggml_nbytes(result));
 
     // expected result:
-    // [ 60.00 110.00 54.00 29.00
-    //  55.00 90.00 126.00 28.00
-    //  50.00 54.00 42.00 64.00 ]
+    // [ 60.00 55.00 50.00 110.00
+    //  90.00 54.00 54.00 126.00
+    //  42.00 29.00 28.00 64.00 ]
 
     printf("mul mat (%d x %d) (transposed result):\n[", (int) result->ne[0], (int) result->ne[1]);
     for (int j = 0; j < result->ne[1] /* rows */; j++) {
@@ -201,7 +201,7 @@ int main(void) {
         }
 
         for (int i = 0; i < result->ne[0] /* cols */; i++) {
-            printf(" %.2f", out_data[i * result->ne[1] + j]);
+            printf(" %.2f", out_data[j * result->ne[0] + i]);
         }
     }
     printf(" ]\n");


### PR DESCRIPTION
there is an error result in ggml/examples/simple/simple-backend: 
![erro_result](https://github.com/user-attachments/assets/8104cd56-ab20-4b44-af37-08fa14364557)

and The correct result should be as shown in the Readme file：
![CORRECT_RESULT](https://github.com/user-attachments/assets/2d8998cd-28ac-4d89-a337-31349f5a5d91)

The above error occurs when traversing the matrix elements index while printing


