### PR TITLE
Add Metal support for GGML_OP_DIAG_MASK_INF for CLIP on Apple GPUs

### DIFF
--- a/src/ggml-metal/ggml-metal-device.cpp
+++ b/src/ggml-metal/ggml-metal-device.cpp
@@ -1660,3 +1660,25 @@ ggml_metal_pipeline_t ggml_metal_library_get_pipeline_opt_step_sgd(ggml_metal_li
 
     return res;
 }
+
+ggml_metal_pipeline_t ggml_metal_library_get_pipeline_diag_mask_inf(
+        ggml_metal_library_t lib,
+        const struct ggml_tensor * op) {
+    GGML_ASSERT(op->op == GGML_OP_DIAG_MASK_INF);
+    GGML_ASSERT(ggml_is_contiguous(op->src[0]));
+
+    char base[256];
+    char name[256];
+
+    snprintf(base, 256, "kernel_diag_mask_inf_%s", ggml_type_name(op->src[0]->type));
+    snprintf(name, 256, "%s", base);
+
+    ggml_metal_pipeline_t res = ggml_metal_library_get_pipeline(lib, name);
+    if (res) {
+        return res;
+    }
+
+    res = ggml_metal_library_compile_pipeline(lib, base, name, nullptr);
+    return res;
+}
+

--- a/src/ggml-metal/ggml-metal-device.h
+++ b/src/ggml-metal/ggml-metal-device.h
@@ -144,6 +144,7 @@ ggml_metal_pipeline_t ggml_metal_library_get_pipeline_arange            (ggml_me
 ggml_metal_pipeline_t ggml_metal_library_get_pipeline_timestep_embedding(ggml_metal_library_t lib, const struct ggml_tensor * op);
 ggml_metal_pipeline_t ggml_metal_library_get_pipeline_opt_step_adamw    (ggml_metal_library_t lib, const struct ggml_tensor * op);
 ggml_metal_pipeline_t ggml_metal_library_get_pipeline_opt_step_sgd      (ggml_metal_library_t lib, const struct ggml_tensor * op);
+ggml_metal_pipeline_t ggml_metal_library_get_pipeline_diag_mask_inf     (ggml_metal_library_t lib, const struct ggml_tensor * op);
 
 ggml_metal_pipeline_t ggml_metal_library_get_pipeline_flash_attn_ext_pad(
         ggml_metal_library_t lib,

--- a/src/ggml-metal/ggml-metal-device.m
+++ b/src/ggml-metal/ggml-metal-device.m
@@ -1020,6 +1020,8 @@ bool ggml_metal_device_supports_op(ggml_metal_device_t dev, const struct ggml_te
         case GGML_OP_OPT_STEP_ADAMW:
         case GGML_OP_OPT_STEP_SGD:
             return has_simdgroup_reduction;
+        case GGML_OP_DIAG_MASK_INF:
+            return true;
         default:
             return false;
     }

--- a/src/ggml-metal/ggml-metal-impl.h
+++ b/src/ggml-metal/ggml-metal-impl.h
@@ -887,4 +887,14 @@ typedef struct {
     int64_t  np;
 } ggml_metal_kargs_opt_step_sgd;
 
+typedef struct {
+    int32_t ne00;   // nc
+    int32_t ne01;   // nr (rows_per_channel)
+    int32_t nrows;  // ggml_nrows(src0)
+    int32_t n_past;
+    uint64_t nb0;   // src0->nb[0]
+    uint64_t nb1;   // src0->nb[1]
+    uint64_t nb2;   // src0->nb[2]
+} ggml_metal_kargs_diag_mask_inf;
+
 #endif // GGML_METAL_IMPL

--- a/src/ggml-metal/ggml-metal-ops.h
+++ b/src/ggml-metal/ggml-metal-ops.h
@@ -84,6 +84,7 @@ int ggml_metal_op_argsort           (ggml_metal_op_t ctx, int idx);
 int ggml_metal_op_leaky_relu        (ggml_metal_op_t ctx, int idx);
 int ggml_metal_op_opt_step_adamw    (ggml_metal_op_t ctx, int idx);
 int ggml_metal_op_opt_step_sgd      (ggml_metal_op_t ctx, int idx);
+int ggml_metal_op_diag_mask_inf     (ggml_metal_op_t ctx, int idx);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### Summary

Add a Metal implementation of `GGML_OP_DIAG_MASK_INF` so the op can run on Apple GPUs.

### Details

Previously, the Metal backend didn't support `GGML_OP_DIAG_MASK_INF`, which caused models using this op to fail with:

> unsupported op 'DIAG_MASK_INF'

For example, `stable-diffusion.cpp`’s SDXL CLIP path could not run with `keep_clip_on_cpu = false` on Metal.

This PR:
- Implements a Metal kernel for `GGML_OP_DIAG_MASK_INF` matching the existing CPU/CUDA semantics.
- Wires it into `ggml-metal` dispatch so attention masks are applied correctly for batched tensors on Apple GPUs.

Related: leejet/stable-diffusion.cpp#1040
