### PR TITLE
ggml-cpu: Add bounds checking in `make_block_q4_0x4` function

### DIFF
--- a/src/ggml-cpu/ggml-cpu-aarch64.cpp
+++ b/src/ggml-cpu/ggml-cpu-aarch64.cpp
@@ -3592,13 +3592,16 @@ static void ggml_gemm_iq4_nl_4x4_q8_0(int n, float * GGML_RESTRICT s, size_t bs,
 }
 
 static block_q4_0x4 make_block_q4_0x4(block_q4_0 * in, unsigned int blck_size_interleave) {
-    block_q4_0x4 out;
+    // Zero initialize the output structure
+    block_q4_0x4 out = {};
 
+    // Copy d values
     for (int i = 0; i < 4; i++) {
         out.d[i] = in[i].d;
     }
 
     const int end = QK4_0 * 2 / blck_size_interleave;
+    const size_t qs_size = sizeof(out.qs);
 
     if (blck_size_interleave == 8) {
         const uint64_t xor_mask = 0x8888888888888888ULL;
@@ -3607,11 +3610,17 @@ static block_q4_0x4 make_block_q4_0x4(block_q4_0 * in, unsigned int blck_size_in
             int src_offset = (i / 4) * blck_size_interleave;
             int dst_offset = i * blck_size_interleave;
 
-            uint64_t elems;
-            // Using memcpy to avoid unaligned memory accesses
-            memcpy(&elems, &in[src_id].qs[src_offset], sizeof(uint64_t));
-            elems ^= xor_mask;
-            memcpy(&out.qs[dst_offset], &elems, sizeof(uint64_t));
+            // Bounds checking
+            if (dst_offset + sizeof(uint64_t) <= qs_size &&
+                src_offset + sizeof(uint64_t) <= sizeof(in[src_id].qs)) {
+                uint64_t elems;
+                // Using memcpy to avoid unaligned memory accesses
+                memcpy(&elems, &in[src_id].qs[src_offset], sizeof(uint64_t));
+                elems ^= xor_mask;
+                memcpy(&out.qs[dst_offset], &elems, sizeof(uint64_t));
+            } else {
+                GGML_ASSERT(false && "buffer overflow prevented in make_block_q4_0x4");
+            }
         }
     } else if (blck_size_interleave == 4) {
         const uint32_t xor_mask = 0x88888888;
@@ -3620,13 +3629,19 @@ static block_q4_0x4 make_block_q4_0x4(block_q4_0 * in, unsigned int blck_size_in
             int src_offset = (i / 4) * blck_size_interleave;
             int dst_offset = i * blck_size_interleave;
 
-            uint32_t elems;
-            memcpy(&elems, &in[src_id].qs[src_offset], sizeof(uint32_t));
-            elems ^= xor_mask;
-            memcpy(&out.qs[dst_offset], &elems, sizeof(uint32_t));
+            // Bounds checking
+            if (dst_offset + sizeof(uint32_t) <= qs_size &&
+                src_offset + sizeof(uint32_t) <= sizeof(in[src_id].qs)) {
+                uint32_t elems;
+                memcpy(&elems, &in[src_id].qs[src_offset], sizeof(uint32_t));
+                elems ^= xor_mask;
+                memcpy(&out.qs[dst_offset], &elems, sizeof(uint32_t));
+            } else {
+                GGML_ASSERT(false && "buffer overflow prevented in make_block_q4_0x4");
+            }
         }
     } else {
-        GGML_ASSERT(false);
+        GGML_ASSERT(false && "invalid block size interleave value");
     }
 
     return out;


### PR DESCRIPTION
Prevent potential buffer overflows by adding explicit bounds checking when copying memory in the `make_block_q4_0x4` function

- fixes: #1094

after:

```sh
~/ggml/build$ cmake --build . --config Release -j 8
[  1%] Building CXX object examples/CMakeFiles/common.dir/common.cpp.o
[  2%] Building C object src/CMakeFiles/ggml-base.dir/ggml.c.o
[  3%] Building C object src/CMakeFiles/ggml-base.dir/ggml-alloc.c.o
[  4%] Building CXX object src/CMakeFiles/ggml-base.dir/ggml-backend.cpp.o
[  6%] Building CXX object src/CMakeFiles/ggml-base.dir/ggml-opt.cpp.o
[  6%] Building CXX object src/CMakeFiles/ggml-base.dir/ggml-threading.cpp.o
[  7%] Building C object src/CMakeFiles/ggml-base.dir/ggml-quants.c.o
[  8%] Building CXX object src/CMakeFiles/ggml-base.dir/gguf.cpp.o
[  9%] Linking CXX shared library libggml-base.so
[  9%] Built target ggml-base
[ 10%] Building CXX object src/CMakeFiles/ggml-cpu.dir/ggml-cpu/ggml-cpu.cpp.o
[ 11%] Building C object src/CMakeFiles/ggml-cpu.dir/ggml-cpu/ggml-cpu.c.o
[ 12%] Building CXX object src/CMakeFiles/ggml-cpu.dir/ggml-cpu/ggml-cpu-aarch64.cpp.o
[ 13%] Building CXX object src/CMakeFiles/ggml-cpu.dir/ggml-cpu/ggml-cpu-hbm.cpp.o
[ 14%] Building CXX object src/CMakeFiles/ggml-cpu.dir/ggml-cpu/ggml-cpu-traits.cpp.o
[ 15%] Building C object src/CMakeFiles/ggml-cpu.dir/ggml-cpu/ggml-cpu-quants.c.o
[ 16%] Building CXX object src/CMakeFiles/ggml-cpu.dir/ggml-cpu/amx/amx.cpp.o
[ 17%] Building CXX object src/CMakeFiles/ggml-cpu.dir/ggml-cpu/amx/mmq.cpp.o
[ 18%] Linking CXX static library libcommon.a
[ 18%] Built target common
[ 19%] Linking CXX shared library libggml-cpu.so
[ 19%] Built target ggml-cpu
[ 20%] Building CXX object src/CMakeFiles/ggml.dir/ggml-backend-reg.cpp.o
[ 21%] Linking CXX shared library libggml.so
[ 21%] Built target ggml
...
```