### PR TITLE
ggml-cpu: BMI2 is only available on amd64

### DIFF
--- a/src/ggml-cpu/CMakeLists.txt
+++ b/src/ggml-cpu/CMakeLists.txt
@@ -308,7 +308,10 @@ function(ggml_add_cpu_backend_variant_impl tag_name)
             endif()
             if (GGML_BMI2)
                 # MSVC does not define macro __BMI2__
-                list(APPEND ARCH_DEFINITIONS __BMI2__ GGML_BMI2)
+                if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "amd64")
+                    # BMI2 is only available on amd64
+                    list(APPEND ARCH_DEFINITIONS __BMI2__ GGML_BMI2)
+                endif()
             endif()
         else ()
             if (GGML_NATIVE)


### PR DESCRIPTION
MSVC doesn't define __BMI2__ so it must be defined by by CMake. It was being set  whenever GGML_BMI2 is set, but that results in a failure (`error LNK2019: unresolved external symbol __pdep_u64`) when targeting x86 (aka 32 bit) Windows. The fix is to only set __BMI2__ when targeting amd64.

*For changes to the core `ggml` library (including to the CMake build system), please open a PR in https://github.com/ggml-org/llama.cpp. Doing so will make your PR more visible, better tested and more likely to be reviewed.*
