### PR TITLE
CUDA: update compilation flags for improved performance

### DIFF
--- a/src/ggml-cuda/CMakeLists.txt
+++ b/src/ggml-cuda/CMakeLists.txt
@@ -96,7 +96,7 @@ if (CUDAToolkit_FOUND)
 
     set(CUDA_CXX_FLAGS "")
 
-    set(CUDA_FLAGS -use_fast_math)
+    set(CUDA_FLAGS -use_fast_math --threads=0 --split-compile=0)
 
     if (GGML_FATAL_WARNINGS)
         list(APPEND CUDA_FLAGS -Werror all-warnings)


### PR DESCRIPTION
This adds CUDA `nvcc` compile parallelization to speed up `.cu` files compilation (which take >3 hours today).
Setting `--threads=0` lets the system find out how many cores it can use for parallelization.
Per NVidia documents: https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#threads-number-t