### PR TITLE
pkg-config: include the new GGML_VERSION as a version

### DIFF
--- a/ggml.pc.in
+++ b/ggml.pc.in
@@ -5,6 +5,6 @@ libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 
 Name: ggml
 Description: The GGML Tensor Library for Machine Learning
-Version: 0.0.0
+Version: @GGML_VERSION@
 Cflags: -I${includedir}
 Libs: -L${libdir} -lggml


### PR DESCRIPTION
Instead of hardcoding 0.0.0

If the 0.9.2-dev version is supposed to mean "less than" 0.9.2 instead of equal, then the .pc version format would need to be changed to 0.9.2dev, since pkgconf uses RPM version comparison. But let's keep it simple for now.

The version in CMake was added in #1336

