### PR TITLE
examples/yolo: fix load_model memory leak

### DIFF
--- a/examples/yolo/yolov3-tiny.cpp
+++ b/examples/yolo/yolov3-tiny.cpp
@@ -107,7 +107,8 @@ static bool load_model(const std::string & fname, yolo_model & model) {
         ggml_backend_tensor_set(cur, ggml_get_data(src), 0, n_size);
     }
     gguf_free(gguf_ctx);
-
+    ggml_free(tmp_ctx);
+    
     model.width  = 416;
     model.height = 416;
     model.conv2d_layers.resize(13);


### PR DESCRIPTION
Fix issure：https://github.com/ggml-org/ggml/issues/1431

https://github.com/ggml-org/ggml/blob/master/examples/yolo/yolov3-tiny.cpp

In function:
static bool load_model(const std::string & fname, yolo_model & model)

struct gguf_init_params gguf_params = {
    /*.no_alloc   =*/ false,
    /*.ctx        =*/ &tmp_ctx,
};
After call: gguf_context * gguf_ctx = gguf_init_from_file(fname.c_str(), gguf_params);
tmp_ctx is allocated memory,
But it was not released, there is memory leak.
