### PR TITLE
Add Vulkan ggml_diag_mask_zero operation

### DIFF
--- a/src/ggml-vulkan/vulkan-shaders/diag_mask_zero.comp
+++ b/src/ggml-vulkan/vulkan-shaders/diag_mask_zero.comp
@@ -1,0 +1,34 @@
+#version 450
+
+#extension GL_EXT_shader_16bit_storage : require
+#extension GL_EXT_control_flow_attributes : enable
+
+layout (push_constant) uniform parameter
+{
+    uint ncols;
+    uint rows_per_channel;
+    uint n_past;
+} p;
+
+#include "types.glsl"
+
+layout(local_size_x = 1, local_size_y = 512, local_size_z = 1) in;
+
+layout (binding = 0) readonly buffer X {A_TYPE data_a[];};
+layout (binding = 1) writeonly buffer D {D_TYPE data_d[];};
+
+void main() {
+    const uint col = gl_GlobalInvocationID.y;
+    const uint row = gl_GlobalInvocationID.x;
+
+    if (col >= p.ncols) {
+        return;
+    }
+
+    const uint i = row*p.ncols + col;
+    if (col > p.n_past + row % p.rows_per_channel) {
+        data_d[i] = 0;
+    } else {
+        data_d[i] = D_TYPE(data_a[i]);
+    }
+}

--- a/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
+++ b/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
@@ -898,6 +898,7 @@ void process_shaders() {
     string_to_spv("silu_back_f32",  "silu_back.comp",   {{"A_TYPE", "float"}, {"B_TYPE", "float"}, {"D_TYPE", "float"}});
 
     string_to_spv("diag_mask_inf_f32", "diag_mask_inf.comp", {{"A_TYPE", "float"}, {"D_TYPE", "float"}});
+    string_to_spv("diag_mask_zero_f32", "diag_mask_zero.comp", {{"A_TYPE", "float"}, {"D_TYPE", "float"}});
 
     string_to_spv("soft_max_f32", "soft_max.comp", merge_maps(base_dict, {{"A_TYPE", "float"}, {"B_TYPE", "float"}, {"D_TYPE", "float"}}));
     string_to_spv("soft_max_f32_f16", "soft_max.comp", merge_maps(base_dict, {{"A_TYPE", "float"}, {"B_TYPE", "float16_t"}, {"D_TYPE", "float"}}));


### PR DESCRIPTION


Changes include:
-  add GGML_OP_DIAG_MASK_ZERO shader referenced ggml_diag_mask_inf.
-  src/ggml-vulkan/vulkan-shaders/diag_mask_zero.comp
-  src/ggml-vulkan/ggml-vulkan.cpp

Test cases ran successfully using the same inputs as ggml_diag_mask_inf:

  DIAG_MASK_INF(type=f32,ne=[10,10,1,1],n_past=5): ?[1;32mOK?[0m
  DIAG_MASK_INF(type=f32,ne=[10,10,3,1],n_past=5): ?[1;32mOK?[0m
  DIAG_MASK_INF(type=f32,ne=[10,10,3,2],n_past=5): ?[1;32mOK?[0m
  DIAG_MASK_ZERO(type=f32,ne=[10,10,1,1],n_past=5): ?[1;32mOK?[0m
  DIAG_MASK_ZERO(type=f32,ne=[10,10,3,1],n_past=5): ?[1;32mOK?[0m
  DIAG_MASK_ZERO(type=f32,ne=[10,10,3,2],n_past=5): ?[1;32mOK?[0m